### PR TITLE
fix: rename duplicated "IO 5" label to "IO 6"

### DIFF
--- a/round-robin-10-72.kicad_sch
+++ b/round-robin-10-72.kicad_sch
@@ -1,6135 +1,16537 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid cbac505e-77a6-4a00-a758-435de33cca16)
-
-  (paper "A3" portrait)
-
-  (lib_symbols
-    (symbol "Diode:1N4148" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "1N4148" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Device" "D" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Pins" "1=K 2=A" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "100V 0.15A standard switching diode, DO-35" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "D*DO?35*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "1N4148_0_1"
-        (polyline
-          (pts
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "1N4148_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 1.27 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "SW_Push" (at 0 -1.524 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "switch normally-open pushbutton push-button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Push button switch, generic, two pins" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SW_Push_0_1"
-        (circle (center -2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 3.048)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 0 180) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 165.1 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 00d75863-bb9f-4d4c-ae8f-f64498ed1533)
-  )
-  (junction (at 226.06 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 04d157fc-c063-40ca-ad05-26c77c1c313c)
-  )
-  (junction (at 185.42 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 05e510f3-8ca9-490a-bdc5-77faace67735)
-  )
-  (junction (at 104.14 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 06a6d1a8-0f12-4174-b63e-d35d8ca618bf)
-  )
-  (junction (at 43.18 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 06e66b38-0070-40a1-8fc5-70306b17897f)
-  )
-  (junction (at 165.1 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 09e82fd3-a43f-4071-83d2-fb0a65931c0e)
-  )
-  (junction (at 63.5 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0a9113d4-8a8c-4abc-b886-f22c92ad18dc)
-  )
-  (junction (at 165.1 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 0a95c2d4-251b-4df1-a8c0-c0fc6241e43d)
-  )
-  (junction (at 124.46 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29)
-  )
-  (junction (at 73.66 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0c7244ee-ddfb-470b-a70b-1cfc53f83773)
-  )
-  (junction (at 134.62 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 0c73479c-4e07-428a-85f3-93341c42ca57)
-  )
-  (junction (at 93.98 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5f3a7a-dc5d-4973-8743-eafaa1c1a462)
-  )
-  (junction (at 43.18 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 10cae212-bc64-40b9-b44f-13fd4a0406a6)
-  )
-  (junction (at 53.34 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 122dbfee-176c-4f21-802f-09581864dffb)
-  )
-  (junction (at 83.82 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1278b5e3-5eff-46d6-a162-44fde2066970)
-  )
-  (junction (at 63.5 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 148ae1ee-d103-45f5-afff-520ea3c7f768)
-  )
-  (junction (at 53.34 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 14bb4fc2-d7df-49aa-b10e-882abdd2aa5f)
-  )
-  (junction (at 185.42 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 15daf298-357b-4f73-8767-34988eed6eb8)
-  )
-  (junction (at 104.14 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 17f3773a-2c02-426d-bcd6-7a35c59a710a)
-  )
-  (junction (at 205.74 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1943e8ad-b21d-4f7c-9e48-baf07472bdf8)
-  )
-  (junction (at 114.3 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 1a11ada5-19c8-45ac-810c-daedbb80ad5b)
-  )
-  (junction (at 73.66 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1c386ee6-5b9d-4eae-92b5-9440e81067f6)
-  )
-  (junction (at 226.06 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 216bc563-0bc0-4447-af79-7933fdef7d63)
-  )
-  (junction (at 93.98 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 21e320b6-a0c4-4d5d-babf-ee5274120507)
-  )
-  (junction (at 185.42 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 23554013-cd0d-4767-9f22-8c19a7d8c5ca)
-  )
-  (junction (at 154.94 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 23916c3a-0d37-416a-91d3-82a34b3ade4a)
-  )
-  (junction (at 165.1 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 2501dc30-a271-4271-9ca6-b085328a23ec)
-  )
-  (junction (at 73.66 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 2654ce54-6e59-4c49-bfbf-12326c83c638)
-  )
-  (junction (at 124.46 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 2b2b66bc-905d-4b48-89f5-1c62f6c27dbb)
-  )
-  (junction (at 134.62 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 2c5878fe-fb0a-42a4-a883-ea4209708ea5)
-  )
-  (junction (at 154.94 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 2cf168f3-fe97-43f2-b72e-223dd4e6b386)
-  )
-  (junction (at 195.58 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 2d5e9ac1-9154-4e79-bf72-21a277b2d96d)
-  )
-  (junction (at 73.66 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 30c9eca3-7c32-4704-8819-3599d7b84f53)
-  )
-  (junction (at 93.98 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 31a1b16e-8174-4fea-bc42-9c75ed9182a0)
-  )
-  (junction (at 83.82 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3)
-  )
-  (junction (at 114.3 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 347306fc-87ef-43e1-a98f-ca29ac9473e6)
-  )
-  (junction (at 124.46 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 352af8be-9d08-4866-961e-b8632013179f)
-  )
-  (junction (at 104.14 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 356b49b0-20ac-4c33-8df8-9b27dee0b312)
-  )
-  (junction (at 175.26 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 357aa667-d746-4e3e-ab2a-484493e6765a)
-  )
-  (junction (at 226.06 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c)
-  )
-  (junction (at 175.26 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 39869536-29f6-4e84-a33a-473fa8fb0f36)
-  )
-  (junction (at 185.42 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 3abcfbc6-0288-48d7-a0e0-144f99e6dd30)
-  )
-  (junction (at 144.78 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 3d987483-3b5e-44fb-b675-40705bf855c1)
-  )
-  (junction (at 134.62 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 3ddd9e62-5556-463c-9539-c0d582cc40e9)
-  )
-  (junction (at 205.74 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 4788fde7-f606-4229-8a7b-9fa04f56d3d4)
-  )
-  (junction (at 195.58 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 4808b7bb-f3e9-4051-abfe-6295f68f9f67)
-  )
-  (junction (at 114.3 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 490a89d7-a161-4f1a-9b45-a55729d9d59b)
-  )
-  (junction (at 124.46 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4c74baef-72cb-4cdf-b4eb-a3d28782257d)
-  )
-  (junction (at 53.34 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 4c7a50e9-7650-493b-b0a7-057b900a13a7)
-  )
-  (junction (at 63.5 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9)
-  )
-  (junction (at 165.1 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 4df4e0a7-6e46-4c32-959d-094f3457d75b)
-  )
-  (junction (at 43.18 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 4e641ba8-cbcf-42cf-89f0-ac977902bf98)
-  )
-  (junction (at 195.58 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 4f68712b-6287-4bdb-948e-a2fe64b7f55e)
-  )
-  (junction (at 73.66 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 4fc826ad-ef7b-406a-9b89-76eb2c211523)
-  )
-  (junction (at 53.34 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 4fce0301-62b3-4ef1-9bae-8d55ea745d66)
-  )
-  (junction (at 195.58 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 50440167-944e-4bae-877b-720ed8635cbd)
-  )
-  (junction (at 185.42 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 508ddd33-e065-44a5-a999-5944a523ef76)
-  )
-  (junction (at 175.26 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 50f2ad43-aa07-4fd1-8d58-f22d767da31f)
-  )
-  (junction (at 53.34 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 53bb27f5-9b54-4704-b90e-33b3053be6c4)
-  )
-  (junction (at 114.3 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 5b35d564-88c3-4b41-864f-a4f82bc4c871)
-  )
-  (junction (at 43.18 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 5bfc49c0-36f2-431c-81ea-cf78c71d7681)
-  )
-  (junction (at 63.5 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 670a793c-4c48-41d1-9f07-66b1d7d84b06)
-  )
-  (junction (at 83.82 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 672e2ce9-8f2c-43ff-9498-0e342bc1c65e)
-  )
-  (junction (at 175.26 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 69e63d66-faab-411c-9093-a81235a7547c)
-  )
-  (junction (at 63.5 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 6b0b87a9-8a81-4bd1-ac24-ffcd6512236b)
-  )
-  (junction (at 43.18 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6bfc7531-8adc-4c87-bf8a-788404262765)
-  )
-  (junction (at 134.62 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1)
-  )
-  (junction (at 154.94 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 6ff7fc69-ca50-4b66-851e-eb36da3cadd8)
-  )
-  (junction (at 63.5 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 712da204-b8e1-4637-b967-521ccf7b108c)
-  )
-  (junction (at 73.66 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 71e77471-d824-448e-a6de-31cce05e17c2)
-  )
-  (junction (at 205.74 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 72e4e912-d3a6-49dd-a5cd-3717c5b10d71)
-  )
-  (junction (at 73.66 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 742ecb41-f257-40d3-a6f3-d155d6036628)
-  )
-  (junction (at 93.98 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 782ee96d-a257-4c78-ac0f-a3b5279bef37)
-  )
-  (junction (at 53.34 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 7943e9ed-5e22-49d3-a238-47d875f3e823)
-  )
-  (junction (at 43.18 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 7dbcae2f-e000-4aff-92b3-5518ea113182)
-  )
-  (junction (at 104.14 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 822096c9-a5b4-460b-8639-9bbf1bb1a2fa)
-  )
-  (junction (at 93.98 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 84442e81-a253-49f6-ab0f-8ece0b39f637)
-  )
-  (junction (at 53.34 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 86d88f2b-6e5b-493a-b3a4-5436a8374fae)
-  )
-  (junction (at 104.14 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 88441b0d-9a40-4e18-8fc9-814cc1cb4d3e)
-  )
-  (junction (at 185.42 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 8a6c81db-4db5-4eb7-a06a-31575c90f62f)
-  )
-  (junction (at 83.82 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 8bf191a4-2dcd-4018-b67a-91aef9fad846)
-  )
-  (junction (at 144.78 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 8d88bb99-f0e4-4a81-b464-31814877675a)
-  )
-  (junction (at 205.74 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 91635678-4449-4ed4-88c1-10b19deef1b0)
-  )
-  (junction (at 226.06 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 95b0c111-7d27-49ee-a08f-b6f35d9d5b54)
-  )
-  (junction (at 93.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 96a12dd2-d02f-4a86-aa6d-3a7015c06462)
-  )
-  (junction (at 134.62 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 99c67f58-7bde-4417-a08c-823e6af847f2)
-  )
-  (junction (at 124.46 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9d2b0f02-b19d-4907-8835-9e7f8a8b9c34)
-  )
-  (junction (at 93.98 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid a2db7df7-b835-49df-98be-3c291238016c)
-  )
-  (junction (at 185.42 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid a3593416-7fea-415d-a48b-ed5f49c771b2)
-  )
-  (junction (at 63.5 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid a6cd881c-1146-4d92-9184-bf83a80c20c4)
-  )
-  (junction (at 165.1 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid a7400bf6-86c3-4d41-886e-57235a457a4c)
-  )
-  (junction (at 165.1 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid a9baaad2-c62c-4b79-a10b-261651ef4961)
-  )
-  (junction (at 226.06 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid a9ece8f4-f868-428b-b7ff-a3dc07b47d6c)
-  )
-  (junction (at 144.78 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid aa4f9edb-d8b6-45e2-8d16-270f3c9fc990)
-  )
-  (junction (at 104.14 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid ab0811a2-347a-4a90-b4d0-f1b1ba038333)
-  )
-  (junction (at 195.58 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid aeb87e8e-694a-4a41-9acc-a8e64ba7f05b)
-  )
-  (junction (at 195.58 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid b03222c4-a4d2-4638-a1da-82da352acd7b)
-  )
-  (junction (at 83.82 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b23bc3a0-3ebe-44a5-9126-8b5c4d648e08)
-  )
-  (junction (at 205.74 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid b3d0ee10-bd96-4305-9675-c2f1f7a7662b)
-  )
-  (junction (at 114.3 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid b5ce3eda-e357-44e1-9c69-f84009fc7a87)
-  )
-  (junction (at 154.94 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid b7093823-b63a-4a1a-b279-5afe0127ec9d)
-  )
-  (junction (at 226.06 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b98759bc-77be-4dce-9aa2-cc5ce3889034)
-  )
-  (junction (at 154.94 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b995f4ca-5e8d-4350-aff6-b7bea568d7f5)
-  )
-  (junction (at 53.34 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3)
-  )
-  (junction (at 205.74 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bb9843d1-ea35-45a8-bd3d-5b381b0dc875)
-  )
-  (junction (at 175.26 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid bbd2fe65-aac5-437c-9177-9832921486d5)
-  )
-  (junction (at 175.26 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid bcf6a98c-2d79-4afb-9a5e-6558bb743cec)
-  )
-  (junction (at 154.94 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid be75ea2d-b3b9-4fd0-812b-104329fac661)
-  )
-  (junction (at 144.78 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid befc6138-873b-4406-bc9e-e5a72f7f36fe)
-  )
-  (junction (at 175.26 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid bf44b855-bf79-4ceb-a9a9-021d72c7f67c)
-  )
-  (junction (at 83.82 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0)
-  )
-  (junction (at 134.62 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid c29c26fc-c285-45ba-9e88-4c2a02375307)
-  )
-  (junction (at 165.1 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid c331d35d-23c9-43ea-b243-b660cb5f4bdb)
-  )
-  (junction (at 134.62 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid c3f1775c-0d63-41d3-b7d8-a4c96d241ce3)
-  )
-  (junction (at 93.98 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c41e97f8-87c8-4e82-92ed-e4644d6f526e)
-  )
-  (junction (at 124.46 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid c51de65b-dd06-4a71-8763-eab77eba6638)
-  )
-  (junction (at 226.06 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c56d20e0-377b-42bf-89fc-25b698ca10b4)
-  )
-  (junction (at 114.3 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c5afc93c-0846-4cf9-8f93-4c8f2232c9fa)
-  )
-  (junction (at 83.82 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid c7d88142-1b7e-4dd1-b026-f2267e06dab1)
-  )
-  (junction (at 43.18 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid c8f222f6-943e-4d7d-919b-3278ca0ede33)
-  )
-  (junction (at 144.78 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cc2d9922-84c9-42ce-883b-c028a251c101)
-  )
-  (junction (at 124.46 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid cd054c4e-f9d4-4701-a538-16740432e58d)
-  )
-  (junction (at 63.5 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid cfd86ddc-0810-4057-8a79-4468ec7b2424)
-  )
-  (junction (at 205.74 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d07b66d1-3d51-4607-8fd1-974bbf8f9371)
-  )
-  (junction (at 53.34 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid d328f077-6d93-4470-a2b2-f4c9287daff0)
-  )
-  (junction (at 205.74 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid d3f7612d-781e-42f5-a5f0-fe2744aa5d60)
-  )
-  (junction (at 83.82 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid d5a179bd-82b1-4661-aebc-4c4d4801bdff)
-  )
-  (junction (at 144.78 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d5b7ef4f-419a-421c-a02d-fd71016e6c97)
-  )
-  (junction (at 154.94 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid d774ae68-7d44-45a8-babf-4a5136fe82a1)
-  )
-  (junction (at 185.42 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d8d69513-50ec-441c-a953-5a6c226b729f)
-  )
-  (junction (at 114.3 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid dcab5abe-0f5a-44d8-b554-722164ca6a23)
-  )
-  (junction (at 154.94 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid dded6bb5-453a-4491-9278-65d2368e4bc0)
-  )
-  (junction (at 93.98 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid dece07f3-2868-47c6-b119-0ca286e7cc50)
-  )
-  (junction (at 175.26 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid e3827bb6-d8e8-410a-8c19-3e64c8191b94)
-  )
-  (junction (at 154.94 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid e46432a2-96f1-448e-8928-bfcbbf445ca9)
-  )
-  (junction (at 175.26 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid e66342f0-16d5-4367-b00a-d7cf257720d9)
-  )
-  (junction (at 114.3 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid ee17efa1-5df9-47d0-aec2-a440d8b33e4c)
-  )
-  (junction (at 195.58 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid ee57e1f7-1cc7-4774-b838-6c366435fbc5)
-  )
-  (junction (at 104.14 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid f0d84c95-52f0-41cd-8742-4de83021f783)
-  )
-  (junction (at 134.62 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid f1379b2f-59c4-4b61-a98f-3645b6e5fe6b)
-  )
-  (junction (at 104.14 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid f24e6016-cf0c-4fe9-b584-ca06dfdbe767)
-  )
-  (junction (at 134.62 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid f368e14e-0af5-4e13-a581-f1a139c24e5c)
-  )
-  (junction (at 195.58 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid f66ca316-fc26-4704-976d-83146ae5fc99)
-  )
-  (junction (at 43.18 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid f6f817c6-438a-4497-93b1-8dc1f36a395c)
-  )
-  (junction (at 124.46 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd)
-  )
-  (junction (at 144.78 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid f8b3b54a-7c03-49e4-8762-b4ef31db5afd)
-  )
-  (junction (at 226.06 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fa2795fd-0138-4010-b310-3d5e73c1be1c)
-  )
-  (junction (at 73.66 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fbda2010-a213-45bb-958d-0c9446d51e42)
-  )
-  (junction (at 195.58 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid fbe658cd-81e2-4835-bad4-ff83513467a3)
-  )
-  (junction (at 73.66 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid fc393c80-fb90-44e5-ac86-763463fd8acd)
-  )
-  (junction (at 114.3 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid fc6abd7a-92c0-4b05-85ed-b3bd910676e1)
-  )
-  (junction (at 144.78 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid fdc0071f-cdad-424a-87db-7bd8a0569159)
-  )
-
-  (wire (pts (xy 154.94 68.58) (xy 175.26 68.58))
-    (stroke (width 0) (type default))
-    (uuid 022cd994-adba-45e0-8a4a-b0b516869c19)
-  )
-  (wire (pts (xy 83.82 60.96) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 022d84d0-7bcb-4024-8618-6f3a7f7b41aa)
-  )
-  (wire (pts (xy 144.78 25.4) (xy 144.78 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0406a358-3219-4537-99c7-cfb994e5303c)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0429bfe1-2992-4c6f-bb22-b2e8e5724910)
-  )
-  (wire (pts (xy 205.74 182.88) (xy 205.74 203.2))
-    (stroke (width 0) (type default))
-    (uuid 04f743f4-6844-43ab-a149-4db3a42e61b3)
-  )
-  (wire (pts (xy 185.42 162.56) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid 070c607f-224b-4963-a847-a5abbe4e2e9d)
-  )
-  (wire (pts (xy 73.66 109.22) (xy 93.98 109.22))
-    (stroke (width 0) (type default))
-    (uuid 07ee4d30-e80a-41ae-829d-e3cecf87d77e)
-  )
-  (wire (pts (xy 114.3 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0897e94f-d1e3-47ff-89f6-5de7a1349783)
-  )
-  (wire (pts (xy 226.06 68.58) (xy 226.06 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0aee33c0-3781-43dc-99cb-690f399192cd)
-  )
-  (wire (pts (xy 195.58 203.2) (xy 205.74 203.2))
-    (stroke (width 0) (type default))
-    (uuid 0bbfe73f-3f00-4157-8def-4fa012c6902e)
-  )
-  (wire (pts (xy 195.58 149.86) (xy 218.44 149.86))
-    (stroke (width 0) (type default))
-    (uuid 0d9578e9-1c8e-43cd-93fc-b592de25d72b)
-  )
-  (wire (pts (xy 43.18 182.88) (xy 43.18 203.2))
-    (stroke (width 0) (type default))
-    (uuid 0e0cdb3f-d11e-41fa-b224-dbdc3dd27130)
-  )
-  (wire (pts (xy 43.18 40.64) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0f76c070-bcf8-4924-a8c5-3abe13c36f41)
-  )
-  (wire (pts (xy 63.5 81.28) (xy 63.5 101.6))
-    (stroke (width 0) (type default))
-    (uuid 11ef6261-91ba-4d4c-99ef-8991b7c91dc8)
-  )
-  (wire (pts (xy 104.14 101.6) (xy 104.14 121.92))
-    (stroke (width 0) (type default))
-    (uuid 12080e73-a151-4804-ac9b-ac3ac13653e9)
-  )
-  (wire (pts (xy 73.66 48.26) (xy 93.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 12a939e2-2ab8-4d74-a5c9-6d61a9528b6e)
-  )
-  (wire (pts (xy 63.5 182.88) (xy 63.5 203.2))
-    (stroke (width 0) (type default))
-    (uuid 13961bb6-28aa-4ee0-a270-8bc7b0339a4b)
-  )
-  (wire (pts (xy 195.58 129.54) (xy 218.44 129.54))
-    (stroke (width 0) (type default))
-    (uuid 143dcad5-8675-4ddc-903b-6ddce8681b1f)
-  )
-  (wire (pts (xy 134.62 210.82) (xy 154.94 210.82))
-    (stroke (width 0) (type default))
-    (uuid 150130ef-d28d-4782-b4fc-0c67b58e9b8e)
-  )
-  (wire (pts (xy 154.94 190.5) (xy 175.26 190.5))
-    (stroke (width 0) (type default))
-    (uuid 15b0be77-2720-4b9e-8da7-956cf862467d)
-  )
-  (wire (pts (xy 93.98 190.5) (xy 114.3 190.5))
-    (stroke (width 0) (type default))
-    (uuid 1767f007-bd12-458a-9e69-f01cc8a5ed24)
-  )
-  (wire (pts (xy 205.74 142.24) (xy 205.74 162.56))
-    (stroke (width 0) (type default))
-    (uuid 18ccb399-8ad2-4b42-b317-de1e9939e9e9)
-  )
-  (wire (pts (xy 104.14 25.4) (xy 104.14 40.64))
-    (stroke (width 0) (type default))
-    (uuid 1af5b449-9a68-414b-a41f-d6f6cba715a8)
-  )
-  (wire (pts (xy 73.66 81.28) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 1c0140d1-6775-49db-9fd5-7ecf63ae1284)
-  )
-  (wire (pts (xy 195.58 109.22) (xy 218.44 109.22))
-    (stroke (width 0) (type default))
-    (uuid 20189d33-2d13-483f-bce7-1849d41f23d3)
-  )
-  (wire (pts (xy 114.3 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid 211f763f-7ef6-4fb5-98df-2e2ff37faa42)
-  )
-  (wire (pts (xy 63.5 40.64) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 23f46f84-f16d-4b0b-b463-c2c0244adcc0)
-  )
-  (wire (pts (xy 33.02 129.54) (xy 53.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid 24da3fea-844d-4666-b730-f8d7b708f242)
-  )
-  (wire (pts (xy 185.42 40.64) (xy 185.42 60.96))
-    (stroke (width 0) (type default))
-    (uuid 265c8115-55ea-4d09-95c1-3178314bfa04)
-  )
-  (wire (pts (xy 53.34 129.54) (xy 73.66 129.54))
-    (stroke (width 0) (type default))
-    (uuid 26f78b89-ba4b-4b48-90d1-1245694ead6f)
-  )
-  (wire (pts (xy 83.82 162.56) (xy 83.82 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2703e5ce-9651-45e1-8bd6-144e60387b78)
-  )
-  (wire (pts (xy 33.02 109.22) (xy 53.34 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2832f642-62e7-4a51-b112-f728658e7714)
-  )
-  (wire (pts (xy 53.34 68.58) (xy 73.66 68.58))
-    (stroke (width 0) (type default))
-    (uuid 29a0e612-9a4c-422c-a9b8-8a9fe3879b8a)
-  )
-  (wire (pts (xy 83.82 101.6) (xy 83.82 121.92))
-    (stroke (width 0) (type default))
-    (uuid 2a44e441-f6d5-4994-b7ba-34283a1facc7)
-  )
-  (wire (pts (xy 124.46 121.92) (xy 124.46 142.24))
-    (stroke (width 0) (type default))
-    (uuid 2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0)
-  )
-  (wire (pts (xy 114.3 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 2a65926a-d988-49f6-92e7-6e4d5936462f)
-  )
-  (wire (pts (xy 165.1 162.56) (xy 165.1 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2afd7500-0a15-4710-acc0-4f03472785c3)
-  )
-  (wire (pts (xy 53.34 60.96) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 2b416882-b7bb-4d0e-968f-5674136bac79)
-  )
-  (wire (pts (xy 165.1 60.96) (xy 165.1 81.28))
-    (stroke (width 0) (type default))
-    (uuid 2b8c9def-eaec-4abd-b08a-c3613e6389df)
-  )
-  (wire (pts (xy 53.34 109.22) (xy 73.66 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd)
-  )
-  (wire (pts (xy 124.46 25.4) (xy 124.46 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3115f7a7-e786-49c1-9e4c-25c171cfeb33)
-  )
-  (wire (pts (xy 73.66 68.58) (xy 93.98 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3197b37c-ee5b-406a-ab67-08670d4b8c09)
-  )
-  (wire (pts (xy 165.1 182.88) (xy 165.1 203.2))
-    (stroke (width 0) (type default))
-    (uuid 335e6f69-208d-4946-a709-07b34240cbfe)
-  )
-  (wire (pts (xy 63.5 60.96) (xy 63.5 81.28))
-    (stroke (width 0) (type default))
-    (uuid 33f2e2d4-69cc-436f-ac8e-75f012072b5c)
-  )
-  (wire (pts (xy 154.94 170.18) (xy 175.26 170.18))
-    (stroke (width 0) (type default))
-    (uuid 3a0ad538-3c94-4a03-ba14-d3e55855f87e)
-  )
-  (wire (pts (xy 134.62 68.58) (xy 154.94 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3b15c81d-3687-4710-9aa6-d57ee4885603)
-  )
-  (wire (pts (xy 63.5 121.92) (xy 63.5 142.24))
-    (stroke (width 0) (type default))
-    (uuid 3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5)
-  )
-  (wire (pts (xy 114.3 190.5) (xy 134.62 190.5))
-    (stroke (width 0) (type default))
-    (uuid 3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb)
-  )
-  (wire (pts (xy 154.94 48.26) (xy 175.26 48.26))
-    (stroke (width 0) (type default))
-    (uuid 3fe99eb3-808c-4fd5-8bf0-8eed87e32524)
-  )
-  (wire (pts (xy 73.66 170.18) (xy 93.98 170.18))
-    (stroke (width 0) (type default))
-    (uuid 40ad23e4-b284-4d51-a92e-26a2272af251)
-  )
-  (wire (pts (xy 165.1 121.92) (xy 165.1 142.24))
-    (stroke (width 0) (type default))
-    (uuid 411efa8a-c2b6-469e-b517-3b3f24ffe025)
-  )
-  (wire (pts (xy 73.66 190.5) (xy 93.98 190.5))
-    (stroke (width 0) (type default))
-    (uuid 432577d5-87d0-4924-a72a-e407dd2ee4b0)
-  )
-  (wire (pts (xy 134.62 170.18) (xy 154.94 170.18))
-    (stroke (width 0) (type default))
-    (uuid 44b0d7a3-542f-48ea-8a2f-25ca02bd7f05)
-  )
-  (wire (pts (xy 53.34 170.18) (xy 73.66 170.18))
-    (stroke (width 0) (type default))
-    (uuid 4554fe48-1b8d-466c-b3f4-c87fb3d79947)
-  )
-  (wire (pts (xy 43.18 60.96) (xy 43.18 81.28))
-    (stroke (width 0) (type default))
-    (uuid 456f0365-d37d-43a2-afac-d06c44cc48af)
-  )
-  (wire (pts (xy 154.94 129.54) (xy 175.26 129.54))
-    (stroke (width 0) (type default))
-    (uuid 462b3865-9668-49d6-a9d9-1406a843104e)
-  )
-  (wire (pts (xy 114.3 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid 473d672b-6459-459b-93fc-780e5d8f9818)
-  )
-  (wire (pts (xy 124.46 81.28) (xy 124.46 101.6))
-    (stroke (width 0) (type default))
-    (uuid 495f9334-ca7f-4aa5-8d75-09576f1afa2c)
-  )
-  (wire (pts (xy 104.14 182.88) (xy 104.14 203.2))
-    (stroke (width 0) (type default))
-    (uuid 4bc89a8f-f8d9-4d47-a286-fb87f34a3ba1)
-  )
-  (wire (pts (xy 195.58 68.58) (xy 218.44 68.58))
-    (stroke (width 0) (type default))
-    (uuid 4dd10eac-e6fb-4446-8933-3009a548bf1c)
-  )
-  (wire (pts (xy 165.1 81.28) (xy 165.1 101.6))
-    (stroke (width 0) (type default))
-    (uuid 50f7b113-f5f8-43e0-9da7-2a02dc224210)
-  )
-  (wire (pts (xy 226.06 190.5) (xy 226.06 210.82))
-    (stroke (width 0) (type default))
-    (uuid 5194f352-1f61-4ee5-af2e-f0eb341e3d13)
-  )
-  (wire (pts (xy 33.02 190.5) (xy 53.34 190.5))
-    (stroke (width 0) (type default))
-    (uuid 55243e41-6164-4661-b707-a6f503f12968)
-  )
-  (wire (pts (xy 53.34 190.5) (xy 73.66 190.5))
-    (stroke (width 0) (type default))
-    (uuid 557847f5-42a8-4c4a-a4d9-d21678c28920)
-  )
-  (wire (pts (xy 104.14 60.96) (xy 104.14 81.28))
-    (stroke (width 0) (type default))
-    (uuid 5837ecd4-cf70-4c14-9c7b-bb5f05f8274a)
-  )
-  (wire (pts (xy 104.14 81.28) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid 5b6ae0de-21c8-4433-a4e0-a3b552474fb0)
-  )
-  (wire (pts (xy 134.62 48.26) (xy 154.94 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5d63c1a3-5086-42ca-8afa-60afe2472b23)
-  )
-  (wire (pts (xy 93.98 210.82) (xy 114.3 210.82))
-    (stroke (width 0) (type default))
-    (uuid 5f73184b-d2cf-4b7b-afcf-f14e002f7ce1)
-  )
-  (wire (pts (xy 53.34 88.9) (xy 73.66 88.9))
-    (stroke (width 0) (type default))
-    (uuid 60b5d548-d07f-40b1-8e16-72d513f499f2)
-  )
-  (wire (pts (xy 154.94 109.22) (xy 175.26 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6196eb37-90e9-4f6c-80ae-9b758a88c740)
-  )
-  (wire (pts (xy 33.02 210.82) (xy 53.34 210.82))
-    (stroke (width 0) (type default))
-    (uuid 6329f5e0-c3e3-42c6-b639-2bebe7a40e8b)
-  )
-  (wire (pts (xy 93.98 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6414e19f-a27a-435d-a47f-a63cba9086f1)
-  )
-  (wire (pts (xy 134.62 109.22) (xy 154.94 109.22))
-    (stroke (width 0) (type default))
-    (uuid 64344100-c91d-4b5c-a8eb-9406d47360dd)
-  )
-  (wire (pts (xy 195.58 88.9) (xy 218.44 88.9))
-    (stroke (width 0) (type default))
-    (uuid 6466dcfe-ac30-4b45-bc6e-0ba63363d641)
-  )
-  (wire (pts (xy 33.02 68.58) (xy 53.34 68.58))
-    (stroke (width 0) (type default))
-    (uuid 68161b0c-a285-475d-a645-59648d12bc07)
-  )
-  (wire (pts (xy 134.62 149.86) (xy 154.94 149.86))
-    (stroke (width 0) (type default))
-    (uuid 690a405c-1ac3-4b57-a93b-778dda168d2c)
-  )
-  (wire (pts (xy 134.62 190.5) (xy 154.94 190.5))
-    (stroke (width 0) (type default))
-    (uuid 6b21e6c7-ab97-41de-aae4-339e943db88e)
-  )
-  (wire (pts (xy 165.1 40.64) (xy 165.1 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc)
-  )
-  (wire (pts (xy 205.74 40.64) (xy 205.74 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6f1d74d1-18f8-4f5b-8c5d-e1587ab09b83)
-  )
-  (wire (pts (xy 195.58 190.5) (xy 218.44 190.5))
-    (stroke (width 0) (type default))
-    (uuid 6f392e01-5127-4d67-8c34-66beb18a9894)
-  )
-  (wire (pts (xy 226.06 149.86) (xy 226.06 170.18))
-    (stroke (width 0) (type default))
-    (uuid 6f77a68c-1e32-433a-820e-9683e6fd5e12)
-  )
-  (wire (pts (xy 205.74 162.56) (xy 205.74 182.88))
-    (stroke (width 0) (type default))
-    (uuid 7083b47b-e7bb-4169-bf41-06719234452e)
-  )
-  (wire (pts (xy 226.06 88.9) (xy 226.06 109.22))
-    (stroke (width 0) (type default))
-    (uuid 70c6e975-f457-4759-9791-1d1de45afbb3)
-  )
-  (wire (pts (xy 134.62 129.54) (xy 154.94 129.54))
-    (stroke (width 0) (type default))
-    (uuid 70f3f37d-4259-413e-b59a-babccfdc3a89)
-  )
-  (wire (pts (xy 43.18 121.92) (xy 43.18 142.24))
-    (stroke (width 0) (type default))
-    (uuid 727cc522-ef34-45d4-b711-997054ff0b37)
-  )
-  (wire (pts (xy 33.02 48.26) (xy 53.34 48.26))
-    (stroke (width 0) (type default))
-    (uuid 737596e8-f579-4b1f-aa71-a489d8ba56da)
-  )
-  (wire (pts (xy 93.98 149.86) (xy 114.3 149.86))
-    (stroke (width 0) (type default))
-    (uuid 770cc50c-0085-42e2-b068-cd0ae3b59919)
-  )
-  (wire (pts (xy 226.06 25.4) (xy 226.06 48.26))
-    (stroke (width 0) (type default))
-    (uuid 794205f1-2f7e-4200-b59c-c02481b0416f)
-  )
-  (wire (pts (xy 73.66 88.9) (xy 93.98 88.9))
-    (stroke (width 0) (type default))
-    (uuid 79a42c80-d7a4-4e03-9070-f9fff835a239)
-  )
-  (wire (pts (xy 33.02 40.64) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid 7a4231d0-fb4b-4c65-9cc1-75d3ed714150)
-  )
-  (wire (pts (xy 185.42 142.24) (xy 185.42 162.56))
-    (stroke (width 0) (type default))
-    (uuid 7caa1de0-1c5d-4933-9515-38159a29c856)
-  )
-  (wire (pts (xy 165.1 25.4) (xy 165.1 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8506f273-12d6-426d-910b-0c9eecbe3765)
-  )
-  (wire (pts (xy 154.94 149.86) (xy 175.26 149.86))
-    (stroke (width 0) (type default))
-    (uuid 869288c6-9182-45ca-8025-5bf497b3633a)
-  )
-  (wire (pts (xy 134.62 88.9) (xy 154.94 88.9))
-    (stroke (width 0) (type default))
-    (uuid 86d6e974-6898-4932-91cb-e8a4c4c283b7)
-  )
-  (wire (pts (xy 104.14 162.56) (xy 104.14 182.88))
-    (stroke (width 0) (type default))
-    (uuid 8c3cf446-d0cc-4b1b-9218-75f38db02fb3)
-  )
-  (wire (pts (xy 53.34 210.82) (xy 73.66 210.82))
-    (stroke (width 0) (type default))
-    (uuid 8d25f923-67ff-47ea-9485-05bc5282bdab)
-  )
-  (wire (pts (xy 93.98 48.26) (xy 114.3 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8d73bae8-988b-435b-a882-ae9668b41d7e)
-  )
-  (wire (pts (xy 104.14 142.24) (xy 104.14 162.56))
-    (stroke (width 0) (type default))
-    (uuid 8dd624a1-3da3-42c1-929d-9366cd043e3d)
-  )
-  (wire (pts (xy 226.06 48.26) (xy 226.06 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8f339462-56e0-4361-9d9b-983c75fb21ef)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 53.34 88.9))
-    (stroke (width 0) (type default))
-    (uuid 909384ab-bc1c-47d8-a34d-c3d137febfc2)
-  )
-  (wire (pts (xy 124.46 101.6) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91eea887-ea8a-4221-ba92-e5ec1caacc4f)
-  )
-  (wire (pts (xy 124.46 142.24) (xy 124.46 162.56))
-    (stroke (width 0) (type default))
-    (uuid 94397688-ce0e-48d4-a59c-7257120bf834)
-  )
-  (wire (pts (xy 185.42 60.96) (xy 185.42 81.28))
-    (stroke (width 0) (type default))
-    (uuid 96776fa9-dbd1-46ef-91bd-e95f23cda112)
-  )
-  (wire (pts (xy 175.26 170.18) (xy 195.58 170.18))
-    (stroke (width 0) (type default))
-    (uuid 969acf2b-33fe-4e89-abf2-451f22e884f4)
-  )
-  (wire (pts (xy 205.74 101.6) (xy 205.74 121.92))
-    (stroke (width 0) (type default))
-    (uuid 97a65ef9-5994-4805-9e12-ca2b38a42461)
-  )
-  (wire (pts (xy 114.3 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 9c79c76c-a95b-401f-9edb-a06a0cceaa4b)
-  )
-  (wire (pts (xy 185.42 182.88) (xy 185.42 203.2))
-    (stroke (width 0) (type default))
-    (uuid 9d4fc90e-2670-42d9-b5a8-2138817fee8a)
-  )
-  (wire (pts (xy 53.34 48.26) (xy 73.66 48.26))
-    (stroke (width 0) (type default))
-    (uuid 9d5ec847-5716-4125-b40b-fdbd3a1587a7)
-  )
-  (wire (pts (xy 175.26 129.54) (xy 195.58 129.54))
-    (stroke (width 0) (type default))
-    (uuid 9edd39d2-8ad2-4ad5-94ce-c356ef944a50)
-  )
-  (wire (pts (xy 165.1 101.6) (xy 165.1 121.92))
-    (stroke (width 0) (type default))
-    (uuid 9f711890-a6d6-4440-8bc1-ed469cb6acc4)
-  )
-  (wire (pts (xy 83.82 182.88) (xy 83.82 203.2))
-    (stroke (width 0) (type default))
-    (uuid a0b86442-47da-481e-aac6-2c18430e056b)
-  )
-  (wire (pts (xy 93.98 101.6) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid a226d887-7662-4dbd-b58b-e683f5d85955)
-  )
-  (wire (pts (xy 124.46 40.64) (xy 124.46 60.96))
-    (stroke (width 0) (type default))
-    (uuid a67c0815-f186-4f70-926f-1b264c84d8d8)
-  )
-  (wire (pts (xy 154.94 162.56) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid a803bbba-64cc-448d-a04f-7f03127ebddd)
-  )
-  (wire (pts (xy 53.34 149.86) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid aac914ea-c9a3-4a8f-94e1-1f91cdd136a3)
-  )
-  (wire (pts (xy 93.98 129.54) (xy 114.3 129.54))
-    (stroke (width 0) (type default))
-    (uuid ab578e4e-a4bf-4ab4-80fc-d97d4aea6370)
-  )
-  (wire (pts (xy 114.3 210.82) (xy 134.62 210.82))
-    (stroke (width 0) (type default))
-    (uuid abd1d27d-b9d9-4cf6-b486-65a2a8efef41)
-  )
-  (wire (pts (xy 175.26 88.9) (xy 195.58 88.9))
-    (stroke (width 0) (type default))
-    (uuid acc95df4-5464-4718-a58a-e43a56e1893a)
-  )
-  (wire (pts (xy 83.82 121.92) (xy 83.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73)
-  )
-  (wire (pts (xy 175.26 48.26) (xy 195.58 48.26))
-    (stroke (width 0) (type default))
-    (uuid adf35dfa-3831-4e3a-9fdd-7a4ac7f5230d)
-  )
-  (wire (pts (xy 93.98 68.58) (xy 114.3 68.58))
-    (stroke (width 0) (type default))
-    (uuid aea6a633-b213-403d-b447-42d91d3ab4da)
-  )
-  (wire (pts (xy 175.26 68.58) (xy 195.58 68.58))
-    (stroke (width 0) (type default))
-    (uuid b2797b5c-16d1-4c35-814c-4b30f0a6683b)
-  )
-  (wire (pts (xy 114.3 170.18) (xy 134.62 170.18))
-    (stroke (width 0) (type default))
-    (uuid b3e14390-7dc6-416b-bbd5-cdf868192ca4)
-  )
-  (wire (pts (xy 73.66 129.54) (xy 93.98 129.54))
-    (stroke (width 0) (type default))
-    (uuid b3f6f053-44f0-4391-9873-b6231b8014db)
-  )
-  (wire (pts (xy 144.78 101.6) (xy 144.78 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7b2475f-30dc-4ea2-b799-96c21242154c)
-  )
-  (wire (pts (xy 175.26 210.82) (xy 195.58 210.82))
-    (stroke (width 0) (type default))
-    (uuid b7c3f0e9-4787-4050-9c72-cdbaf3e08cfe)
-  )
-  (wire (pts (xy 83.82 81.28) (xy 83.82 101.6))
-    (stroke (width 0) (type default))
-    (uuid b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5)
-  )
-  (wire (pts (xy 226.06 170.18) (xy 226.06 190.5))
-    (stroke (width 0) (type default))
-    (uuid ba045c1c-f33c-4ee8-bfe6-db2af30446e4)
-  )
-  (wire (pts (xy 43.18 101.6) (xy 43.18 121.92))
-    (stroke (width 0) (type default))
-    (uuid bb49a3de-620b-45ad-a54c-29dcceaf0796)
-  )
-  (wire (pts (xy 144.78 121.92) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid bf12198a-9e62-45c3-b466-f5d86de75219)
-  )
-  (wire (pts (xy 73.66 210.82) (xy 93.98 210.82))
-    (stroke (width 0) (type default))
-    (uuid c007dc03-0700-44f8-b7e3-69868fe31a12)
-  )
-  (wire (pts (xy 205.74 60.96) (xy 205.74 81.28))
-    (stroke (width 0) (type default))
-    (uuid c0bbd51b-0041-4026-a546-37b4ba305884)
-  )
-  (wire (pts (xy 63.5 25.4) (xy 63.5 40.64))
-    (stroke (width 0) (type default))
-    (uuid c1a940de-fa49-4106-a8b9-697952eec2a2)
-  )
-  (wire (pts (xy 104.14 121.92) (xy 104.14 142.24))
-    (stroke (width 0) (type default))
-    (uuid c298ba49-6974-4340-859f-5d5a2b4132ff)
-  )
-  (wire (pts (xy 124.46 182.88) (xy 124.46 203.2))
-    (stroke (width 0) (type default))
-    (uuid c3555de4-415f-4041-a3dd-bd91effa102c)
-  )
-  (wire (pts (xy 175.26 182.88) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid c3f1f747-e966-4c2c-8090-4f190e07864a)
-  )
-  (wire (pts (xy 124.46 162.56) (xy 124.46 182.88))
-    (stroke (width 0) (type default))
-    (uuid c6080a0e-4059-4120-b2e7-12c9aff607b7)
-  )
-  (wire (pts (xy 124.46 60.96) (xy 124.46 81.28))
-    (stroke (width 0) (type default))
-    (uuid c950d145-c024-47a8-ba57-97efd7bb658b)
-  )
-  (wire (pts (xy 154.94 88.9) (xy 175.26 88.9))
-    (stroke (width 0) (type default))
-    (uuid c980f191-a655-4149-a076-6b096870a525)
-  )
-  (wire (pts (xy 144.78 142.24) (xy 144.78 162.56))
-    (stroke (width 0) (type default))
-    (uuid ca92ed7f-ae97-4c0c-81e4-820de1c001c1)
-  )
-  (wire (pts (xy 226.06 109.22) (xy 226.06 129.54))
-    (stroke (width 0) (type default))
-    (uuid cdde081d-7bdd-42e6-869e-3ff07b8b464b)
-  )
-  (wire (pts (xy 185.42 121.92) (xy 185.42 142.24))
-    (stroke (width 0) (type default))
-    (uuid cee2f4f4-6cbc-4838-b71a-3189173bbcfe)
-  )
-  (wire (pts (xy 83.82 40.64) (xy 83.82 60.96))
-    (stroke (width 0) (type default))
-    (uuid cff15ec3-f29c-4d36-8776-64c5d29be534)
-  )
-  (wire (pts (xy 175.26 109.22) (xy 195.58 109.22))
-    (stroke (width 0) (type default))
-    (uuid d0ca1f96-c34f-481a-93d5-3555eaca4541)
-  )
-  (wire (pts (xy 83.82 25.4) (xy 83.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid d1088709-a9b9-4e05-8ea2-f87942ee2796)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 93.98 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1347903-ae03-46a2-a707-154093060583)
-  )
-  (wire (pts (xy 175.26 149.86) (xy 195.58 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1443f9b-09ec-44c4-8217-4ea1c781d667)
-  )
-  (wire (pts (xy 144.78 40.64) (xy 144.78 60.96))
-    (stroke (width 0) (type default))
-    (uuid d2183fb3-afd3-46ca-955e-993ea31aa5d3)
-  )
-  (wire (pts (xy 185.42 25.4) (xy 185.42 40.64))
-    (stroke (width 0) (type default))
-    (uuid d2951d7e-82c5-4b56-9a90-ca8ae6d71e44)
-  )
-  (wire (pts (xy 205.74 25.4) (xy 205.74 40.64))
-    (stroke (width 0) (type default))
-    (uuid d4107bae-81df-4028-a211-ea4ab3232bfc)
-  )
-  (wire (pts (xy 43.18 162.56) (xy 43.18 182.88))
-    (stroke (width 0) (type default))
-    (uuid d56982aa-6580-4d04-83ea-6bf3a85282cc)
-  )
-  (wire (pts (xy 185.42 101.6) (xy 185.42 121.92))
-    (stroke (width 0) (type default))
-    (uuid d675b927-bdff-4eac-82e7-3f468caedaf2)
-  )
-  (wire (pts (xy 43.18 142.24) (xy 43.18 162.56))
-    (stroke (width 0) (type default))
-    (uuid d76ad758-0ae0-4ce6-9f67-c689c066c744)
-  )
-  (wire (pts (xy 144.78 182.88) (xy 144.78 203.2))
-    (stroke (width 0) (type default))
-    (uuid d8747c5c-1650-4a8e-b6a0-4fa4acd098ae)
-  )
-  (wire (pts (xy 205.74 81.28) (xy 205.74 101.6))
-    (stroke (width 0) (type default))
-    (uuid d920ca82-8ad7-4105-a47d-6c01f55c13d9)
-  )
-  (wire (pts (xy 33.02 149.86) (xy 53.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid da80b027-904b-4ca2-99c6-5937c80c825c)
-  )
-  (wire (pts (xy 63.5 142.24) (xy 63.5 162.56))
-    (stroke (width 0) (type default))
-    (uuid db492971-48ff-4667-996c-f5d540a20741)
-  )
-  (wire (pts (xy 205.74 121.92) (xy 205.74 142.24))
-    (stroke (width 0) (type default))
-    (uuid dc91af22-52c4-4234-961f-adc3ed363a9c)
-  )
-  (wire (pts (xy 165.1 142.24) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid dccfde3a-ff1d-42ec-97d5-a8f6cccea832)
-  )
-  (wire (pts (xy 33.02 170.18) (xy 53.34 170.18))
-    (stroke (width 0) (type default))
-    (uuid de8e54c6-84d9-47e5-8f08-dc3e96b8afdb)
-  )
-  (wire (pts (xy 43.18 81.28) (xy 43.18 101.6))
-    (stroke (width 0) (type default))
-    (uuid df5c3763-e66c-46c4-9070-0f73d8115bc4)
-  )
-  (wire (pts (xy 226.06 129.54) (xy 226.06 149.86))
-    (stroke (width 0) (type default))
-    (uuid dfb5a082-e4d5-46ea-8dc8-c65064cd598b)
-  )
-  (wire (pts (xy 93.98 170.18) (xy 114.3 170.18))
-    (stroke (width 0) (type default))
-    (uuid e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb)
-  )
-  (wire (pts (xy 144.78 81.28) (xy 144.78 101.6))
-    (stroke (width 0) (type default))
-    (uuid e444742a-24b1-4bbf-b7ee-438e6dffc9cc)
-  )
-  (wire (pts (xy 195.58 48.26) (xy 218.44 48.26))
-    (stroke (width 0) (type default))
-    (uuid e550e849-255b-418f-9c4c-fc9c233d87ed)
-  )
-  (wire (pts (xy 175.26 190.5) (xy 195.58 190.5))
-    (stroke (width 0) (type default))
-    (uuid e5e38d44-8bf0-426b-a99f-727527ca9657)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid e6d06035-ccb7-4d3e-ae70-d73150e65bbb)
-  )
-  (wire (pts (xy 195.58 210.82) (xy 218.44 210.82))
-    (stroke (width 0) (type default))
-    (uuid e7de80e0-8b7f-450c-9d32-23820caa1781)
-  )
-  (wire (pts (xy 114.3 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa)
-  )
-  (wire (pts (xy 63.5 101.6) (xy 63.5 121.92))
-    (stroke (width 0) (type default))
-    (uuid edeeb0d9-51cc-411d-aac4-77f10b619702)
-  )
-  (wire (pts (xy 104.14 40.64) (xy 104.14 60.96))
-    (stroke (width 0) (type default))
-    (uuid ef5c9f05-d71b-4562-9939-852432c066c5)
-  )
-  (wire (pts (xy 144.78 162.56) (xy 144.78 182.88))
-    (stroke (width 0) (type default))
-    (uuid efa47227-d3f9-4214-af64-a7e9107c0edb)
-  )
-  (wire (pts (xy 144.78 60.96) (xy 144.78 81.28))
-    (stroke (width 0) (type default))
-    (uuid f0ce7c2b-d80c-49f2-bf63-62b750f7ca47)
-  )
-  (wire (pts (xy 154.94 210.82) (xy 175.26 210.82))
-    (stroke (width 0) (type default))
-    (uuid f262cb15-d063-4165-a9f6-3e6a5c7bac7c)
-  )
-  (wire (pts (xy 63.5 162.56) (xy 63.5 182.88))
-    (stroke (width 0) (type default))
-    (uuid f5658dea-a5b6-4ba9-9360-11c3315c15be)
-  )
-  (wire (pts (xy 134.62 142.24) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid f781a362-e0d4-48be-9d13-5686e05b406f)
-  )
-  (wire (pts (xy 195.58 170.18) (xy 218.44 170.18))
-    (stroke (width 0) (type default))
-    (uuid f95e0e09-daac-4a87-aa64-d71bee00c840)
-  )
-  (wire (pts (xy 43.18 25.4) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid fa765e67-a220-4a00-944c-7663298f0ead)
-  )
-  (wire (pts (xy 83.82 142.24) (xy 83.82 162.56))
-    (stroke (width 0) (type default))
-    (uuid fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b)
-  )
-  (wire (pts (xy 185.42 81.28) (xy 185.42 101.6))
-    (stroke (width 0) (type default))
-    (uuid ffe6085a-a7be-4653-b911-c10de4574454)
-  )
-
-  (global_label "IO 3" (shape bidirectional) (at 104.14 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 24ec698b-5cae-4571-b9c4-c0e35d64a64d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 104.14 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 1" (shape bidirectional) (at 63.5 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2d4b15a5-8b6c-4ca3-a7bb-7848c8036590)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 63.5 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 7" (shape bidirectional) (at 185.42 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 45d4e03e-6cff-41ce-b946-708382da0601)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 185.42 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 0" (shape bidirectional) (at 43.18 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 465a517d-f0e1-4825-8675-1cce54bfa7a5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 43.18 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "INTR" (shape bidirectional) (at 226.06 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4e12b932-2346-4e84-b5a4-80468334f3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 234.25 25.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "IO 2" (shape bidirectional) (at 83.82 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 70d42e66-a74c-4de2-af96-d1860851d3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 83.82 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 165.1 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 89461221-a936-49a3-bf5d-18ec120f3e0c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 165.1 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 144.78 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d44cceb0-f409-4e5f-a98a-9feead2e845d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 8" (shape bidirectional) (at 205.74 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid e036ec60-274a-4de6-9324-dafd5b920142)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 205.74 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 4" (shape bidirectional) (at 124.46 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f36f49e4-227f-479f-b914-786aa44dd568)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 124.46 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 190.5 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0188dba3-054f-4958-9440-27c9ca673633)
-    (property "Reference" "DI7" (at 222.25 186.69 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 193.04 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid deea1889-824f-4f7a-a6be-9546db353c85))
-    (pin "2" (uuid 2080be86-a538-40a8-8f30-ead2a96d02d3))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0263b847-a932-4a31-9f35-35bb23f7000d)
-    (property "Reference" "D62" (at 152.4 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc2e60ca-c74f-4e4b-a0a0-9705327e9578))
-    (pin "2" (uuid d12efbfe-85ac-442f-8c0f-ddbe5646c7d5))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D62") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 64.77 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 04430572-8314-4d21-974c-22350cead1a6)
-    (property "Reference" "DS1" (at 55.88 65.405 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 55.88 62.865 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e433df4-9fec-4cfb-b60f-eebca7c574cf))
-    (pin "2" (uuid 9bcc1487-0612-4bdb-a2de-a8b2f590b28f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 44.45 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080aaa87-0974-4a77-bf63-185495f411a0)
-    (property "Reference" "DS0" (at 35.56 45.085 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 35.56 42.545 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bfacad1-28fd-4f2e-93dc-68f478b8a6ba))
-    (pin "2" (uuid 376f73f9-79fa-4153-ae38-31ed5446db52))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09d14922-c46a-4bf1-bb2c-1d224060568c)
-    (property "Reference" "D40" (at 111.76 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2f1a1d2-df3d-4680-9706-2ca411fa6890))
-    (pin "2" (uuid f58fd788-6016-46e7-b903-3606dd2ec21d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D40") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 149.86 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0d18473f-e37a-4136-b721-5a2e40e4f8ed)
-    (property "Reference" "DI5" (at 222.25 146.05 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 152.4 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d5a885ca-5076-44e6-9a84-d07474947dde))
-    (pin "2" (uuid 047b5b54-de8b-4afc-abc2-c6d1f2d17bd2))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 170.18 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0ef17723-f7f8-4fdb-8913-5a4ceefbc065)
-    (property "Reference" "DI6" (at 222.25 166.37 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 172.72 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df5a6b10-ba48-4f34-96ce-3832d480a7ee))
-    (pin "2" (uuid 59f34a55-6ac4-496d-8c40-1b8f1eafbcb5))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0fadd319-be81-4c25-8d23-e7495a114aa7)
-    (property "Reference" "RC4-0" (at 119.38 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid efb1c47f-fe25-4bea-8081-43d3c19de5cd))
-    (pin "2" (uuid 9138c970-6e3d-46df-9354-5174df2a4e52))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ff76361-9578-4f9f-a20c-f042e24a7755)
-    (property "Reference" "D5" (at 30.48 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06))
-    (pin "2" (uuid cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 11f01cd8-f751-497f-9599-50fe1fc0a618)
-    (property "Reference" "RC5-4" (at 139.7 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc28293-fab9-4f93-b3d5-ca9ee69110c4))
-    (pin "2" (uuid 088ac770-af1e-4c4f-ad11-5b44a20594d8))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 13ddd48d-7d2b-415d-b8fa-15c71e245acc)
-    (property "Reference" "D61" (at 152.4 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 745d89b9-e75a-40ae-97bc-d1eadf220f02))
-    (pin "2" (uuid 7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D61") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 17d027e3-2b58-470b-9fc5-f21e547cdc82)
-    (property "Reference" "RC8-1" (at 200.66 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7f893b29-9b1f-44b8-bac5-e11991e6b604))
-    (pin "2" (uuid 6b5e04e4-6889-4e49-9600-35d15ee54578))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1b13866a-6fbf-441b-9c64-56258379f43a)
-    (property "Reference" "D65" (at 152.4 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c70f4670-9685-4aab-ac4f-4ebaf44d5847))
-    (pin "2" (uuid 8b9c860d-59e1-424e-a148-1aa2c0db4056))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D65") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a)
-    (property "Reference" "RC6-4" (at 160.02 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3427b432-e194-40af-9dcb-04dccafe2b0f))
-    (pin "2" (uuid 8af48a1b-2c49-47d9-959c-ee33cdd6f977))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d4decb6-e690-4f06-b8aa-6dd29b7f2622)
-    (property "Reference" "D58" (at 132.08 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0a89d11-f9ed-4dad-a764-70b931421ce9))
-    (pin "2" (uuid e072fab0-4e83-437a-8387-943f8bcc1213))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D58") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1e5f084d-4db5-48ad-a2a3-76f186559614)
-    (property "Reference" "RC3-1" (at 99.06 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa))
-    (pin "2" (uuid 40b7f115-b5d7-4fa0-b12b-c1c7b6866feb))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 210.82 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 210fa303-e6c4-43b3-8ff0-f2f9178c950d)
-    (property "Reference" "DI8" (at 222.25 207.01 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 213.36 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cad82d1c-a62b-40c6-a2ae-61d28ed2d913))
-    (pin "2" (uuid ca0c8c70-cbfc-4421-833b-b58ab5f50511))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 22a72d93-d5b5-4a6b-95f6-755ac10ccf50)
-    (property "Reference" "RC4-7" (at 119.38 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 18c97ab1-62df-42bc-9dfa-dba3415ee8e2))
-    (pin "2" (uuid ff0eb9a3-538a-4ebf-a42b-97fe870ddfea))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 244b7f9d-3923-4908-be6d-02c49eb4663c)
-    (property "Reference" "RC2-3" (at 78.74 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d79440a-2f90-4c0b-8d60-528615b0bd65))
-    (pin "2" (uuid 7f1d0566-f385-4126-b190-2379308ed05b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 166.37 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2518146c-59f4-45b7-a4fa-f618686ab064)
-    (property "Reference" "DS6" (at 157.48 167.005 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 157.48 164.465 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cee2f461-8f62-48d8-ac7b-1698deb984c1))
-    (pin "2" (uuid 460b9088-619c-4166-a615-45e17ecf1f0d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2519cd5e-8ecf-41a4-a9d0-5b856882cb05)
-    (property "Reference" "D63" (at 152.4 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ea1c9827-ebfa-43f1-b2c6-5a572466713e))
-    (pin "2" (uuid 0496ba9c-818c-4d39-979a-e8785e06d12a))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D63") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 28137b00-0d76-493b-92b8-23037474163f)
-    (property "Reference" "RC1-3" (at 58.42 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3))
-    (pin "2" (uuid 41d35b0f-21b5-4da8-92df-229c816b63c5))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2a208574-f638-4917-a68f-bc3ff176d324)
-    (property "Reference" "D75" (at 172.72 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 503e8179-7a4a-4075-8fcf-2d7bb00a3908))
-    (pin "2" (uuid a744b0f2-49c4-46a7-9ec2-cefb21173879))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D75") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c50947a-4bb9-43c2-b65c-4726e224b6b0)
-    (property "Reference" "RC3-0" (at 99.06 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b))
-    (pin "2" (uuid 30241adf-a2e7-4976-a53a-5c267616618e))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2e38accc-5291-44a5-82e8-9bec928b99c0)
-    (property "Reference" "D18" (at 50.8 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20ca8cf6-b241-4581-b5e1-dadf97a2cf3f))
-    (pin "2" (uuid dc0b457e-4296-4b82-a953-b255f1e09c5c))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D18") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2f872c45-59ae-4f02-abee-114e38b97a80)
-    (property "Reference" "D87" (at 193.04 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4139db20-9977-4a84-b30c-e04c47ec888a))
-    (pin "2" (uuid bdc078b6-22f8-427e-a1f3-872c3722a746))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D87") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30340eba-9ed0-42ff-b11f-98a864f7223e)
-    (property "Reference" "RC1-4" (at 58.42 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aa956a67-c26e-4a57-9ddb-59688a6476ad))
-    (pin "2" (uuid 23cd0d93-5050-40ea-9d49-879bbcbb8bcd))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30b60f6a-8d20-44dd-b832-1906a957c513)
-    (property "Reference" "D54" (at 132.08 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c2ad1a4-b254-49a0-8435-d3a374353ffc))
-    (pin "2" (uuid 27a3cb64-baf1-430a-b797-bd52c0e46cbe))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D54") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 310fec10-f10c-41d7-9446-87c12744e146)
-    (property "Reference" "D26" (at 71.12 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e1d524d3-5d24-4c87-b480-74c57a74b567))
-    (pin "2" (uuid c0e9aa05-6318-4fdc-abee-cb43875c8e46))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D26") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35827986-7004-4f70-a10a-6ceb42f33d9f)
-    (property "Reference" "RC1-2" (at 58.42 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 879d3b07-b41e-4233-b196-e223f635bdf3))
-    (pin "2" (uuid 641f8ea7-6306-4550-92c8-e3cc0ed3e5a5))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3598234f-e6ed-4eb6-b25a-52bde6e19729)
-    (property "Reference" "D82" (at 193.04 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f8d7980-fcb9-49ec-8704-044fa4175b07))
-    (pin "2" (uuid e2992df7-1f75-4c2b-bd16-ce868f4adf82))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D82") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 369ff51e-db51-4132-aa26-7b5d981cba74)
-    (property "Reference" "D17" (at 50.8 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9b5adb2f-c180-494e-86cd-ef0a68591be2))
-    (pin "2" (uuid 24774a87-3207-4ab9-a94d-2b9e1b568e65))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D17") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 37da2014-affc-4731-b642-c4245ff411f2)
-    (property "Reference" "RC5-7" (at 139.7 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ac410347-ba8b-493b-832e-a3f9e3359951))
-    (pin "2" (uuid 4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976)
-    (property "Reference" "D43" (at 111.76 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7d6fb6c4-b36c-4ff1-879b-43826c273a72))
-    (pin "2" (uuid 198c65f6-b3df-4780-9f6d-1c910e870a1b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D43") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3a9b19be-43ef-409c-9489-c069efbfa3ee)
-    (property "Reference" "RC0-7" (at 38.1 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 898cdd62-8ad6-4d58-b6f7-f4db79a4cca2))
-    (pin "2" (uuid 277b2226-c100-403c-a519-ef9cdc3923fe))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ac53e86-aa26-4394-9e99-e33f3c863b14)
-    (property "Reference" "RC7-1" (at 180.34 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e6efb38c-f391-43d6-9511-8c7da50b3d51))
-    (pin "2" (uuid 03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ad37b9b-353e-40fc-ac40-f5195f3dc605)
-    (property "Reference" "RC1-8" (at 58.42 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3efa7b0a-a125-48e1-96a0-b756f7dea902))
-    (pin "2" (uuid e99d0060-9d73-4fee-8521-d18593d0656b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef0222e-2eac-4930-ac36-0f395f4593b6)
-    (property "Reference" "RC1-0" (at 58.42 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f0b9b8-9322-4d89-a423-dd3d807d99ff))
-    (pin "2" (uuid ce54609e-9d1d-4a3b-81a2-5a384dbe41c8))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef86e49-a152-4515-afb0-4098f497c742)
-    (property "Reference" "D31" (at 91.44 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a))
-    (pin "2" (uuid b917ad78-96a8-428f-ad4f-d49149b5b97b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D31") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 402f0f46-5eb8-421b-9b9f-01a54b5cfa87)
-    (property "Reference" "RC4-1" (at 119.38 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cb206c0-1fab-4ac5-b301-f9678369525b))
-    (pin "2" (uuid b99c2ecc-04a5-4c54-a491-d99fe2562dcc))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 40d8058d-714e-4f99-a508-f64f9c8b575b)
-    (property "Reference" "D60" (at 152.4 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 66710233-d2ab-4921-aa86-488ee87fbb3a))
-    (pin "2" (uuid a9636da9-222c-478f-bc5b-71d3f0473300))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D60") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 430b936d-b8ad-4c28-b93d-4046aec980c7)
-    (property "Reference" "D67" (at 152.4 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9255475-7a77-44cc-9bd9-589d63ced82b))
-    (pin "2" (uuid 9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D67") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 433f3f09-0867-41a3-8ac6-5f00bd3314fc)
-    (property "Reference" "D32" (at 91.44 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 11a29637-fd50-4473-bb70-d4116312a4f5))
-    (pin "2" (uuid 53f6307d-8380-45e9-b3fa-4d05a2bd575d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44499808-710f-44ae-bed2-0632db78b8c8)
-    (property "Reference" "D71" (at 172.72 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8805b31-9770-4092-b10a-101cf112fd76))
-    (pin "2" (uuid 9f3056b1-b197-421f-9d54-08cf5cc88970))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D71") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4461a601-2e4b-4cf8-8094-5e4d8e990676)
-    (property "Reference" "RC5-8" (at 139.7 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f54d1c0f-d68b-4769-9ef7-ac6475687d30))
-    (pin "2" (uuid 49768dd5-fbea-4db4-9154-60b22afd8a29))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44de9323-bd5d-49cd-bf0a-70392801309d)
-    (property "Reference" "D45" (at 111.76 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb2b185b-5d98-46b8-8516-9e5c980291cf))
-    (pin "2" (uuid f730da3b-5ef9-4abc-8c8d-0794fe3feb87))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D45") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 454ad926-1c6a-4aa4-b6f8-25297463de18)
-    (property "Reference" "RC3-2" (at 99.06 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f0aebfce-7e76-40f1-83ef-5914b8ebbcc7))
-    (pin "2" (uuid 744fce2b-a15c-45a6-92b0-e880efafb5f6))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 48.26 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46348ccc-126c-461a-8e39-f93f389ddaa7)
-    (property "Reference" "DI0" (at 222.25 44.45 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 50.8 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c86bf5fa-c113-44c1-b93d-7a5d4ac11904))
-    (pin "2" (uuid dbd8322f-50c7-4271-821c-b0005fd066b2))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4a7f7b3d-918b-431a-b79d-c66494b3ec50)
-    (property "Reference" "D52" (at 132.08 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd114d76-87b2-4089-b211-b7b541ac42b3))
-    (pin "2" (uuid a360aa38-116c-4dd0-a569-f6a7a5a88a05))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D52") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4d978207-10b9-4a43-a474-2e66421925a0)
-    (property "Reference" "D64" (at 152.4 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 27529674-e97c-460d-9de8-89cd61c8a6eb))
-    (pin "2" (uuid 57e77ee6-e62d-402e-a614-a833da3fbafb))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D64") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4e9036c3-3848-485b-8b45-7e377c05efba)
-    (property "Reference" "D86" (at 193.04 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cebd91c6-213c-407e-8871-b40d23e32e3c))
-    (pin "2" (uuid 209631a2-8c98-4e88-8a48-286a9aadd110))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D86") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5466fd2d-f22f-409b-b7da-f8d297aeb7a2)
-    (property "Reference" "RC6-5" (at 160.02 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffdd8419-9afa-4f38-bfbf-7dc4e869b438))
-    (pin "2" (uuid 0db27643-51f5-4634-a791-2c4813885195))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5518d7f7-6de1-409b-a6d0-90efa78c0b82)
-    (property "Reference" "D7" (at 30.48 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9bdf2265-17dd-4712-9f75-996577068823))
-    (pin "2" (uuid cd2654f9-f2c1-4ff7-bbce-8fe664862762))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 553a576d-44a1-4bad-9211-394526206f63)
-    (property "Reference" "D41" (at 111.76 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4a035e61-91c9-41ba-9328-bc9b284e86c2))
-    (pin "2" (uuid 8628539f-d3cd-4957-a6bb-5c605649e715))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D41") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55c4f5cb-c530-414c-92f5-fbf9e58a8885)
-    (property "Reference" "D37" (at 91.44 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64d90630-a755-4eae-b416-80d8ff93fde4))
-    (pin "2" (uuid 77e4ef56-5ac3-4295-aacb-04ae680de9b7))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D37") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55dc1959-7c17-496b-b079-56725e7400ff)
-    (property "Reference" "RC7-6" (at 180.34 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d91f51f-9558-44e7-9b69-c9ba25dbac1f))
-    (pin "2" (uuid f7ee2403-2740-4116-96fa-c5f3c0c9f293))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 563bf078-cf50-4f0f-84d6-a83a0feddd45)
-    (property "Reference" "D70" (at 172.72 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 91318668-36ae-48a7-a13c-18d4c2f08036))
-    (pin "2" (uuid 29b99e4d-eeeb-4f18-b49f-b44a360c9eac))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D70") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 207.01 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5642ac65-20dd-447b-a5a3-1b21218d5bac)
-    (property "Reference" "DS8" (at 198.12 207.645 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 198.12 205.105 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6d406bb4-8771-4842-b48d-4d5e1f3de0cf))
-    (pin "2" (uuid bcdb56a4-4458-438f-b33a-abdcc29a1ebf))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 68.58 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5692cd7d-67c7-4fe7-8b4d-c8bc86968b31)
-    (property "Reference" "DI1" (at 222.25 64.77 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9abe1fc5-b3c1-424f-8519-d12916c57a11))
-    (pin "2" (uuid 168b1203-c5fc-4b69-b8e5-94d0bdc27e41))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 57e7516d-643d-4cd1-9646-d8696e387a16)
-    (property "Reference" "D38" (at 91.44 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c0d30413-2127-456f-a30c-24a92d981ac9))
-    (pin "2" (uuid a92161f1-81a1-4199-93bf-ab8287ab6d27))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D38") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59263e5e-1eeb-458b-9b02-ca162d4a65d7)
-    (property "Reference" "D21" (at 71.12 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2372f523-257f-414c-92f4-8d433cfbee15))
-    (pin "2" (uuid 21891727-1d09-4cab-bd90-75c57b141f7c))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D21") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59fdee43-9b65-471d-9ea8-5dc40dc65f6e)
-    (property "Reference" "D35" (at 91.44 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5834d436-0e26-481b-a20d-40fa6346502e))
-    (pin "2" (uuid 59af1ddc-701f-49c0-b6cd-778072695c5c))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D35") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5aeb247f-6f79-4df2-b767-9ca89069182c)
-    (property "Reference" "D56" (at 132.08 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d46c0cdd-d9c1-44c1-ba6c-034fc547ff01))
-    (pin "2" (uuid 53f3e198-3ef2-40c4-a8f7-298435eddd0b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D56") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5c60f960-fb0a-46f6-9aff-5d8144586231)
-    (property "Reference" "RC4-6" (at 119.38 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 990f1ee1-d6da-4ae8-809a-1911d8099a4c))
-    (pin "2" (uuid a8276c00-b61f-4db4-8f4f-e51e512de654))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5f21a75c-b9ee-47bf-adcf-39a03e42660f)
-    (property "Reference" "D15" (at 50.8 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1))
-    (pin "2" (uuid 7a8a84c2-38d2-473b-955d-81dd816a398e))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D15") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5fa8cce4-fbbf-4784-a459-71364b77e1a7)
-    (property "Reference" "RC0-2" (at 38.1 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cb7750fa-a378-43a3-a1c6-638c32a1c79e))
-    (pin "2" (uuid 67dfe958-6bd5-4618-98a3-d513db4ad5c0))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5ff7733c-a36f-4b29-a8e7-bdf79fabdf72)
-    (property "Reference" "D4" (at 30.48 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ed6062e9-f00a-474a-840f-39685bd66d70))
-    (pin "2" (uuid c0e85db4-b88d-4383-8de6-9f7370be62a6))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61b2e3fc-583b-407b-beff-dd8441f2f403)
-    (property "Reference" "RC2-6" (at 78.74 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 752f308d-4723-4468-9745-81de18307ba3))
-    (pin "2" (uuid 3267c09c-2818-42d7-96a9-6aaa2d6c4a92))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6368f5d6-df20-4a23-a72c-e29e990ea131)
-    (property "Reference" "D36" (at 91.44 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cd72461-15a2-466d-828d-9560639fb78b))
-    (pin "2" (uuid e26d27e6-f81a-4557-bc98-f3f953d25d26))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D36") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 64616073-76e8-465f-9707-663a78749bf1)
-    (property "Reference" "RC7-3" (at 180.34 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0925180b-4c04-468a-84a3-7e0c543a243b))
-    (pin "2" (uuid 000c5508-f583-4022-ad6d-ee3a9a754164))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6692c134-d619-4b90-b4c4-ab21aa3df3a5)
-    (property "Reference" "RC8-7" (at 200.66 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 453a02c7-7770-40fc-8f21-06b63fd625f1))
-    (pin "2" (uuid 3ebf9656-8129-4c66-8b10-67f0c0e2bb28))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 67aba0e0-2c92-4816-99a5-9091230a7899)
-    (property "Reference" "RC3-6" (at 99.06 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9c252319-dc79-4365-afaa-77dcde3e6c4e))
-    (pin "2" (uuid a5f35312-d094-4f22-9eb9-0edc1f8fb9c4))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6aa79de9-555a-4ed1-93d3-b801685ebd28)
-    (property "Reference" "D53" (at 132.08 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2031fe-ef72-48a9-afa6-c06144a31b2c))
-    (pin "2" (uuid 7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D53") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6ef4f980-15ce-420f-b02f-d66ae810e188)
-    (property "Reference" "D78" (at 172.72 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 680d9493-5437-446a-836f-9ed5bb999bdf))
-    (pin "2" (uuid d64a76a9-3b5d-48b1-9a48-ee12b0cd1ab7))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D78") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 70d661b8-51f1-49b8-ad84-9ce8d120c0fc)
-    (property "Reference" "RC6-2" (at 160.02 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2175ea2-22e6-4720-ab54-24959d43a616))
-    (pin "2" (uuid 63a1bf12-3f2f-4dc8-8a86-7932361b8306))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 712ade27-46b2-4d0c-b658-ec3775a1c528)
-    (property "Reference" "RC3-8" (at 99.06 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4811e298-73bc-4ac1-af58-3ae7f508d1d7))
-    (pin "2" (uuid ac21b718-c133-4ed3-a2f4-c437b7879cce))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 72047ccc-8813-4e13-ae4a-04618a9ab771)
-    (property "Reference" "D23" (at 71.12 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84))
-    (pin "2" (uuid 6dee3493-b1eb-401e-abb4-cbdef0ef3867))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D23") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7295efa3-e253-4b6b-ad8d-641bcea1e272)
-    (property "Reference" "D68" (at 152.4 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0450f5cb-94f5-4de3-b50e-da553aca1ff3))
-    (pin "2" (uuid 47f460cc-5812-4c14-b97e-030930a4c1aa))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D68") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7322809e-8332-47c6-af41-fcf3bbcec7d0)
-    (property "Reference" "D34" (at 91.44 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e3b096d1-dbd9-4fb8-8775-725a7aed0bc4))
-    (pin "2" (uuid 63756bb0-b693-4bbc-82da-e89a6b927e71))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D34") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 76054860-648b-474e-9b4d-cc9d83653495)
-    (property "Reference" "D10" (at 50.8 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d7e8bc-1ac3-4327-ab17-369de6ee755c))
-    (pin "2" (uuid c8283bba-c907-48e0-9745-e0818ca7ab04))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 77aa25a5-82c7-42c3-9d55-8606dd65ffa8)
-    (property "Reference" "RC5-1" (at 139.7 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51db5d58-5004-4c9c-b8d1-c184bfb493da))
-    (pin "2" (uuid 16d6f605-4627-49bd-9180-8203902febfd))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7876e2e4-9d5a-416f-b97a-e958a989e5b8)
-    (property "Reference" "D16" (at 50.8 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8bd5710-8f18-4748-9b3c-a975f78342a1))
-    (pin "2" (uuid da0aa924-203b-4985-9bff-4185f3555d43))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D16") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7b85c895-ed2f-4daf-bbd5-9b0e9148eed9)
-    (property "Reference" "RC7-8" (at 180.34 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6604866-4e4a-4cb4-bf09-ea0fa22fde38))
-    (pin "2" (uuid 0729bbae-70ee-4c7e-8da7-29c0812b5be7))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8010e136-1dd3-496f-b7ef-81fb0c8b419e)
-    (property "Reference" "D20" (at 71.12 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5aa5bf69-e040-48d4-81fc-332aff45c2f9))
-    (pin "2" (uuid f5458189-75e2-45c3-bf32-0320ebe63391))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D20") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80c46ab4-724f-418d-bb6f-e89792097e1a)
-    (property "Reference" "RC2-4" (at 78.74 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc0fd3d-897b-4e06-ac65-16066b68709e))
-    (pin "2" (uuid b7b98128-d37a-4ac7-b049-5cf9bdd5aadb))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 814545b5-c5a6-4c45-83b2-5c1b5ef43a22)
-    (property "Reference" "D57" (at 132.08 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid adc35f03-9c02-4ca4-bbc5-866d317a7469))
-    (pin "2" (uuid f05a395b-0185-4ab8-bf1d-fa0561316ad4))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D57") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 81912d5a-1def-44e9-a6ef-abaf3ecd517d)
-    (property "Reference" "RC6-1" (at 160.02 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fa9aca31-bd8b-4e2e-8b86-05d191575df9))
-    (pin "2" (uuid fce38bd6-fb8f-42a6-8d68-ecda7f1a588f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 820f9c2f-0705-41a0-aa6a-3a211d61773f)
-    (property "Reference" "RC6-7" (at 160.02 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eb135129-1d78-4d36-9389-941aee94da0a))
-    (pin "2" (uuid 2a32e7b7-f134-4c47-a153-d8fce8404094))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83cc3bf3-09a0-4d14-be9d-180ca479485f)
-    (property "Reference" "D73" (at 172.72 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 22a68b69-e4e9-436e-b154-616fe8bb66c2))
-    (pin "2" (uuid b8e81b5d-9257-4482-8c33-cdfcb13c22e7))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D73") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83fb734e-dbcd-4939-9bb9-d97efd05ec97)
-    (property "Reference" "RC5-6" (at 139.7 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7315a9fc-fd63-46c2-90db-bee656dc7568))
-    (pin "2" (uuid f2997912-9551-49e9-aab8-387875819f56))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 84146f81-04f3-4efb-b753-bdc596c8e7a9)
-    (property "Reference" "RC4-3" (at 119.38 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 774ced50-3b17-48fe-b2d7-22681b1dd1f7))
-    (pin "2" (uuid bad310c0-ca25-47d0-b27e-42438b959c7b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 86602dfb-ea19-4060-ad39-496c613a47cb)
-    (property "Reference" "D30" (at 91.44 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 02958e5d-18b7-48f3-9883-661ceaa75da5))
-    (pin "2" (uuid abed4b13-9431-40c7-848f-b30c05e39dfd))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D30") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8af20987-c3c2-465e-8640-61ab0bd7d8fa)
-    (property "Reference" "D81" (at 193.04 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f42cdbf-02ba-4b39-8586-bbff1b6ed80b))
-    (pin "2" (uuid 7d939371-3ab1-4f18-b55f-07048dcfe21f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D81") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8b2b0803-8190-43b4-9c0d-a9a9edc27829)
-    (property "Reference" "RC2-7" (at 78.74 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8e9f64d-5849-4a62-8bf4-dafc65fcdd75))
-    (pin "2" (uuid e45fa11d-c755-4d62-baa5-974f973ba20f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8c168cda-0a39-478d-9d71-1073400c7ed7)
-    (property "Reference" "RC1-5" (at 58.42 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d2851af-db15-44cf-8e07-da339bdc18b2))
-    (pin "2" (uuid 94b381a2-7c19-4916-9f9a-ee00221d04d3))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 129.54 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7)
-    (property "Reference" "DI4" (at 222.25 125.73 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c02807d6-1705-4325-bcb0-203f4e9a5baa))
-    (pin "2" (uuid d6c46059-bf9c-4959-836e-e4d33dcc5edd))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8eb7a7fa-054b-460a-a80c-73a56219fecd)
-    (property "Reference" "RC7-0" (at 180.34 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be9c1065-912d-49b5-8f2f-271b4a0c1db2))
-    (pin "2" (uuid 626f5614-e69d-4277-acf6-7ff35b08ddb4))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 90049005-7b99-4d2f-9282-dbf53b76b55d)
-    (property "Reference" "RC3-7" (at 99.06 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 62acb361-e48a-40de-9689-6c103c4c7663))
-    (pin "2" (uuid f3ee11cf-4f81-4591-ab5d-f41aece910dc))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 186.69 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 91a5d9b4-63df-4567-88f7-1d2f7ac8c33d)
-    (property "Reference" "DS7" (at 177.8 187.325 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 177.8 184.785 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2ec7f316-054f-444d-9c0b-c2c6e1d51faf))
-    (pin "2" (uuid e22dc61a-a86f-42a7-9c26-623bb8233a05))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 933178a7-83a9-4f29-88ef-1e369645dcaa)
-    (property "Reference" "RC2-8" (at 78.74 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4d133f2b-f4f1-4994-a89d-7141989cf18e))
-    (pin "2" (uuid 9ed70267-ef82-4b49-85af-67297365ea60))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 93921179-259f-4393-a6ae-bfcb2df690b6)
-    (property "Reference" "D80" (at 193.04 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d32d457e-c0ce-46dc-ac4a-08e965633eab))
-    (pin "2" (uuid 0645b564-d7c5-4845-82b9-8702f3f470a4))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D80") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9578a4b6-1a56-40b7-be8d-56404ef59fdf)
-    (property "Reference" "RC1-6" (at 58.42 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0b899b44-3ae3-40be-a452-1f16eaa5f4af))
-    (pin "2" (uuid 11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 109.22 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 957e7a82-ca9c-46a8-bca9-099b05fe7e8f)
-    (property "Reference" "DI3" (at 222.25 105.41 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 111.76 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc53fac9-006c-4101-8113-949ab8e05afb))
-    (pin "2" (uuid f6122429-5885-4b7a-b72a-162ca49c70c2))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9af5b930-d274-4b05-b0bf-e2c27b7e71dd)
-    (property "Reference" "D6" (at 30.48 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bdad3d4-58ec-438c-beb8-3eea36a29d95))
-    (pin "2" (uuid 5ff4e8af-dd18-4010-b183-21b8178cd684))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 222.25 88.9 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd)
-    (property "Reference" "DI2" (at 222.25 85.09 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 224.155 91.44 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 222.25 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 222.25 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 222.25 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 222.25 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a))
-    (pin "2" (uuid 81e4b9c6-9b09-4e38-94e9-cebdeae457ee))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9e96ab02-44ee-4ac7-8251-0d309b7409ad)
-    (property "Reference" "RC5-3" (at 139.7 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd85b120-1be2-4f17-a3d7-505a734afc72))
-    (pin "2" (uuid 666e03ce-bf1c-4b58-ac4e-f01557ca11fd))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a3969e5a-abe0-44e9-adf1-6255946e3f4c)
-    (property "Reference" "RC6-0" (at 160.02 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bc4d6aea-ec1e-45c7-842c-68cd7e21336f))
-    (pin "2" (uuid f785fa77-0ac2-41ff-9704-1acbb4a72c84))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a400377f-e146-4099-97e7-db21e16d5759)
-    (property "Reference" "D3" (at 30.48 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bfc71c1-6349-4b3f-bf89-22c83277904e))
-    (pin "2" (uuid dafd4b6c-6c2f-41e0-95ab-05ead276d86d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a576c983-0812-4f76-8327-d260ce9c2826)
-    (property "Reference" "D27" (at 71.12 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c11deb1a-dbe0-4d39-8303-331b09dd3cc0))
-    (pin "2" (uuid 9251c46a-97e6-41c1-9326-a6a8b52abc12))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D27") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a71b771b-4e14-4d95-98e7-86a6250f569e)
-    (property "Reference" "RC0-4" (at 38.1 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 95049e61-b78e-490f-86e1-aba711db5c19))
-    (pin "2" (uuid 6e474ba8-5b88-41c8-9259-b0ebfb6012f0))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid abf3c9d9-a279-4546-abcf-5e4f6862bc48)
-    (property "Reference" "D2" (at 30.48 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3499f31-3593-4cd9-977b-3b6479091d7b))
-    (pin "2" (uuid 17f09d49-1093-4838-8e5c-8fc4c42e5d05))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac10b530-144b-4dfc-ab37-ad7a8ced8612)
-    (property "Reference" "RC4-5" (at 119.38 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6c95156-54b9-4f54-a278-f808b4871687))
-    (pin "2" (uuid c3dc8d92-1759-4195-a3c9-81260bc6d8b1))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 85.09 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid accba515-4e8d-4804-afea-f36f436141c3)
-    (property "Reference" "DS2" (at 76.2 85.725 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 76.2 83.185 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 034e4344-7cda-43bc-a12a-f56b6e8f68f5))
-    (pin "2" (uuid 6f0bef00-c613-46da-9667-752b92174ad1))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ad352cc7-0ffd-4a04-82ac-bc693299cd86)
-    (property "Reference" "D83" (at 193.04 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9662d2b8-61ec-4840-a8f1-af48833c11eb))
-    (pin "2" (uuid 4d0c4f9f-b435-4d30-95d7-23d9f87d5f48))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D83") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid afcc8d67-6ed8-4a82-aef7-417b4229ad61)
-    (property "Reference" "RC7-4" (at 180.34 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 982715f0-55ee-4146-b98e-756e5b630dca))
-    (pin "2" (uuid 7f384a84-9632-4ac9-a8b6-05778cf49f62))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b05bbd1d-9d65-4ef7-a639-885ae69d8b01)
-    (property "Reference" "RC8-0" (at 200.66 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 16c6866c-1d06-4257-9cde-9d9c6f4c3642))
-    (pin "2" (uuid 70b152f6-7e7d-4a93-9ef0-b6ec51ff9b25))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b2cc8c06-500a-41ac-a412-7baf61e0f24c)
-    (property "Reference" "RC6-3" (at 160.02 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0a77d5cb-df53-4102-99ed-4829fa686656))
-    (pin "2" (uuid 22df81c2-2a06-44e2-bed1-a6d6c14df76a))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 146.05 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3573dc3-ef18-4f4c-817b-c984ae7cfae9)
-    (property "Reference" "DS5" (at 137.16 146.685 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 137.16 144.145 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 813e7cf6-f821-4e03-95cc-308010bed54e))
-    (pin "2" (uuid 9669a028-42d7-436f-8ec5-bc3423db62d6))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b39d56f9-3079-43e4-bb1b-80277fdae425)
-    (property "Reference" "RC4-2" (at 119.38 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b205d044-9ffa-4dce-82fd-f51ba622a818))
-    (pin "2" (uuid 29ce7588-4a17-4be4-9207-ea3ed2669aa1))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3c497a9-b81f-4161-88cf-2e58ddb4cdd8)
-    (property "Reference" "RC3-4" (at 99.06 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ae78f0d3-f75a-49c8-ab9b-8a9831e434d7))
-    (pin "2" (uuid a59e897c-0784-437d-9243-baf91d40a453))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b92624bc-936a-4bc6-ac7c-dbc9faa7208a)
-    (property "Reference" "D8" (at 30.48 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0ef02d0f-103e-468b-b30c-fac4e90fb218))
-    (pin "2" (uuid aa510cff-115d-4ad1-9c78-bf1246172261))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba3c5bf2-9824-404a-befe-7584c286e012)
-    (property "Reference" "D48" (at 111.76 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 38e4de38-525a-4e2c-8e51-9d4770973903))
-    (pin "2" (uuid e71e068d-4f7e-493a-960b-e49aa171ca56))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D48") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba927934-b2e1-4953-b21b-54ef02be8935)
-    (property "Reference" "RC0-5" (at 38.1 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cadba0a-3bb3-40cd-acea-644da4b3e05f))
-    (pin "2" (uuid 1368ebac-096c-415f-acaf-9afb071e729f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bb2c72f0-a908-44e7-b7d5-67df52eed516)
-    (property "Reference" "DS4" (at 116.84 126.365 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 116.84 123.825 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5ab0b348-3e2a-4517-90b3-fad111de6205))
-    (pin "2" (uuid 6e7351bb-5d09-464f-9e8d-535ba0f5c6f3))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bbc3ae57-e1db-475c-9bc3-18c822e7531a)
-    (property "Reference" "D28" (at 71.12 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90783402-edc5-4638-ae16-d31c3aaf5e2b))
-    (pin "2" (uuid f9e9c399-273d-43fc-9007-1e5ca67fea38))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D28") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be02506a-2bb1-4713-b046-f0327dae72de)
-    (property "Reference" "RC0-1" (at 38.1 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 97a92abd-708c-465e-baf7-79fa35370a7c))
-    (pin "2" (uuid c9056b1e-419e-478d-9fc4-be1e95902d28))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be554787-60ed-4b8f-b7bc-2220fcd28430)
-    (property "Reference" "RC8-3" (at 200.66 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 76eac86e-4d5a-4833-a702-c89fc5eb96e0))
-    (pin "2" (uuid 6e41d262-c7fe-4c54-b525-59ae026a918d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d)
-    (property "Reference" "RC5-2" (at 139.7 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f22c39d-012a-4297-b61c-1ff841801333))
-    (pin "2" (uuid adbe8c88-ad34-405b-866a-efb64899002f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c11b6807-83e7-46af-9d7e-9d56aab4109c)
-    (property "Reference" "D46" (at 111.76 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46))
-    (pin "2" (uuid 6764bae9-067c-4178-897e-2c25048ade8b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D46") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c164cb58-7d29-400c-b219-f07036f5e8c9)
-    (property "Reference" "RC0-3" (at 38.1 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92164ea1-76d0-4223-80cc-32c093c14fcd))
-    (pin "2" (uuid e615b2e5-6986-47ac-8f35-da60c20b811c))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c43b92c2-4283-44f7-8cb3-665623564383)
-    (property "Reference" "D42" (at 111.76 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0929e13-ab77-4737-9d55-142bd9901b1c))
-    (pin "2" (uuid 0f45988c-1752-479c-97d5-fbada14f9a42))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D42") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c72dd108-be98-47d5-b809-561778aa3212)
-    (property "Reference" "RC2-5" (at 78.74 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d2f0fd-ce69-4d4e-a4ab-163c1691ef24))
-    (pin "2" (uuid 03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c7f185b3-c785-4ddb-9c6f-f854c93057c1)
-    (property "Reference" "D85" (at 193.04 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b8f08018-67e0-4945-91d2-9a40292e0a1a))
-    (pin "2" (uuid 096b6293-e540-4273-b6aa-9e314016c840))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D85") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe)
-    (property "Reference" "D50" (at 132.08 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a606860e-126b-4f3e-bcfe-a2dfa8adc9c8))
-    (pin "2" (uuid 59120505-a333-4c63-8904-aa379cfb043b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D50") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c996541a-3b07-4fed-9687-afa9b7ffb878)
-    (property "Reference" "RC7-5" (at 180.34 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 560b334e-ed5f-40a2-b100-5974e92ce94c))
-    (pin "2" (uuid 55bbe733-1ff6-4a73-b892-49d49c6c0fc9))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce521a1c-e123-4f49-866e-f4f51848f864)
-    (property "Reference" "RC7-2" (at 180.34 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2a9b15ea-df9e-4ef0-a128-13d2e129d7f7))
-    (pin "2" (uuid e9530707-f705-4741-a308-e08f558f67a1))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e)
-    (property "Reference" "D51" (at 132.08 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48596e1c-4629-46bb-98c1-de11cd41e539))
-    (pin "2" (uuid f7decfb7-c4ef-4861-ba8a-043f44f3b09e))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D51") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cf81ef85-b58f-422a-b88a-7b7914aa3581)
-    (property "Reference" "D12" (at 50.8 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e34c154b-a3cb-467d-891b-2f2891056190))
-    (pin "2" (uuid dc926c49-c915-470d-b2b5-00749f3505bb))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D12") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d40b4fbb-e58c-433e-b2c5-236bb8aa92c5)
-    (property "Reference" "D1" (at 30.48 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90049b07-ff34-407c-ad1c-bcb8b89b241c))
-    (pin "2" (uuid 7bd5d68f-4902-47f7-bc35-be0973d0d904))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578)
-    (property "Reference" "RC5-0" (at 139.7 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5729530-792d-44f2-80ff-f6315aae335e))
-    (pin "2" (uuid 01f42ec4-9037-47c0-8fc0-8f7345fd0a2b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d69b760e-d231-449e-ae78-5289569bfcf8)
-    (property "Reference" "RC4-8" (at 119.38 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b2174dcf-3936-44c4-b9c9-8a8c2ffd5559))
-    (pin "2" (uuid 553bf002-fd89-4554-b1c2-ed094fd5fe57))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d7b98385-4339-43e1-a83a-6daba8def1f8)
-    (property "Reference" "RC0-8" (at 38.1 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c3a8852b-59c8-4849-9f9f-edc39c43f8e6))
-    (pin "2" (uuid f4bfef10-0157-4077-9c8b-8858eccf5c1a))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69)
-    (property "Reference" "RC2-1" (at 78.74 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ba2015a3-c3ad-44cf-b530-b2a60bac2c12))
-    (pin "2" (uuid 12bdf482-8bd0-4b7d-a511-fcaadc8ab54d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid daefbaa6-3e17-4eca-837b-024ccac5fc10)
-    (property "Reference" "D14" (at 50.8 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12e5236e-b23d-4e38-9768-e28d1693b6eb))
-    (pin "2" (uuid 1be4fe23-ac83-4b50-b43f-2e4b33c335d7))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D14") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid df14ac0c-5b64-41d1-ac61-954e84a88f4b)
-    (property "Reference" "D47" (at 111.76 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7284aa2f-4456-4e07-9251-a86b7acd95b1))
-    (pin "2" (uuid c06243a0-5a23-4af5-88df-f2a88bfb1da0))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D47") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e214b496-153e-40f8-93df-30f96574576d)
-    (property "Reference" "RC6-8" (at 160.02 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 762c516c-df17-4ae0-8f7f-03315e74925e))
-    (pin "2" (uuid 874fed4d-cc1d-47bf-b14e-533fedfc9875))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e255666b-19cd-45a4-b5c1-8997235eb1ad)
-    (property "Reference" "D72" (at 172.72 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92803ca1-7814-4c2f-986c-c7a2afaea4b2))
-    (pin "2" (uuid f1e544c9-5e94-460f-960c-d30fdb857f44))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D72") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e433e872-70f0-4e5b-b473-1ebd1af79f33)
-    (property "Reference" "D84" (at 193.04 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2c838395-b13b-44f3-9cda-ae0061827054))
-    (pin "2" (uuid b7abe52a-50b6-4b31-8da0-3b0e1433e922))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D84") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e490f25a-1360-4f95-aa79-5f1d93892bb3)
-    (property "Reference" "RC3-5" (at 99.06 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 056973a8-92e3-49be-9b21-fe961241d12f))
-    (pin "2" (uuid 01c4c06b-d45d-4ffb-ad72-57ca7686fd55))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e6262d19-9b35-41b6-845a-39c20b831416)
-    (property "Reference" "D76" (at 172.72 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8324bd70-bd5e-4513-bc52-cc4e838003e8))
-    (pin "2" (uuid 64285f25-2c5b-4231-8d94-7ba284d5a2d2))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D76") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e97aeea5-7475-4b9f-a312-6f51452496a5)
-    (property "Reference" "RC8-4" (at 200.66 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b5d442a-c78e-4d0d-8f8c-3cc6c91bf307))
-    (pin "2" (uuid 4b2eebd0-ccb3-482c-8c43-2690e285e66f))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 105.41 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b)
-    (property "Reference" "DS3" (at 96.52 106.045 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 96.52 103.505 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 738869bf-f410-43b7-b7e7-4e927d69911a))
-    (pin "2" (uuid 71649a24-87f4-49fb-9896-e50c64c03a31))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb153eb2-74b0-4cb9-b105-af356654d60d)
-    (property "Reference" "D24" (at 71.12 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77c4fd5e-5c79-4799-aab6-2f07a57c7df3))
-    (pin "2" (uuid a062346b-452b-46dc-a106-fab01848555d))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D24") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ee3742e9-8e22-4413-88a6-b893a7cb3439)
-    (property "Reference" "RC8-6" (at 200.66 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12157fba-1ac0-4b59-9ef4-f0b7f556fda2))
-    (pin "2" (uuid a6fa6d7f-615c-410e-9188-d1867808891a))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ef64a689-efe5-479a-a53a-19c9f4177765)
-    (property "Reference" "D74" (at 172.72 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fc4be4a8-3bcc-4a9b-8dca-654b73020c91))
-    (pin "2" (uuid 982449b6-25db-4afc-abf2-592e07b23449))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D74") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1920e34-64a4-41c9-8680-7fa42f5dfb9d)
-    (property "Reference" "RC2-0" (at 78.74 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9242378-4df5-4b90-afbf-1098ccb8067f))
-    (pin "2" (uuid a135b9b9-316d-4cb2-a5a5-8d618a00a752))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1a5bcca-72b0-4fb1-9570-8abc0f731fb7)
-    (property "Reference" "RC1-7" (at 58.42 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 058cb33f-3013-4884-ba52-2b175c6e6f25))
-    (pin "2" (uuid cb54004f-a1b9-489e-9cdf-00b812c2d5fa))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f735328c-2a24-4fb3-983d-b3e512d5a5cf)
-    (property "Reference" "RC8-5" (at 200.66 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid af0d403b-f1be-40d9-bf46-12c29a8b07f1))
-    (pin "2" (uuid cf12207d-8835-4b4d-855b-207eb48891b5))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f9c61822-7d54-487f-93d1-920e041f55a6)
-    (property "Reference" "RC8-2" (at 200.66 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffd61ace-0250-4fd9-8d0c-c2c917d0d4b5))
-    (pin "2" (uuid d354ba15-00ca-4efb-954b-871f951259db))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fc941f43-b642-4fef-8515-f8f851adced2)
-    (property "Reference" "D13" (at 50.8 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c))
-    (pin "2" (uuid ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D13") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fcc35b13-8da5-4271-981a-5470b3add3e5)
-    (property "Reference" "D25" (at 71.12 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0d662a-16b3-4c76-b4ee-49de18b57b47))
-    (pin "2" (uuid ba9a1f4c-173e-4b32-907f-fe9b31df718b))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D25") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fd13d6af-afdf-4367-a43b-1889348eabd8)
-    (property "Reference" "RC0-6" (at 38.1 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 854af50a-a007-4ba3-a405-76f0f99e9817))
-    (pin "2" (uuid bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142))
-    (instances
-      (project "round-robin-10-72"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "cbac505e-77a6-4a00-a758-435de33cca16")
+	(paper "A3" portrait)
+	(lib_symbols
+		(symbol "Diode:1N4148"
+			(pin_numbers hide)
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "1N4148"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "100V 0.15A standard switching diode, DO-35"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Device" "D"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "D*DO?35*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "1N4148_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "1N4148_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 165.1 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "00d75863-bb9f-4d4c-ae8f-f64498ed1533")
+	)
+	(junction
+		(at 226.06 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "04d157fc-c063-40ca-ad05-26c77c1c313c")
+	)
+	(junction
+		(at 185.42 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "05e510f3-8ca9-490a-bdc5-77faace67735")
+	)
+	(junction
+		(at 104.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06a6d1a8-0f12-4174-b63e-d35d8ca618bf")
+	)
+	(junction
+		(at 43.18 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06e66b38-0070-40a1-8fc5-70306b17897f")
+	)
+	(junction
+		(at 165.1 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "09e82fd3-a43f-4071-83d2-fb0a65931c0e")
+	)
+	(junction
+		(at 63.5 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a9113d4-8a8c-4abc-b886-f22c92ad18dc")
+	)
+	(junction
+		(at 165.1 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a95c2d4-251b-4df1-a8c0-c0fc6241e43d")
+	)
+	(junction
+		(at 124.46 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29")
+	)
+	(junction
+		(at 73.66 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c7244ee-ddfb-470b-a70b-1cfc53f83773")
+	)
+	(junction
+		(at 134.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c73479c-4e07-428a-85f3-93341c42ca57")
+	)
+	(junction
+		(at 93.98 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5f3a7a-dc5d-4973-8743-eafaa1c1a462")
+	)
+	(junction
+		(at 43.18 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "10cae212-bc64-40b9-b44f-13fd4a0406a6")
+	)
+	(junction
+		(at 53.34 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "122dbfee-176c-4f21-802f-09581864dffb")
+	)
+	(junction
+		(at 83.82 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1278b5e3-5eff-46d6-a162-44fde2066970")
+	)
+	(junction
+		(at 63.5 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "148ae1ee-d103-45f5-afff-520ea3c7f768")
+	)
+	(junction
+		(at 53.34 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14bb4fc2-d7df-49aa-b10e-882abdd2aa5f")
+	)
+	(junction
+		(at 185.42 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "15daf298-357b-4f73-8767-34988eed6eb8")
+	)
+	(junction
+		(at 104.14 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17f3773a-2c02-426d-bcd6-7a35c59a710a")
+	)
+	(junction
+		(at 205.74 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1943e8ad-b21d-4f7c-9e48-baf07472bdf8")
+	)
+	(junction
+		(at 114.3 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a11ada5-19c8-45ac-810c-daedbb80ad5b")
+	)
+	(junction
+		(at 73.66 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c386ee6-5b9d-4eae-92b5-9440e81067f6")
+	)
+	(junction
+		(at 226.06 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "216bc563-0bc0-4447-af79-7933fdef7d63")
+	)
+	(junction
+		(at 93.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21e320b6-a0c4-4d5d-babf-ee5274120507")
+	)
+	(junction
+		(at 185.42 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23554013-cd0d-4767-9f22-8c19a7d8c5ca")
+	)
+	(junction
+		(at 154.94 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23916c3a-0d37-416a-91d3-82a34b3ade4a")
+	)
+	(junction
+		(at 165.1 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2501dc30-a271-4271-9ca6-b085328a23ec")
+	)
+	(junction
+		(at 73.66 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2654ce54-6e59-4c49-bfbf-12326c83c638")
+	)
+	(junction
+		(at 124.46 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2b2b66bc-905d-4b48-89f5-1c62f6c27dbb")
+	)
+	(junction
+		(at 134.62 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c5878fe-fb0a-42a4-a883-ea4209708ea5")
+	)
+	(junction
+		(at 154.94 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2cf168f3-fe97-43f2-b72e-223dd4e6b386")
+	)
+	(junction
+		(at 195.58 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2d5e9ac1-9154-4e79-bf72-21a277b2d96d")
+	)
+	(junction
+		(at 73.66 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30c9eca3-7c32-4704-8819-3599d7b84f53")
+	)
+	(junction
+		(at 93.98 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "31a1b16e-8174-4fea-bc42-9c75ed9182a0")
+	)
+	(junction
+		(at 83.82 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3")
+	)
+	(junction
+		(at 114.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "347306fc-87ef-43e1-a98f-ca29ac9473e6")
+	)
+	(junction
+		(at 124.46 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "352af8be-9d08-4866-961e-b8632013179f")
+	)
+	(junction
+		(at 104.14 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "356b49b0-20ac-4c33-8df8-9b27dee0b312")
+	)
+	(junction
+		(at 175.26 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "357aa667-d746-4e3e-ab2a-484493e6765a")
+	)
+	(junction
+		(at 226.06 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c")
+	)
+	(junction
+		(at 175.26 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "39869536-29f6-4e84-a33a-473fa8fb0f36")
+	)
+	(junction
+		(at 185.42 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3abcfbc6-0288-48d7-a0e0-144f99e6dd30")
+	)
+	(junction
+		(at 144.78 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3d987483-3b5e-44fb-b675-40705bf855c1")
+	)
+	(junction
+		(at 134.62 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ddd9e62-5556-463c-9539-c0d582cc40e9")
+	)
+	(junction
+		(at 205.74 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4788fde7-f606-4229-8a7b-9fa04f56d3d4")
+	)
+	(junction
+		(at 195.58 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4808b7bb-f3e9-4051-abfe-6295f68f9f67")
+	)
+	(junction
+		(at 114.3 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "490a89d7-a161-4f1a-9b45-a55729d9d59b")
+	)
+	(junction
+		(at 124.46 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c74baef-72cb-4cdf-b4eb-a3d28782257d")
+	)
+	(junction
+		(at 53.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c7a50e9-7650-493b-b0a7-057b900a13a7")
+	)
+	(junction
+		(at 63.5 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9")
+	)
+	(junction
+		(at 165.1 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4df4e0a7-6e46-4c32-959d-094f3457d75b")
+	)
+	(junction
+		(at 43.18 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e641ba8-cbcf-42cf-89f0-ac977902bf98")
+	)
+	(junction
+		(at 195.58 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4f68712b-6287-4bdb-948e-a2fe64b7f55e")
+	)
+	(junction
+		(at 73.66 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fc826ad-ef7b-406a-9b89-76eb2c211523")
+	)
+	(junction
+		(at 53.34 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fce0301-62b3-4ef1-9bae-8d55ea745d66")
+	)
+	(junction
+		(at 195.58 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "50440167-944e-4bae-877b-720ed8635cbd")
+	)
+	(junction
+		(at 185.42 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "508ddd33-e065-44a5-a999-5944a523ef76")
+	)
+	(junction
+		(at 175.26 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "50f2ad43-aa07-4fd1-8d58-f22d767da31f")
+	)
+	(junction
+		(at 53.34 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53bb27f5-9b54-4704-b90e-33b3053be6c4")
+	)
+	(junction
+		(at 114.3 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b35d564-88c3-4b41-864f-a4f82bc4c871")
+	)
+	(junction
+		(at 43.18 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5bfc49c0-36f2-431c-81ea-cf78c71d7681")
+	)
+	(junction
+		(at 63.5 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "670a793c-4c48-41d1-9f07-66b1d7d84b06")
+	)
+	(junction
+		(at 83.82 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "672e2ce9-8f2c-43ff-9498-0e342bc1c65e")
+	)
+	(junction
+		(at 175.26 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "69e63d66-faab-411c-9093-a81235a7547c")
+	)
+	(junction
+		(at 63.5 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6b0b87a9-8a81-4bd1-ac24-ffcd6512236b")
+	)
+	(junction
+		(at 43.18 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6bfc7531-8adc-4c87-bf8a-788404262765")
+	)
+	(junction
+		(at 134.62 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1")
+	)
+	(junction
+		(at 154.94 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6ff7fc69-ca50-4b66-851e-eb36da3cadd8")
+	)
+	(junction
+		(at 63.5 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "712da204-b8e1-4637-b967-521ccf7b108c")
+	)
+	(junction
+		(at 73.66 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71e77471-d824-448e-a6de-31cce05e17c2")
+	)
+	(junction
+		(at 205.74 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "72e4e912-d3a6-49dd-a5cd-3717c5b10d71")
+	)
+	(junction
+		(at 73.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "742ecb41-f257-40d3-a6f3-d155d6036628")
+	)
+	(junction
+		(at 93.98 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "782ee96d-a257-4c78-ac0f-a3b5279bef37")
+	)
+	(junction
+		(at 53.34 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7943e9ed-5e22-49d3-a238-47d875f3e823")
+	)
+	(junction
+		(at 43.18 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7dbcae2f-e000-4aff-92b3-5518ea113182")
+	)
+	(junction
+		(at 104.14 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "822096c9-a5b4-460b-8639-9bbf1bb1a2fa")
+	)
+	(junction
+		(at 93.98 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84442e81-a253-49f6-ab0f-8ece0b39f637")
+	)
+	(junction
+		(at 53.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "86d88f2b-6e5b-493a-b3a4-5436a8374fae")
+	)
+	(junction
+		(at 104.14 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "88441b0d-9a40-4e18-8fc9-814cc1cb4d3e")
+	)
+	(junction
+		(at 185.42 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8a6c81db-4db5-4eb7-a06a-31575c90f62f")
+	)
+	(junction
+		(at 83.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bf191a4-2dcd-4018-b67a-91aef9fad846")
+	)
+	(junction
+		(at 144.78 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d88bb99-f0e4-4a81-b464-31814877675a")
+	)
+	(junction
+		(at 205.74 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "91635678-4449-4ed4-88c1-10b19deef1b0")
+	)
+	(junction
+		(at 226.06 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95b0c111-7d27-49ee-a08f-b6f35d9d5b54")
+	)
+	(junction
+		(at 93.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96a12dd2-d02f-4a86-aa6d-3a7015c06462")
+	)
+	(junction
+		(at 134.62 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99c67f58-7bde-4417-a08c-823e6af847f2")
+	)
+	(junction
+		(at 124.46 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9d2b0f02-b19d-4907-8835-9e7f8a8b9c34")
+	)
+	(junction
+		(at 93.98 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a2db7df7-b835-49df-98be-3c291238016c")
+	)
+	(junction
+		(at 185.42 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a3593416-7fea-415d-a48b-ed5f49c771b2")
+	)
+	(junction
+		(at 63.5 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a6cd881c-1146-4d92-9184-bf83a80c20c4")
+	)
+	(junction
+		(at 165.1 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a7400bf6-86c3-4d41-886e-57235a457a4c")
+	)
+	(junction
+		(at 165.1 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9baaad2-c62c-4b79-a10b-261651ef4961")
+	)
+	(junction
+		(at 226.06 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9ece8f4-f868-428b-b7ff-a3dc07b47d6c")
+	)
+	(junction
+		(at 144.78 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aa4f9edb-d8b6-45e2-8d16-270f3c9fc990")
+	)
+	(junction
+		(at 104.14 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ab0811a2-347a-4a90-b4d0-f1b1ba038333")
+	)
+	(junction
+		(at 195.58 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aeb87e8e-694a-4a41-9acc-a8e64ba7f05b")
+	)
+	(junction
+		(at 195.58 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b03222c4-a4d2-4638-a1da-82da352acd7b")
+	)
+	(junction
+		(at 83.82 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b23bc3a0-3ebe-44a5-9126-8b5c4d648e08")
+	)
+	(junction
+		(at 205.74 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b3d0ee10-bd96-4305-9675-c2f1f7a7662b")
+	)
+	(junction
+		(at 114.3 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b5ce3eda-e357-44e1-9c69-f84009fc7a87")
+	)
+	(junction
+		(at 154.94 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b7093823-b63a-4a1a-b279-5afe0127ec9d")
+	)
+	(junction
+		(at 226.06 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b98759bc-77be-4dce-9aa2-cc5ce3889034")
+	)
+	(junction
+		(at 154.94 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b995f4ca-5e8d-4350-aff6-b7bea568d7f5")
+	)
+	(junction
+		(at 53.34 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3")
+	)
+	(junction
+		(at 205.74 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb9843d1-ea35-45a8-bd3d-5b381b0dc875")
+	)
+	(junction
+		(at 175.26 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bbd2fe65-aac5-437c-9177-9832921486d5")
+	)
+	(junction
+		(at 175.26 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bcf6a98c-2d79-4afb-9a5e-6558bb743cec")
+	)
+	(junction
+		(at 154.94 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be75ea2d-b3b9-4fd0-812b-104329fac661")
+	)
+	(junction
+		(at 144.78 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "befc6138-873b-4406-bc9e-e5a72f7f36fe")
+	)
+	(junction
+		(at 175.26 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf44b855-bf79-4ceb-a9a9-021d72c7f67c")
+	)
+	(junction
+		(at 83.82 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0")
+	)
+	(junction
+		(at 134.62 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c29c26fc-c285-45ba-9e88-4c2a02375307")
+	)
+	(junction
+		(at 165.1 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c331d35d-23c9-43ea-b243-b660cb5f4bdb")
+	)
+	(junction
+		(at 134.62 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c3f1775c-0d63-41d3-b7d8-a4c96d241ce3")
+	)
+	(junction
+		(at 93.98 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c41e97f8-87c8-4e82-92ed-e4644d6f526e")
+	)
+	(junction
+		(at 124.46 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c51de65b-dd06-4a71-8763-eab77eba6638")
+	)
+	(junction
+		(at 226.06 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c56d20e0-377b-42bf-89fc-25b698ca10b4")
+	)
+	(junction
+		(at 114.3 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c5afc93c-0846-4cf9-8f93-4c8f2232c9fa")
+	)
+	(junction
+		(at 83.82 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c7d88142-1b7e-4dd1-b026-f2267e06dab1")
+	)
+	(junction
+		(at 43.18 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8f222f6-943e-4d7d-919b-3278ca0ede33")
+	)
+	(junction
+		(at 144.78 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc2d9922-84c9-42ce-883b-c028a251c101")
+	)
+	(junction
+		(at 124.46 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cd054c4e-f9d4-4701-a538-16740432e58d")
+	)
+	(junction
+		(at 63.5 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cfd86ddc-0810-4057-8a79-4468ec7b2424")
+	)
+	(junction
+		(at 205.74 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d07b66d1-3d51-4607-8fd1-974bbf8f9371")
+	)
+	(junction
+		(at 53.34 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d328f077-6d93-4470-a2b2-f4c9287daff0")
+	)
+	(junction
+		(at 205.74 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d3f7612d-781e-42f5-a5f0-fe2744aa5d60")
+	)
+	(junction
+		(at 83.82 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5a179bd-82b1-4661-aebc-4c4d4801bdff")
+	)
+	(junction
+		(at 144.78 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b7ef4f-419a-421c-a02d-fd71016e6c97")
+	)
+	(junction
+		(at 154.94 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d774ae68-7d44-45a8-babf-4a5136fe82a1")
+	)
+	(junction
+		(at 185.42 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d8d69513-50ec-441c-a953-5a6c226b729f")
+	)
+	(junction
+		(at 114.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcab5abe-0f5a-44d8-b554-722164ca6a23")
+	)
+	(junction
+		(at 154.94 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dded6bb5-453a-4491-9278-65d2368e4bc0")
+	)
+	(junction
+		(at 93.98 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dece07f3-2868-47c6-b119-0ca286e7cc50")
+	)
+	(junction
+		(at 175.26 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e3827bb6-d8e8-410a-8c19-3e64c8191b94")
+	)
+	(junction
+		(at 154.94 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e46432a2-96f1-448e-8928-bfcbbf445ca9")
+	)
+	(junction
+		(at 175.26 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e66342f0-16d5-4367-b00a-d7cf257720d9")
+	)
+	(junction
+		(at 114.3 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee17efa1-5df9-47d0-aec2-a440d8b33e4c")
+	)
+	(junction
+		(at 195.58 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee57e1f7-1cc7-4774-b838-6c366435fbc5")
+	)
+	(junction
+		(at 104.14 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f0d84c95-52f0-41cd-8742-4de83021f783")
+	)
+	(junction
+		(at 134.62 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f1379b2f-59c4-4b61-a98f-3645b6e5fe6b")
+	)
+	(junction
+		(at 104.14 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f24e6016-cf0c-4fe9-b584-ca06dfdbe767")
+	)
+	(junction
+		(at 134.62 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f368e14e-0af5-4e13-a581-f1a139c24e5c")
+	)
+	(junction
+		(at 195.58 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f66ca316-fc26-4704-976d-83146ae5fc99")
+	)
+	(junction
+		(at 43.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6f817c6-438a-4497-93b1-8dc1f36a395c")
+	)
+	(junction
+		(at 124.46 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd")
+	)
+	(junction
+		(at 144.78 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8b3b54a-7c03-49e4-8762-b4ef31db5afd")
+	)
+	(junction
+		(at 226.06 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa2795fd-0138-4010-b310-3d5e73c1be1c")
+	)
+	(junction
+		(at 73.66 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbda2010-a213-45bb-958d-0c9446d51e42")
+	)
+	(junction
+		(at 195.58 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbe658cd-81e2-4835-bad4-ff83513467a3")
+	)
+	(junction
+		(at 73.66 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc393c80-fb90-44e5-ac86-763463fd8acd")
+	)
+	(junction
+		(at 114.3 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc6abd7a-92c0-4b05-85ed-b3bd910676e1")
+	)
+	(junction
+		(at 144.78 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdc0071f-cdad-424a-87db-7bd8a0569159")
+	)
+	(wire
+		(pts
+			(xy 154.94 68.58) (xy 175.26 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022cd994-adba-45e0-8a4a-b0b516869c19")
+	)
+	(wire
+		(pts
+			(xy 83.82 60.96) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022d84d0-7bcb-4024-8618-6f3a7f7b41aa")
+	)
+	(wire
+		(pts
+			(xy 144.78 25.4) (xy 144.78 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0406a358-3219-4537-99c7-cfb994e5303c")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0429bfe1-2992-4c6f-bb22-b2e8e5724910")
+	)
+	(wire
+		(pts
+			(xy 205.74 182.88) (xy 205.74 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "04f743f4-6844-43ab-a149-4db3a42e61b3")
+	)
+	(wire
+		(pts
+			(xy 185.42 162.56) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "070c607f-224b-4963-a847-a5abbe4e2e9d")
+	)
+	(wire
+		(pts
+			(xy 73.66 109.22) (xy 93.98 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07ee4d30-e80a-41ae-829d-e3cecf87d77e")
+	)
+	(wire
+		(pts
+			(xy 114.3 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0897e94f-d1e3-47ff-89f6-5de7a1349783")
+	)
+	(wire
+		(pts
+			(xy 226.06 68.58) (xy 226.06 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aee33c0-3781-43dc-99cb-690f399192cd")
+	)
+	(wire
+		(pts
+			(xy 195.58 203.2) (xy 205.74 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bbfe73f-3f00-4157-8def-4fa012c6902e")
+	)
+	(wire
+		(pts
+			(xy 195.58 149.86) (xy 218.44 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d9578e9-1c8e-43cd-93fc-b592de25d72b")
+	)
+	(wire
+		(pts
+			(xy 43.18 182.88) (xy 43.18 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e0cdb3f-d11e-41fa-b224-dbdc3dd27130")
+	)
+	(wire
+		(pts
+			(xy 43.18 40.64) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f76c070-bcf8-4924-a8c5-3abe13c36f41")
+	)
+	(wire
+		(pts
+			(xy 63.5 81.28) (xy 63.5 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ef6261-91ba-4d4c-99ef-8991b7c91dc8")
+	)
+	(wire
+		(pts
+			(xy 104.14 101.6) (xy 104.14 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12080e73-a151-4804-ac9b-ac3ac13653e9")
+	)
+	(wire
+		(pts
+			(xy 73.66 48.26) (xy 93.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12a939e2-2ab8-4d74-a5c9-6d61a9528b6e")
+	)
+	(wire
+		(pts
+			(xy 63.5 182.88) (xy 63.5 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13961bb6-28aa-4ee0-a270-8bc7b0339a4b")
+	)
+	(wire
+		(pts
+			(xy 195.58 129.54) (xy 218.44 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "143dcad5-8675-4ddc-903b-6ddce8681b1f")
+	)
+	(wire
+		(pts
+			(xy 134.62 210.82) (xy 154.94 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "150130ef-d28d-4782-b4fc-0c67b58e9b8e")
+	)
+	(wire
+		(pts
+			(xy 154.94 190.5) (xy 175.26 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "15b0be77-2720-4b9e-8da7-956cf862467d")
+	)
+	(wire
+		(pts
+			(xy 93.98 190.5) (xy 114.3 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1767f007-bd12-458a-9e69-f01cc8a5ed24")
+	)
+	(wire
+		(pts
+			(xy 205.74 142.24) (xy 205.74 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18ccb399-8ad2-4b42-b317-de1e9939e9e9")
+	)
+	(wire
+		(pts
+			(xy 104.14 25.4) (xy 104.14 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af5b449-9a68-414b-a41f-d6f6cba715a8")
+	)
+	(wire
+		(pts
+			(xy 73.66 81.28) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0140d1-6775-49db-9fd5-7ecf63ae1284")
+	)
+	(wire
+		(pts
+			(xy 195.58 109.22) (xy 218.44 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "20189d33-2d13-483f-bce7-1849d41f23d3")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "211f763f-7ef6-4fb5-98df-2e2ff37faa42")
+	)
+	(wire
+		(pts
+			(xy 63.5 40.64) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23f46f84-f16d-4b0b-b463-c2c0244adcc0")
+	)
+	(wire
+		(pts
+			(xy 33.02 129.54) (xy 53.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24da3fea-844d-4666-b730-f8d7b708f242")
+	)
+	(wire
+		(pts
+			(xy 185.42 40.64) (xy 185.42 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "265c8115-55ea-4d09-95c1-3178314bfa04")
+	)
+	(wire
+		(pts
+			(xy 53.34 129.54) (xy 73.66 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26f78b89-ba4b-4b48-90d1-1245694ead6f")
+	)
+	(wire
+		(pts
+			(xy 83.82 162.56) (xy 83.82 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2703e5ce-9651-45e1-8bd6-144e60387b78")
+	)
+	(wire
+		(pts
+			(xy 33.02 109.22) (xy 53.34 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2832f642-62e7-4a51-b112-f728658e7714")
+	)
+	(wire
+		(pts
+			(xy 53.34 68.58) (xy 73.66 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29a0e612-9a4c-422c-a9b8-8a9fe3879b8a")
+	)
+	(wire
+		(pts
+			(xy 83.82 101.6) (xy 83.82 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a44e441-f6d5-4994-b7ba-34283a1facc7")
+	)
+	(wire
+		(pts
+			(xy 124.46 121.92) (xy 124.46 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0")
+	)
+	(wire
+		(pts
+			(xy 114.3 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a65926a-d988-49f6-92e7-6e4d5936462f")
+	)
+	(wire
+		(pts
+			(xy 165.1 162.56) (xy 165.1 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2afd7500-0a15-4710-acc0-4f03472785c3")
+	)
+	(wire
+		(pts
+			(xy 53.34 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b416882-b7bb-4d0e-968f-5674136bac79")
+	)
+	(wire
+		(pts
+			(xy 165.1 60.96) (xy 165.1 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b8c9def-eaec-4abd-b08a-c3613e6389df")
+	)
+	(wire
+		(pts
+			(xy 53.34 109.22) (xy 73.66 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd")
+	)
+	(wire
+		(pts
+			(xy 124.46 25.4) (xy 124.46 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3115f7a7-e786-49c1-9e4c-25c171cfeb33")
+	)
+	(wire
+		(pts
+			(xy 73.66 68.58) (xy 93.98 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3197b37c-ee5b-406a-ab67-08670d4b8c09")
+	)
+	(wire
+		(pts
+			(xy 165.1 182.88) (xy 165.1 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "335e6f69-208d-4946-a709-07b34240cbfe")
+	)
+	(wire
+		(pts
+			(xy 63.5 60.96) (xy 63.5 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "33f2e2d4-69cc-436f-ac8e-75f012072b5c")
+	)
+	(wire
+		(pts
+			(xy 154.94 170.18) (xy 175.26 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a0ad538-3c94-4a03-ba14-d3e55855f87e")
+	)
+	(wire
+		(pts
+			(xy 134.62 68.58) (xy 154.94 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b15c81d-3687-4710-9aa6-d57ee4885603")
+	)
+	(wire
+		(pts
+			(xy 63.5 121.92) (xy 63.5 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5")
+	)
+	(wire
+		(pts
+			(xy 114.3 190.5) (xy 134.62 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb")
+	)
+	(wire
+		(pts
+			(xy 154.94 48.26) (xy 175.26 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3fe99eb3-808c-4fd5-8bf0-8eed87e32524")
+	)
+	(wire
+		(pts
+			(xy 73.66 170.18) (xy 93.98 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40ad23e4-b284-4d51-a92e-26a2272af251")
+	)
+	(wire
+		(pts
+			(xy 165.1 121.92) (xy 165.1 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "411efa8a-c2b6-469e-b517-3b3f24ffe025")
+	)
+	(wire
+		(pts
+			(xy 73.66 190.5) (xy 93.98 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "432577d5-87d0-4924-a72a-e407dd2ee4b0")
+	)
+	(wire
+		(pts
+			(xy 134.62 170.18) (xy 154.94 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44b0d7a3-542f-48ea-8a2f-25ca02bd7f05")
+	)
+	(wire
+		(pts
+			(xy 53.34 170.18) (xy 73.66 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4554fe48-1b8d-466c-b3f4-c87fb3d79947")
+	)
+	(wire
+		(pts
+			(xy 43.18 60.96) (xy 43.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456f0365-d37d-43a2-afac-d06c44cc48af")
+	)
+	(wire
+		(pts
+			(xy 154.94 129.54) (xy 175.26 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "462b3865-9668-49d6-a9d9-1406a843104e")
+	)
+	(wire
+		(pts
+			(xy 114.3 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "473d672b-6459-459b-93fc-780e5d8f9818")
+	)
+	(wire
+		(pts
+			(xy 124.46 81.28) (xy 124.46 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "495f9334-ca7f-4aa5-8d75-09576f1afa2c")
+	)
+	(wire
+		(pts
+			(xy 104.14 182.88) (xy 104.14 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4bc89a8f-f8d9-4d47-a286-fb87f34a3ba1")
+	)
+	(wire
+		(pts
+			(xy 195.58 68.58) (xy 218.44 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4dd10eac-e6fb-4446-8933-3009a548bf1c")
+	)
+	(wire
+		(pts
+			(xy 165.1 81.28) (xy 165.1 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f7b113-f5f8-43e0-9da7-2a02dc224210")
+	)
+	(wire
+		(pts
+			(xy 226.06 190.5) (xy 226.06 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5194f352-1f61-4ee5-af2e-f0eb341e3d13")
+	)
+	(wire
+		(pts
+			(xy 33.02 190.5) (xy 53.34 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55243e41-6164-4661-b707-a6f503f12968")
+	)
+	(wire
+		(pts
+			(xy 53.34 190.5) (xy 73.66 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "557847f5-42a8-4c4a-a4d9-d21678c28920")
+	)
+	(wire
+		(pts
+			(xy 104.14 60.96) (xy 104.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5837ecd4-cf70-4c14-9c7b-bb5f05f8274a")
+	)
+	(wire
+		(pts
+			(xy 104.14 81.28) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6ae0de-21c8-4433-a4e0-a3b552474fb0")
+	)
+	(wire
+		(pts
+			(xy 134.62 48.26) (xy 154.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d63c1a3-5086-42ca-8afa-60afe2472b23")
+	)
+	(wire
+		(pts
+			(xy 93.98 210.82) (xy 114.3 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f73184b-d2cf-4b7b-afcf-f14e002f7ce1")
+	)
+	(wire
+		(pts
+			(xy 53.34 88.9) (xy 73.66 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b5d548-d07f-40b1-8e16-72d513f499f2")
+	)
+	(wire
+		(pts
+			(xy 154.94 109.22) (xy 175.26 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6196eb37-90e9-4f6c-80ae-9b758a88c740")
+	)
+	(wire
+		(pts
+			(xy 33.02 210.82) (xy 53.34 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6329f5e0-c3e3-42c6-b639-2bebe7a40e8b")
+	)
+	(wire
+		(pts
+			(xy 93.98 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6414e19f-a27a-435d-a47f-a63cba9086f1")
+	)
+	(wire
+		(pts
+			(xy 134.62 109.22) (xy 154.94 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64344100-c91d-4b5c-a8eb-9406d47360dd")
+	)
+	(wire
+		(pts
+			(xy 195.58 88.9) (xy 218.44 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6466dcfe-ac30-4b45-bc6e-0ba63363d641")
+	)
+	(wire
+		(pts
+			(xy 33.02 68.58) (xy 53.34 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68161b0c-a285-475d-a645-59648d12bc07")
+	)
+	(wire
+		(pts
+			(xy 134.62 149.86) (xy 154.94 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690a405c-1ac3-4b57-a93b-778dda168d2c")
+	)
+	(wire
+		(pts
+			(xy 134.62 190.5) (xy 154.94 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b21e6c7-ab97-41de-aae4-339e943db88e")
+	)
+	(wire
+		(pts
+			(xy 165.1 40.64) (xy 165.1 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc")
+	)
+	(wire
+		(pts
+			(xy 205.74 40.64) (xy 205.74 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f1d74d1-18f8-4f5b-8c5d-e1587ab09b83")
+	)
+	(wire
+		(pts
+			(xy 195.58 190.5) (xy 218.44 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f392e01-5127-4d67-8c34-66beb18a9894")
+	)
+	(wire
+		(pts
+			(xy 226.06 149.86) (xy 226.06 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f77a68c-1e32-433a-820e-9683e6fd5e12")
+	)
+	(wire
+		(pts
+			(xy 205.74 162.56) (xy 205.74 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7083b47b-e7bb-4169-bf41-06719234452e")
+	)
+	(wire
+		(pts
+			(xy 226.06 88.9) (xy 226.06 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70c6e975-f457-4759-9791-1d1de45afbb3")
+	)
+	(wire
+		(pts
+			(xy 134.62 129.54) (xy 154.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70f3f37d-4259-413e-b59a-babccfdc3a89")
+	)
+	(wire
+		(pts
+			(xy 43.18 121.92) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "727cc522-ef34-45d4-b711-997054ff0b37")
+	)
+	(wire
+		(pts
+			(xy 33.02 48.26) (xy 53.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "737596e8-f579-4b1f-aa71-a489d8ba56da")
+	)
+	(wire
+		(pts
+			(xy 93.98 149.86) (xy 114.3 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "770cc50c-0085-42e2-b068-cd0ae3b59919")
+	)
+	(wire
+		(pts
+			(xy 226.06 25.4) (xy 226.06 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "794205f1-2f7e-4200-b59c-c02481b0416f")
+	)
+	(wire
+		(pts
+			(xy 73.66 88.9) (xy 93.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79a42c80-d7a4-4e03-9070-f9fff835a239")
+	)
+	(wire
+		(pts
+			(xy 33.02 40.64) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a4231d0-fb4b-4c65-9cc1-75d3ed714150")
+	)
+	(wire
+		(pts
+			(xy 185.42 142.24) (xy 185.42 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7caa1de0-1c5d-4933-9515-38159a29c856")
+	)
+	(wire
+		(pts
+			(xy 165.1 25.4) (xy 165.1 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8506f273-12d6-426d-910b-0c9eecbe3765")
+	)
+	(wire
+		(pts
+			(xy 154.94 149.86) (xy 175.26 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "869288c6-9182-45ca-8025-5bf497b3633a")
+	)
+	(wire
+		(pts
+			(xy 134.62 88.9) (xy 154.94 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86d6e974-6898-4932-91cb-e8a4c4c283b7")
+	)
+	(wire
+		(pts
+			(xy 104.14 162.56) (xy 104.14 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c3cf446-d0cc-4b1b-9218-75f38db02fb3")
+	)
+	(wire
+		(pts
+			(xy 53.34 210.82) (xy 73.66 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d25f923-67ff-47ea-9485-05bc5282bdab")
+	)
+	(wire
+		(pts
+			(xy 93.98 48.26) (xy 114.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d73bae8-988b-435b-a882-ae9668b41d7e")
+	)
+	(wire
+		(pts
+			(xy 104.14 142.24) (xy 104.14 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dd624a1-3da3-42c1-929d-9366cd043e3d")
+	)
+	(wire
+		(pts
+			(xy 226.06 48.26) (xy 226.06 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f339462-56e0-4361-9d9b-983c75fb21ef")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "909384ab-bc1c-47d8-a34d-c3d137febfc2")
+	)
+	(wire
+		(pts
+			(xy 124.46 101.6) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91eea887-ea8a-4221-ba92-e5ec1caacc4f")
+	)
+	(wire
+		(pts
+			(xy 124.46 142.24) (xy 124.46 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94397688-ce0e-48d4-a59c-7257120bf834")
+	)
+	(wire
+		(pts
+			(xy 185.42 60.96) (xy 185.42 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96776fa9-dbd1-46ef-91bd-e95f23cda112")
+	)
+	(wire
+		(pts
+			(xy 175.26 170.18) (xy 195.58 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "969acf2b-33fe-4e89-abf2-451f22e884f4")
+	)
+	(wire
+		(pts
+			(xy 205.74 101.6) (xy 205.74 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "97a65ef9-5994-4805-9e12-ca2b38a42461")
+	)
+	(wire
+		(pts
+			(xy 114.3 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c79c76c-a95b-401f-9edb-a06a0cceaa4b")
+	)
+	(wire
+		(pts
+			(xy 185.42 182.88) (xy 185.42 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d4fc90e-2670-42d9-b5a8-2138817fee8a")
+	)
+	(wire
+		(pts
+			(xy 53.34 48.26) (xy 73.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ec847-5716-4125-b40b-fdbd3a1587a7")
+	)
+	(wire
+		(pts
+			(xy 175.26 129.54) (xy 195.58 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9edd39d2-8ad2-4ad5-94ce-c356ef944a50")
+	)
+	(wire
+		(pts
+			(xy 165.1 101.6) (xy 165.1 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f711890-a6d6-4440-8bc1-ed469cb6acc4")
+	)
+	(wire
+		(pts
+			(xy 83.82 182.88) (xy 83.82 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a0b86442-47da-481e-aac6-2c18430e056b")
+	)
+	(wire
+		(pts
+			(xy 93.98 101.6) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a226d887-7662-4dbd-b58b-e683f5d85955")
+	)
+	(wire
+		(pts
+			(xy 124.46 40.64) (xy 124.46 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a67c0815-f186-4f70-926f-1b264c84d8d8")
+	)
+	(wire
+		(pts
+			(xy 154.94 162.56) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a803bbba-64cc-448d-a04f-7f03127ebddd")
+	)
+	(wire
+		(pts
+			(xy 53.34 149.86) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aac914ea-c9a3-4a8f-94e1-1f91cdd136a3")
+	)
+	(wire
+		(pts
+			(xy 93.98 129.54) (xy 114.3 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab578e4e-a4bf-4ab4-80fc-d97d4aea6370")
+	)
+	(wire
+		(pts
+			(xy 114.3 210.82) (xy 134.62 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abd1d27d-b9d9-4cf6-b486-65a2a8efef41")
+	)
+	(wire
+		(pts
+			(xy 175.26 88.9) (xy 195.58 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "acc95df4-5464-4718-a58a-e43a56e1893a")
+	)
+	(wire
+		(pts
+			(xy 83.82 121.92) (xy 83.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73")
+	)
+	(wire
+		(pts
+			(xy 175.26 48.26) (xy 195.58 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "adf35dfa-3831-4e3a-9fdd-7a4ac7f5230d")
+	)
+	(wire
+		(pts
+			(xy 93.98 68.58) (xy 114.3 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aea6a633-b213-403d-b447-42d91d3ab4da")
+	)
+	(wire
+		(pts
+			(xy 175.26 68.58) (xy 195.58 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2797b5c-16d1-4c35-814c-4b30f0a6683b")
+	)
+	(wire
+		(pts
+			(xy 114.3 170.18) (xy 134.62 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3e14390-7dc6-416b-bbd5-cdf868192ca4")
+	)
+	(wire
+		(pts
+			(xy 73.66 129.54) (xy 93.98 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f6f053-44f0-4391-9873-b6231b8014db")
+	)
+	(wire
+		(pts
+			(xy 144.78 101.6) (xy 144.78 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7b2475f-30dc-4ea2-b799-96c21242154c")
+	)
+	(wire
+		(pts
+			(xy 175.26 210.82) (xy 195.58 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7c3f0e9-4787-4050-9c72-cdbaf3e08cfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 81.28) (xy 83.82 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5")
+	)
+	(wire
+		(pts
+			(xy 226.06 170.18) (xy 226.06 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba045c1c-f33c-4ee8-bfe6-db2af30446e4")
+	)
+	(wire
+		(pts
+			(xy 43.18 101.6) (xy 43.18 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb49a3de-620b-45ad-a54c-29dcceaf0796")
+	)
+	(wire
+		(pts
+			(xy 144.78 121.92) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf12198a-9e62-45c3-b466-f5d86de75219")
+	)
+	(wire
+		(pts
+			(xy 73.66 210.82) (xy 93.98 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c007dc03-0700-44f8-b7e3-69868fe31a12")
+	)
+	(wire
+		(pts
+			(xy 205.74 60.96) (xy 205.74 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0bbd51b-0041-4026-a546-37b4ba305884")
+	)
+	(wire
+		(pts
+			(xy 63.5 25.4) (xy 63.5 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1a940de-fa49-4106-a8b9-697952eec2a2")
+	)
+	(wire
+		(pts
+			(xy 104.14 121.92) (xy 104.14 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c298ba49-6974-4340-859f-5d5a2b4132ff")
+	)
+	(wire
+		(pts
+			(xy 124.46 182.88) (xy 124.46 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3555de4-415f-4041-a3dd-bd91effa102c")
+	)
+	(wire
+		(pts
+			(xy 175.26 182.88) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3f1f747-e966-4c2c-8090-4f190e07864a")
+	)
+	(wire
+		(pts
+			(xy 124.46 162.56) (xy 124.46 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6080a0e-4059-4120-b2e7-12c9aff607b7")
+	)
+	(wire
+		(pts
+			(xy 124.46 60.96) (xy 124.46 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c950d145-c024-47a8-ba57-97efd7bb658b")
+	)
+	(wire
+		(pts
+			(xy 154.94 88.9) (xy 175.26 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c980f191-a655-4149-a076-6b096870a525")
+	)
+	(wire
+		(pts
+			(xy 144.78 142.24) (xy 144.78 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca92ed7f-ae97-4c0c-81e4-820de1c001c1")
+	)
+	(wire
+		(pts
+			(xy 226.06 109.22) (xy 226.06 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdde081d-7bdd-42e6-869e-3ff07b8b464b")
+	)
+	(wire
+		(pts
+			(xy 185.42 121.92) (xy 185.42 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cee2f4f4-6cbc-4838-b71a-3189173bbcfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 40.64) (xy 83.82 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cff15ec3-f29c-4d36-8776-64c5d29be534")
+	)
+	(wire
+		(pts
+			(xy 175.26 109.22) (xy 195.58 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d0ca1f96-c34f-481a-93d5-3555eaca4541")
+	)
+	(wire
+		(pts
+			(xy 83.82 25.4) (xy 83.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1088709-a9b9-4e05-8ea2-f87942ee2796")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 93.98 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1347903-ae03-46a2-a707-154093060583")
+	)
+	(wire
+		(pts
+			(xy 175.26 149.86) (xy 195.58 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1443f9b-09ec-44c4-8217-4ea1c781d667")
+	)
+	(wire
+		(pts
+			(xy 144.78 40.64) (xy 144.78 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2183fb3-afd3-46ca-955e-993ea31aa5d3")
+	)
+	(wire
+		(pts
+			(xy 185.42 25.4) (xy 185.42 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2951d7e-82c5-4b56-9a90-ca8ae6d71e44")
+	)
+	(wire
+		(pts
+			(xy 205.74 25.4) (xy 205.74 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4107bae-81df-4028-a211-ea4ab3232bfc")
+	)
+	(wire
+		(pts
+			(xy 43.18 162.56) (xy 43.18 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d56982aa-6580-4d04-83ea-6bf3a85282cc")
+	)
+	(wire
+		(pts
+			(xy 185.42 101.6) (xy 185.42 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d675b927-bdff-4eac-82e7-3f468caedaf2")
+	)
+	(wire
+		(pts
+			(xy 43.18 142.24) (xy 43.18 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d76ad758-0ae0-4ce6-9f67-c689c066c744")
+	)
+	(wire
+		(pts
+			(xy 144.78 182.88) (xy 144.78 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8747c5c-1650-4a8e-b6a0-4fa4acd098ae")
+	)
+	(wire
+		(pts
+			(xy 205.74 81.28) (xy 205.74 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d920ca82-8ad7-4105-a47d-6c01f55c13d9")
+	)
+	(wire
+		(pts
+			(xy 33.02 149.86) (xy 53.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da80b027-904b-4ca2-99c6-5937c80c825c")
+	)
+	(wire
+		(pts
+			(xy 63.5 142.24) (xy 63.5 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db492971-48ff-4667-996c-f5d540a20741")
+	)
+	(wire
+		(pts
+			(xy 205.74 121.92) (xy 205.74 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc91af22-52c4-4234-961f-adc3ed363a9c")
+	)
+	(wire
+		(pts
+			(xy 165.1 142.24) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dccfde3a-ff1d-42ec-97d5-a8f6cccea832")
+	)
+	(wire
+		(pts
+			(xy 33.02 170.18) (xy 53.34 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de8e54c6-84d9-47e5-8f08-dc3e96b8afdb")
+	)
+	(wire
+		(pts
+			(xy 43.18 81.28) (xy 43.18 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df5c3763-e66c-46c4-9070-0f73d8115bc4")
+	)
+	(wire
+		(pts
+			(xy 226.06 129.54) (xy 226.06 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfb5a082-e4d5-46ea-8dc8-c65064cd598b")
+	)
+	(wire
+		(pts
+			(xy 93.98 170.18) (xy 114.3 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb")
+	)
+	(wire
+		(pts
+			(xy 144.78 81.28) (xy 144.78 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e444742a-24b1-4bbf-b7ee-438e6dffc9cc")
+	)
+	(wire
+		(pts
+			(xy 195.58 48.26) (xy 218.44 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e550e849-255b-418f-9c4c-fc9c233d87ed")
+	)
+	(wire
+		(pts
+			(xy 175.26 190.5) (xy 195.58 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5e38d44-8bf0-426b-a99f-727527ca9657")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6d06035-ccb7-4d3e-ae70-d73150e65bbb")
+	)
+	(wire
+		(pts
+			(xy 195.58 210.82) (xy 218.44 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7de80e0-8b7f-450c-9d32-23820caa1781")
+	)
+	(wire
+		(pts
+			(xy 114.3 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa")
+	)
+	(wire
+		(pts
+			(xy 63.5 101.6) (xy 63.5 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edeeb0d9-51cc-411d-aac4-77f10b619702")
+	)
+	(wire
+		(pts
+			(xy 104.14 40.64) (xy 104.14 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5c9f05-d71b-4562-9939-852432c066c5")
+	)
+	(wire
+		(pts
+			(xy 144.78 162.56) (xy 144.78 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "efa47227-d3f9-4214-af64-a7e9107c0edb")
+	)
+	(wire
+		(pts
+			(xy 144.78 60.96) (xy 144.78 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0ce7c2b-d80c-49f2-bf63-62b750f7ca47")
+	)
+	(wire
+		(pts
+			(xy 154.94 210.82) (xy 175.26 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f262cb15-d063-4165-a9f6-3e6a5c7bac7c")
+	)
+	(wire
+		(pts
+			(xy 63.5 162.56) (xy 63.5 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5658dea-a5b6-4ba9-9360-11c3315c15be")
+	)
+	(wire
+		(pts
+			(xy 134.62 142.24) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f781a362-e0d4-48be-9d13-5686e05b406f")
+	)
+	(wire
+		(pts
+			(xy 195.58 170.18) (xy 218.44 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f95e0e09-daac-4a87-aa64-d71bee00c840")
+	)
+	(wire
+		(pts
+			(xy 43.18 25.4) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa765e67-a220-4a00-944c-7663298f0ead")
+	)
+	(wire
+		(pts
+			(xy 83.82 142.24) (xy 83.82 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b")
+	)
+	(wire
+		(pts
+			(xy 185.42 81.28) (xy 185.42 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ffe6085a-a7be-4653-b911-c10de4574454")
+	)
+	(global_label "IO 3"
+		(shape bidirectional)
+		(at 104.14 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "24ec698b-5cae-4571-b9c4-c0e35d64a64d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 104.14 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 1"
+		(shape bidirectional)
+		(at 63.5 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d4b15a5-8b6c-4ca3-a7bb-7848c8036590")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 63.5 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 7"
+		(shape bidirectional)
+		(at 185.42 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "45d4e03e-6cff-41ce-b946-708382da0601")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 185.42 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 0"
+		(shape bidirectional)
+		(at 43.18 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "465a517d-f0e1-4825-8675-1cce54bfa7a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 43.18 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "INTR"
+		(shape bidirectional)
+		(at 226.06 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4e12b932-2346-4e84-b5a4-80468334f3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 234.25 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 2"
+		(shape bidirectional)
+		(at 83.82 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70d42e66-a74c-4de2-af96-d1860851d3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 83.82 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 165.1 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 165.1 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 144.78 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d44cceb0-f409-4e5f-a98a-9feead2e845d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 8"
+		(shape bidirectional)
+		(at 205.74 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e036ec60-274a-4de6-9324-dafd5b920142")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 205.74 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 4"
+		(shape bidirectional)
+		(at 124.46 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f36f49e4-227f-479f-b914-786aa44dd568")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 190.5 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0188dba3-054f-4958-9440-27c9ca673633")
+		(property "Reference" "DI7"
+			(at 222.25 186.69 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 193.04 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "deea1889-824f-4f7a-a6be-9546db353c85")
+		)
+		(pin "2"
+			(uuid "2080be86-a538-40a8-8f30-ead2a96d02d3")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0263b847-a932-4a31-9f35-35bb23f7000d")
+		(property "Reference" "D62"
+			(at 152.4 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc2e60ca-c74f-4e4b-a0a0-9705327e9578")
+		)
+		(pin "2"
+			(uuid "d12efbfe-85ac-442f-8c0f-ddbe5646c7d5")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D62")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04430572-8314-4d21-974c-22350cead1a6")
+		(property "Reference" "DS1"
+			(at 55.88 65.405 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 55.88 62.865 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3e433df4-9fec-4cfb-b60f-eebca7c574cf")
+		)
+		(pin "2"
+			(uuid "9bcc1487-0612-4bdb-a2de-a8b2f590b28f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 44.45 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080aaa87-0974-4a77-bf63-185495f411a0")
+		(property "Reference" "DS0"
+			(at 35.56 45.085 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 35.56 42.545 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bfacad1-28fd-4f2e-93dc-68f478b8a6ba")
+		)
+		(pin "2"
+			(uuid "376f73f9-79fa-4153-ae38-31ed5446db52")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09d14922-c46a-4bf1-bb2c-1d224060568c")
+		(property "Reference" "D40"
+			(at 111.76 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c2f1a1d2-df3d-4680-9706-2ca411fa6890")
+		)
+		(pin "2"
+			(uuid "f58fd788-6016-46e7-b903-3606dd2ec21d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D40")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 149.86 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d18473f-e37a-4136-b721-5a2e40e4f8ed")
+		(property "Reference" "DI5"
+			(at 222.25 146.05 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 152.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5a885ca-5076-44e6-9a84-d07474947dde")
+		)
+		(pin "2"
+			(uuid "047b5b54-de8b-4afc-abc2-c6d1f2d17bd2")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 170.18 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0ef17723-f7f8-4fdb-8913-5a4ceefbc065")
+		(property "Reference" "DI6"
+			(at 222.25 166.37 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 172.72 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df5a6b10-ba48-4f34-96ce-3832d480a7ee")
+		)
+		(pin "2"
+			(uuid "59f34a55-6ac4-496d-8c40-1b8f1eafbcb5")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0fadd319-be81-4c25-8d23-e7495a114aa7")
+		(property "Reference" "RC4-0"
+			(at 119.38 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "efb1c47f-fe25-4bea-8081-43d3c19de5cd")
+		)
+		(pin "2"
+			(uuid "9138c970-6e3d-46df-9354-5174df2a4e52")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ff76361-9578-4f9f-a20c-f042e24a7755")
+		(property "Reference" "D5"
+			(at 30.48 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06")
+		)
+		(pin "2"
+			(uuid "cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "11f01cd8-f751-497f-9599-50fe1fc0a618")
+		(property "Reference" "RC5-4"
+			(at 139.7 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc28293-fab9-4f93-b3d5-ca9ee69110c4")
+		)
+		(pin "2"
+			(uuid "088ac770-af1e-4c4f-ad11-5b44a20594d8")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "13ddd48d-7d2b-415d-b8fa-15c71e245acc")
+		(property "Reference" "D61"
+			(at 152.4 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "745d89b9-e75a-40ae-97bc-d1eadf220f02")
+		)
+		(pin "2"
+			(uuid "7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D61")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "17d027e3-2b58-470b-9fc5-f21e547cdc82")
+		(property "Reference" "RC8-1"
+			(at 200.66 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7f893b29-9b1f-44b8-bac5-e11991e6b604")
+		)
+		(pin "2"
+			(uuid "6b5e04e4-6889-4e49-9600-35d15ee54578")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1b13866a-6fbf-441b-9c64-56258379f43a")
+		(property "Reference" "D65"
+			(at 152.4 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c70f4670-9685-4aab-ac4f-4ebaf44d5847")
+		)
+		(pin "2"
+			(uuid "8b9c860d-59e1-424e-a148-1aa2c0db4056")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D65")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a")
+		(property "Reference" "RC6-4"
+			(at 160.02 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3427b432-e194-40af-9dcb-04dccafe2b0f")
+		)
+		(pin "2"
+			(uuid "8af48a1b-2c49-47d9-959c-ee33cdd6f977")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d4decb6-e690-4f06-b8aa-6dd29b7f2622")
+		(property "Reference" "D58"
+			(at 132.08 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0a89d11-f9ed-4dad-a764-70b931421ce9")
+		)
+		(pin "2"
+			(uuid "e072fab0-4e83-437a-8387-943f8bcc1213")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D58")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1e5f084d-4db5-48ad-a2a3-76f186559614")
+		(property "Reference" "RC3-1"
+			(at 99.06 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa")
+		)
+		(pin "2"
+			(uuid "40b7f115-b5d7-4fa0-b12b-c1c7b6866feb")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 210.82 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "210fa303-e6c4-43b3-8ff0-f2f9178c950d")
+		(property "Reference" "DI8"
+			(at 222.25 207.01 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 213.36 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cad82d1c-a62b-40c6-a2ae-61d28ed2d913")
+		)
+		(pin "2"
+			(uuid "ca0c8c70-cbfc-4421-833b-b58ab5f50511")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "22a72d93-d5b5-4a6b-95f6-755ac10ccf50")
+		(property "Reference" "RC4-7"
+			(at 119.38 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "18c97ab1-62df-42bc-9dfa-dba3415ee8e2")
+		)
+		(pin "2"
+			(uuid "ff0eb9a3-538a-4ebf-a42b-97fe870ddfea")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "244b7f9d-3923-4908-be6d-02c49eb4663c")
+		(property "Reference" "RC2-3"
+			(at 78.74 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1d79440a-2f90-4c0b-8d60-528615b0bd65")
+		)
+		(pin "2"
+			(uuid "7f1d0566-f385-4126-b190-2379308ed05b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 166.37 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2518146c-59f4-45b7-a4fa-f618686ab064")
+		(property "Reference" "DS6"
+			(at 157.48 167.005 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 157.48 164.465 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cee2f461-8f62-48d8-ac7b-1698deb984c1")
+		)
+		(pin "2"
+			(uuid "460b9088-619c-4166-a615-45e17ecf1f0d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2519cd5e-8ecf-41a4-a9d0-5b856882cb05")
+		(property "Reference" "D63"
+			(at 152.4 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ea1c9827-ebfa-43f1-b2c6-5a572466713e")
+		)
+		(pin "2"
+			(uuid "0496ba9c-818c-4d39-979a-e8785e06d12a")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D63")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "28137b00-0d76-493b-92b8-23037474163f")
+		(property "Reference" "RC1-3"
+			(at 58.42 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3")
+		)
+		(pin "2"
+			(uuid "41d35b0f-21b5-4da8-92df-229c816b63c5")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2a208574-f638-4917-a68f-bc3ff176d324")
+		(property "Reference" "D75"
+			(at 172.72 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "503e8179-7a4a-4075-8fcf-2d7bb00a3908")
+		)
+		(pin "2"
+			(uuid "a744b0f2-49c4-46a7-9ec2-cefb21173879")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D75")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c50947a-4bb9-43c2-b65c-4726e224b6b0")
+		(property "Reference" "RC3-0"
+			(at 99.06 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b")
+		)
+		(pin "2"
+			(uuid "30241adf-a2e7-4976-a53a-5c267616618e")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2e38accc-5291-44a5-82e8-9bec928b99c0")
+		(property "Reference" "D18"
+			(at 50.8 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20ca8cf6-b241-4581-b5e1-dadf97a2cf3f")
+		)
+		(pin "2"
+			(uuid "dc0b457e-4296-4b82-a953-b255f1e09c5c")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D18")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2f872c45-59ae-4f02-abee-114e38b97a80")
+		(property "Reference" "D87"
+			(at 193.04 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4139db20-9977-4a84-b30c-e04c47ec888a")
+		)
+		(pin "2"
+			(uuid "bdc078b6-22f8-427e-a1f3-872c3722a746")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D87")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30340eba-9ed0-42ff-b11f-98a864f7223e")
+		(property "Reference" "RC1-4"
+			(at 58.42 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aa956a67-c26e-4a57-9ddb-59688a6476ad")
+		)
+		(pin "2"
+			(uuid "23cd0d93-5050-40ea-9d49-879bbcbb8bcd")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30b60f6a-8d20-44dd-b832-1906a957c513")
+		(property "Reference" "D54"
+			(at 132.08 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2ad1a4-b254-49a0-8435-d3a374353ffc")
+		)
+		(pin "2"
+			(uuid "27a3cb64-baf1-430a-b797-bd52c0e46cbe")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D54")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "310fec10-f10c-41d7-9446-87c12744e146")
+		(property "Reference" "D26"
+			(at 71.12 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e1d524d3-5d24-4c87-b480-74c57a74b567")
+		)
+		(pin "2"
+			(uuid "c0e9aa05-6318-4fdc-abee-cb43875c8e46")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D26")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35827986-7004-4f70-a10a-6ceb42f33d9f")
+		(property "Reference" "RC1-2"
+			(at 58.42 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "879d3b07-b41e-4233-b196-e223f635bdf3")
+		)
+		(pin "2"
+			(uuid "641f8ea7-6306-4550-92c8-e3cc0ed3e5a5")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3598234f-e6ed-4eb6-b25a-52bde6e19729")
+		(property "Reference" "D82"
+			(at 193.04 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f8d7980-fcb9-49ec-8704-044fa4175b07")
+		)
+		(pin "2"
+			(uuid "e2992df7-1f75-4c2b-bd16-ce868f4adf82")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D82")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "369ff51e-db51-4132-aa26-7b5d981cba74")
+		(property "Reference" "D17"
+			(at 50.8 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b5adb2f-c180-494e-86cd-ef0a68591be2")
+		)
+		(pin "2"
+			(uuid "24774a87-3207-4ab9-a94d-2b9e1b568e65")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D17")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "37da2014-affc-4731-b642-c4245ff411f2")
+		(property "Reference" "RC5-7"
+			(at 139.7 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ac410347-ba8b-493b-832e-a3f9e3359951")
+		)
+		(pin "2"
+			(uuid "4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976")
+		(property "Reference" "D43"
+			(at 111.76 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6fb6c4-b36c-4ff1-879b-43826c273a72")
+		)
+		(pin "2"
+			(uuid "198c65f6-b3df-4780-9f6d-1c910e870a1b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D43")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3a9b19be-43ef-409c-9489-c069efbfa3ee")
+		(property "Reference" "RC0-7"
+			(at 38.1 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "898cdd62-8ad6-4d58-b6f7-f4db79a4cca2")
+		)
+		(pin "2"
+			(uuid "277b2226-c100-403c-a519-ef9cdc3923fe")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ac53e86-aa26-4394-9e99-e33f3c863b14")
+		(property "Reference" "RC7-1"
+			(at 180.34 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e6efb38c-f391-43d6-9511-8c7da50b3d51")
+		)
+		(pin "2"
+			(uuid "03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ad37b9b-353e-40fc-ac40-f5195f3dc605")
+		(property "Reference" "RC1-8"
+			(at 58.42 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3efa7b0a-a125-48e1-96a0-b756f7dea902")
+		)
+		(pin "2"
+			(uuid "e99d0060-9d73-4fee-8521-d18593d0656b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef0222e-2eac-4930-ac36-0f395f4593b6")
+		(property "Reference" "RC1-0"
+			(at 58.42 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20f0b9b8-9322-4d89-a423-dd3d807d99ff")
+		)
+		(pin "2"
+			(uuid "ce54609e-9d1d-4a3b-81a2-5a384dbe41c8")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef86e49-a152-4515-afb0-4098f497c742")
+		(property "Reference" "D31"
+			(at 91.44 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a")
+		)
+		(pin "2"
+			(uuid "b917ad78-96a8-428f-ad4f-d49149b5b97b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "402f0f46-5eb8-421b-9b9f-01a54b5cfa87")
+		(property "Reference" "RC4-1"
+			(at 119.38 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cb206c0-1fab-4ac5-b301-f9678369525b")
+		)
+		(pin "2"
+			(uuid "b99c2ecc-04a5-4c54-a491-d99fe2562dcc")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40d8058d-714e-4f99-a508-f64f9c8b575b")
+		(property "Reference" "D60"
+			(at 152.4 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66710233-d2ab-4921-aa86-488ee87fbb3a")
+		)
+		(pin "2"
+			(uuid "a9636da9-222c-478f-bc5b-71d3f0473300")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D60")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "430b936d-b8ad-4c28-b93d-4046aec980c7")
+		(property "Reference" "D67"
+			(at 152.4 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9255475-7a77-44cc-9bd9-589d63ced82b")
+		)
+		(pin "2"
+			(uuid "9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D67")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "433f3f09-0867-41a3-8ac6-5f00bd3314fc")
+		(property "Reference" "D32"
+			(at 91.44 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11a29637-fd50-4473-bb70-d4116312a4f5")
+		)
+		(pin "2"
+			(uuid "53f6307d-8380-45e9-b3fa-4d05a2bd575d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44499808-710f-44ae-bed2-0632db78b8c8")
+		(property "Reference" "D71"
+			(at 172.72 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8805b31-9770-4092-b10a-101cf112fd76")
+		)
+		(pin "2"
+			(uuid "9f3056b1-b197-421f-9d54-08cf5cc88970")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D71")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4461a601-2e4b-4cf8-8094-5e4d8e990676")
+		(property "Reference" "RC5-8"
+			(at 139.7 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f54d1c0f-d68b-4769-9ef7-ac6475687d30")
+		)
+		(pin "2"
+			(uuid "49768dd5-fbea-4db4-9154-60b22afd8a29")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44de9323-bd5d-49cd-bf0a-70392801309d")
+		(property "Reference" "D45"
+			(at 111.76 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb2b185b-5d98-46b8-8516-9e5c980291cf")
+		)
+		(pin "2"
+			(uuid "f730da3b-5ef9-4abc-8c8d-0794fe3feb87")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D45")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "454ad926-1c6a-4aa4-b6f8-25297463de18")
+		(property "Reference" "RC3-2"
+			(at 99.06 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0aebfce-7e76-40f1-83ef-5914b8ebbcc7")
+		)
+		(pin "2"
+			(uuid "744fce2b-a15c-45a6-92b0-e880efafb5f6")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 48.26 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46348ccc-126c-461a-8e39-f93f389ddaa7")
+		(property "Reference" "DI0"
+			(at 222.25 44.45 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 50.8 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c86bf5fa-c113-44c1-b93d-7a5d4ac11904")
+		)
+		(pin "2"
+			(uuid "dbd8322f-50c7-4271-821c-b0005fd066b2")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a7f7b3d-918b-431a-b79d-c66494b3ec50")
+		(property "Reference" "D52"
+			(at 132.08 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd114d76-87b2-4089-b211-b7b541ac42b3")
+		)
+		(pin "2"
+			(uuid "a360aa38-116c-4dd0-a569-f6a7a5a88a05")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D52")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4d978207-10b9-4a43-a474-2e66421925a0")
+		(property "Reference" "D64"
+			(at 152.4 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "27529674-e97c-460d-9de8-89cd61c8a6eb")
+		)
+		(pin "2"
+			(uuid "57e77ee6-e62d-402e-a614-a833da3fbafb")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D64")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4e9036c3-3848-485b-8b45-7e377c05efba")
+		(property "Reference" "D86"
+			(at 193.04 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cebd91c6-213c-407e-8871-b40d23e32e3c")
+		)
+		(pin "2"
+			(uuid "209631a2-8c98-4e88-8a48-286a9aadd110")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D86")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5466fd2d-f22f-409b-b7da-f8d297aeb7a2")
+		(property "Reference" "RC6-5"
+			(at 160.02 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffdd8419-9afa-4f38-bfbf-7dc4e869b438")
+		)
+		(pin "2"
+			(uuid "0db27643-51f5-4634-a791-2c4813885195")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5518d7f7-6de1-409b-a6d0-90efa78c0b82")
+		(property "Reference" "D7"
+			(at 30.48 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9bdf2265-17dd-4712-9f75-996577068823")
+		)
+		(pin "2"
+			(uuid "cd2654f9-f2c1-4ff7-bbce-8fe664862762")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "553a576d-44a1-4bad-9211-394526206f63")
+		(property "Reference" "D41"
+			(at 111.76 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4a035e61-91c9-41ba-9328-bc9b284e86c2")
+		)
+		(pin "2"
+			(uuid "8628539f-d3cd-4957-a6bb-5c605649e715")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55c4f5cb-c530-414c-92f5-fbf9e58a8885")
+		(property "Reference" "D37"
+			(at 91.44 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "64d90630-a755-4eae-b416-80d8ff93fde4")
+		)
+		(pin "2"
+			(uuid "77e4ef56-5ac3-4295-aacb-04ae680de9b7")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D37")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55dc1959-7c17-496b-b079-56725e7400ff")
+		(property "Reference" "RC7-6"
+			(at 180.34 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d91f51f-9558-44e7-9b69-c9ba25dbac1f")
+		)
+		(pin "2"
+			(uuid "f7ee2403-2740-4116-96fa-c5f3c0c9f293")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "563bf078-cf50-4f0f-84d6-a83a0feddd45")
+		(property "Reference" "D70"
+			(at 172.72 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "91318668-36ae-48a7-a13c-18d4c2f08036")
+		)
+		(pin "2"
+			(uuid "29b99e4d-eeeb-4f18-b49f-b44a360c9eac")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D70")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 207.01 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5642ac65-20dd-447b-a5a3-1b21218d5bac")
+		(property "Reference" "DS8"
+			(at 198.12 207.645 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 198.12 205.105 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6d406bb4-8771-4842-b48d-4d5e1f3de0cf")
+		)
+		(pin "2"
+			(uuid "bcdb56a4-4458-438f-b33a-abdcc29a1ebf")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 68.58 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5692cd7d-67c7-4fe7-8b4d-c8bc86968b31")
+		(property "Reference" "DI1"
+			(at 222.25 64.77 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9abe1fc5-b3c1-424f-8519-d12916c57a11")
+		)
+		(pin "2"
+			(uuid "168b1203-c5fc-4b69-b8e5-94d0bdc27e41")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "57e7516d-643d-4cd1-9646-d8696e387a16")
+		(property "Reference" "D38"
+			(at 91.44 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c0d30413-2127-456f-a30c-24a92d981ac9")
+		)
+		(pin "2"
+			(uuid "a92161f1-81a1-4199-93bf-ab8287ab6d27")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D38")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59263e5e-1eeb-458b-9b02-ca162d4a65d7")
+		(property "Reference" "D21"
+			(at 71.12 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2372f523-257f-414c-92f4-8d433cfbee15")
+		)
+		(pin "2"
+			(uuid "21891727-1d09-4cab-bd90-75c57b141f7c")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59fdee43-9b65-471d-9ea8-5dc40dc65f6e")
+		(property "Reference" "D35"
+			(at 91.44 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5834d436-0e26-481b-a20d-40fa6346502e")
+		)
+		(pin "2"
+			(uuid "59af1ddc-701f-49c0-b6cd-778072695c5c")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D35")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5aeb247f-6f79-4df2-b767-9ca89069182c")
+		(property "Reference" "D56"
+			(at 132.08 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d46c0cdd-d9c1-44c1-ba6c-034fc547ff01")
+		)
+		(pin "2"
+			(uuid "53f3e198-3ef2-40c4-a8f7-298435eddd0b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D56")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5c60f960-fb0a-46f6-9aff-5d8144586231")
+		(property "Reference" "RC4-6"
+			(at 119.38 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "990f1ee1-d6da-4ae8-809a-1911d8099a4c")
+		)
+		(pin "2"
+			(uuid "a8276c00-b61f-4db4-8f4f-e51e512de654")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f21a75c-b9ee-47bf-adcf-39a03e42660f")
+		(property "Reference" "D15"
+			(at 50.8 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1")
+		)
+		(pin "2"
+			(uuid "7a8a84c2-38d2-473b-955d-81dd816a398e")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fa8cce4-fbbf-4784-a459-71364b77e1a7")
+		(property "Reference" "RC0-2"
+			(at 38.1 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cb7750fa-a378-43a3-a1c6-638c32a1c79e")
+		)
+		(pin "2"
+			(uuid "67dfe958-6bd5-4618-98a3-d513db4ad5c0")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5ff7733c-a36f-4b29-a8e7-bdf79fabdf72")
+		(property "Reference" "D4"
+			(at 30.48 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed6062e9-f00a-474a-840f-39685bd66d70")
+		)
+		(pin "2"
+			(uuid "c0e85db4-b88d-4383-8de6-9f7370be62a6")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61b2e3fc-583b-407b-beff-dd8441f2f403")
+		(property "Reference" "RC2-6"
+			(at 78.74 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "752f308d-4723-4468-9745-81de18307ba3")
+		)
+		(pin "2"
+			(uuid "3267c09c-2818-42d7-96a9-6aaa2d6c4a92")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6368f5d6-df20-4a23-a72c-e29e990ea131")
+		(property "Reference" "D36"
+			(at 91.44 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cd72461-15a2-466d-828d-9560639fb78b")
+		)
+		(pin "2"
+			(uuid "e26d27e6-f81a-4557-bc98-f3f953d25d26")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D36")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "64616073-76e8-465f-9707-663a78749bf1")
+		(property "Reference" "RC7-3"
+			(at 180.34 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0925180b-4c04-468a-84a3-7e0c543a243b")
+		)
+		(pin "2"
+			(uuid "000c5508-f583-4022-ad6d-ee3a9a754164")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6692c134-d619-4b90-b4c4-ab21aa3df3a5")
+		(property "Reference" "RC8-7"
+			(at 200.66 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "453a02c7-7770-40fc-8f21-06b63fd625f1")
+		)
+		(pin "2"
+			(uuid "3ebf9656-8129-4c66-8b10-67f0c0e2bb28")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "67aba0e0-2c92-4816-99a5-9091230a7899")
+		(property "Reference" "RC3-6"
+			(at 99.06 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c252319-dc79-4365-afaa-77dcde3e6c4e")
+		)
+		(pin "2"
+			(uuid "a5f35312-d094-4f22-9eb9-0edc1f8fb9c4")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6aa79de9-555a-4ed1-93d3-b801685ebd28")
+		(property "Reference" "D53"
+			(at 132.08 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b2031fe-ef72-48a9-afa6-c06144a31b2c")
+		)
+		(pin "2"
+			(uuid "7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D53")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6ef4f980-15ce-420f-b02f-d66ae810e188")
+		(property "Reference" "D78"
+			(at 172.72 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "680d9493-5437-446a-836f-9ed5bb999bdf")
+		)
+		(pin "2"
+			(uuid "d64a76a9-3b5d-48b1-9a48-ee12b0cd1ab7")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D78")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "70d661b8-51f1-49b8-ad84-9ce8d120c0fc")
+		(property "Reference" "RC6-2"
+			(at 160.02 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e2175ea2-22e6-4720-ab54-24959d43a616")
+		)
+		(pin "2"
+			(uuid "63a1bf12-3f2f-4dc8-8a86-7932361b8306")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "712ade27-46b2-4d0c-b658-ec3775a1c528")
+		(property "Reference" "RC3-8"
+			(at 99.06 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4811e298-73bc-4ac1-af58-3ae7f508d1d7")
+		)
+		(pin "2"
+			(uuid "ac21b718-c133-4ed3-a2f4-c437b7879cce")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "72047ccc-8813-4e13-ae4a-04618a9ab771")
+		(property "Reference" "D23"
+			(at 71.12 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84")
+		)
+		(pin "2"
+			(uuid "6dee3493-b1eb-401e-abb4-cbdef0ef3867")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7295efa3-e253-4b6b-ad8d-641bcea1e272")
+		(property "Reference" "D68"
+			(at 152.4 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0450f5cb-94f5-4de3-b50e-da553aca1ff3")
+		)
+		(pin "2"
+			(uuid "47f460cc-5812-4c14-b97e-030930a4c1aa")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D68")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7322809e-8332-47c6-af41-fcf3bbcec7d0")
+		(property "Reference" "D34"
+			(at 91.44 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e3b096d1-dbd9-4fb8-8775-725a7aed0bc4")
+		)
+		(pin "2"
+			(uuid "63756bb0-b693-4bbc-82da-e89a6b927e71")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D34")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "76054860-648b-474e-9b4d-cc9d83653495")
+		(property "Reference" "D10"
+			(at 50.8 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d7e8bc-1ac3-4327-ab17-369de6ee755c")
+		)
+		(pin "2"
+			(uuid "c8283bba-c907-48e0-9745-e0818ca7ab04")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "77aa25a5-82c7-42c3-9d55-8606dd65ffa8")
+		(property "Reference" "RC5-1"
+			(at 139.7 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51db5d58-5004-4c9c-b8d1-c184bfb493da")
+		)
+		(pin "2"
+			(uuid "16d6f605-4627-49bd-9180-8203902febfd")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7876e2e4-9d5a-416f-b97a-e958a989e5b8")
+		(property "Reference" "D16"
+			(at 50.8 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8bd5710-8f18-4748-9b3c-a975f78342a1")
+		)
+		(pin "2"
+			(uuid "da0aa924-203b-4985-9bff-4185f3555d43")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D16")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7b85c895-ed2f-4daf-bbd5-9b0e9148eed9")
+		(property "Reference" "RC7-8"
+			(at 180.34 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c6604866-4e4a-4cb4-bf09-ea0fa22fde38")
+		)
+		(pin "2"
+			(uuid "0729bbae-70ee-4c7e-8da7-29c0812b5be7")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8010e136-1dd3-496f-b7ef-81fb0c8b419e")
+		(property "Reference" "D20"
+			(at 71.12 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5aa5bf69-e040-48d4-81fc-332aff45c2f9")
+		)
+		(pin "2"
+			(uuid "f5458189-75e2-45c3-bf32-0320ebe63391")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80c46ab4-724f-418d-bb6f-e89792097e1a")
+		(property "Reference" "RC2-4"
+			(at 78.74 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc0fd3d-897b-4e06-ac65-16066b68709e")
+		)
+		(pin "2"
+			(uuid "b7b98128-d37a-4ac7-b049-5cf9bdd5aadb")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "814545b5-c5a6-4c45-83b2-5c1b5ef43a22")
+		(property "Reference" "D57"
+			(at 132.08 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "adc35f03-9c02-4ca4-bbc5-866d317a7469")
+		)
+		(pin "2"
+			(uuid "f05a395b-0185-4ab8-bf1d-fa0561316ad4")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D57")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "81912d5a-1def-44e9-a6ef-abaf3ecd517d")
+		(property "Reference" "RC6-1"
+			(at 160.02 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fa9aca31-bd8b-4e2e-8b86-05d191575df9")
+		)
+		(pin "2"
+			(uuid "fce38bd6-fb8f-42a6-8d68-ecda7f1a588f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "820f9c2f-0705-41a0-aa6a-3a211d61773f")
+		(property "Reference" "RC6-7"
+			(at 160.02 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb135129-1d78-4d36-9389-941aee94da0a")
+		)
+		(pin "2"
+			(uuid "2a32e7b7-f134-4c47-a153-d8fce8404094")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83cc3bf3-09a0-4d14-be9d-180ca479485f")
+		(property "Reference" "D73"
+			(at 172.72 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22a68b69-e4e9-436e-b154-616fe8bb66c2")
+		)
+		(pin "2"
+			(uuid "b8e81b5d-9257-4482-8c33-cdfcb13c22e7")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D73")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83fb734e-dbcd-4939-9bb9-d97efd05ec97")
+		(property "Reference" "RC5-6"
+			(at 139.7 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7315a9fc-fd63-46c2-90db-bee656dc7568")
+		)
+		(pin "2"
+			(uuid "f2997912-9551-49e9-aab8-387875819f56")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "84146f81-04f3-4efb-b753-bdc596c8e7a9")
+		(property "Reference" "RC4-3"
+			(at 119.38 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "774ced50-3b17-48fe-b2d7-22681b1dd1f7")
+		)
+		(pin "2"
+			(uuid "bad310c0-ca25-47d0-b27e-42438b959c7b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86602dfb-ea19-4060-ad39-496c613a47cb")
+		(property "Reference" "D30"
+			(at 91.44 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "02958e5d-18b7-48f3-9883-661ceaa75da5")
+		)
+		(pin "2"
+			(uuid "abed4b13-9431-40c7-848f-b30c05e39dfd")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D30")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8af20987-c3c2-465e-8640-61ab0bd7d8fa")
+		(property "Reference" "D81"
+			(at 193.04 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f42cdbf-02ba-4b39-8586-bbff1b6ed80b")
+		)
+		(pin "2"
+			(uuid "7d939371-3ab1-4f18-b55f-07048dcfe21f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D81")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8b2b0803-8190-43b4-9c0d-a9a9edc27829")
+		(property "Reference" "RC2-7"
+			(at 78.74 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8e9f64d-5849-4a62-8bf4-dafc65fcdd75")
+		)
+		(pin "2"
+			(uuid "e45fa11d-c755-4d62-baa5-974f973ba20f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c168cda-0a39-478d-9d71-1073400c7ed7")
+		(property "Reference" "RC1-5"
+			(at 58.42 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d2851af-db15-44cf-8e07-da339bdc18b2")
+		)
+		(pin "2"
+			(uuid "94b381a2-7c19-4916-9f9a-ee00221d04d3")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 129.54 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7")
+		(property "Reference" "DI4"
+			(at 222.25 125.73 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c02807d6-1705-4325-bcb0-203f4e9a5baa")
+		)
+		(pin "2"
+			(uuid "d6c46059-bf9c-4959-836e-e4d33dcc5edd")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8eb7a7fa-054b-460a-a80c-73a56219fecd")
+		(property "Reference" "RC7-0"
+			(at 180.34 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be9c1065-912d-49b5-8f2f-271b4a0c1db2")
+		)
+		(pin "2"
+			(uuid "626f5614-e69d-4277-acf6-7ff35b08ddb4")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "90049005-7b99-4d2f-9282-dbf53b76b55d")
+		(property "Reference" "RC3-7"
+			(at 99.06 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "62acb361-e48a-40de-9689-6c103c4c7663")
+		)
+		(pin "2"
+			(uuid "f3ee11cf-4f81-4591-ab5d-f41aece910dc")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 186.69 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "91a5d9b4-63df-4567-88f7-1d2f7ac8c33d")
+		(property "Reference" "DS7"
+			(at 177.8 187.325 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 177.8 184.785 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2ec7f316-054f-444d-9c0b-c2c6e1d51faf")
+		)
+		(pin "2"
+			(uuid "e22dc61a-a86f-42a7-9c26-623bb8233a05")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "933178a7-83a9-4f29-88ef-1e369645dcaa")
+		(property "Reference" "RC2-8"
+			(at 78.74 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4d133f2b-f4f1-4994-a89d-7141989cf18e")
+		)
+		(pin "2"
+			(uuid "9ed70267-ef82-4b49-85af-67297365ea60")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "93921179-259f-4393-a6ae-bfcb2df690b6")
+		(property "Reference" "D80"
+			(at 193.04 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d32d457e-c0ce-46dc-ac4a-08e965633eab")
+		)
+		(pin "2"
+			(uuid "0645b564-d7c5-4845-82b9-8702f3f470a4")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D80")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9578a4b6-1a56-40b7-be8d-56404ef59fdf")
+		(property "Reference" "RC1-6"
+			(at 58.42 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0b899b44-3ae3-40be-a452-1f16eaa5f4af")
+		)
+		(pin "2"
+			(uuid "11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 109.22 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "957e7a82-ca9c-46a8-bca9-099b05fe7e8f")
+		(property "Reference" "DI3"
+			(at 222.25 105.41 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc53fac9-006c-4101-8113-949ab8e05afb")
+		)
+		(pin "2"
+			(uuid "f6122429-5885-4b7a-b72a-162ca49c70c2")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9af5b930-d274-4b05-b0bf-e2c27b7e71dd")
+		(property "Reference" "D6"
+			(at 30.48 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bdad3d4-58ec-438c-beb8-3eea36a29d95")
+		)
+		(pin "2"
+			(uuid "5ff4e8af-dd18-4010-b183-21b8178cd684")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 222.25 88.9 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd")
+		(property "Reference" "DI2"
+			(at 222.25 85.09 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 224.155 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 222.25 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 222.25 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 222.25 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 222.25 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 222.25 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a")
+		)
+		(pin "2"
+			(uuid "81e4b9c6-9b09-4e38-94e9-cebdeae457ee")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e96ab02-44ee-4ac7-8251-0d309b7409ad")
+		(property "Reference" "RC5-3"
+			(at 139.7 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd85b120-1be2-4f17-a3d7-505a734afc72")
+		)
+		(pin "2"
+			(uuid "666e03ce-bf1c-4b58-ac4e-f01557ca11fd")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a3969e5a-abe0-44e9-adf1-6255946e3f4c")
+		(property "Reference" "RC6-0"
+			(at 160.02 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc4d6aea-ec1e-45c7-842c-68cd7e21336f")
+		)
+		(pin "2"
+			(uuid "f785fa77-0ac2-41ff-9704-1acbb4a72c84")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a400377f-e146-4099-97e7-db21e16d5759")
+		(property "Reference" "D3"
+			(at 30.48 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bfc71c1-6349-4b3f-bf89-22c83277904e")
+		)
+		(pin "2"
+			(uuid "dafd4b6c-6c2f-41e0-95ab-05ead276d86d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a576c983-0812-4f76-8327-d260ce9c2826")
+		(property "Reference" "D27"
+			(at 71.12 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c11deb1a-dbe0-4d39-8303-331b09dd3cc0")
+		)
+		(pin "2"
+			(uuid "9251c46a-97e6-41c1-9326-a6a8b52abc12")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D27")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a71b771b-4e14-4d95-98e7-86a6250f569e")
+		(property "Reference" "RC0-4"
+			(at 38.1 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "95049e61-b78e-490f-86e1-aba711db5c19")
+		)
+		(pin "2"
+			(uuid "6e474ba8-5b88-41c8-9259-b0ebfb6012f0")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "abf3c9d9-a279-4546-abcf-5e4f6862bc48")
+		(property "Reference" "D2"
+			(at 30.48 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a3499f31-3593-4cd9-977b-3b6479091d7b")
+		)
+		(pin "2"
+			(uuid "17f09d49-1093-4838-8e5c-8fc4c42e5d05")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac10b530-144b-4dfc-ab37-ad7a8ced8612")
+		(property "Reference" "RC4-5"
+			(at 119.38 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d6c95156-54b9-4f54-a278-f808b4871687")
+		)
+		(pin "2"
+			(uuid "c3dc8d92-1759-4195-a3c9-81260bc6d8b1")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 85.09 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "accba515-4e8d-4804-afea-f36f436141c3")
+		(property "Reference" "DS2"
+			(at 76.2 85.725 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 76.2 83.185 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "034e4344-7cda-43bc-a12a-f56b6e8f68f5")
+		)
+		(pin "2"
+			(uuid "6f0bef00-c613-46da-9667-752b92174ad1")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ad352cc7-0ffd-4a04-82ac-bc693299cd86")
+		(property "Reference" "D83"
+			(at 193.04 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9662d2b8-61ec-4840-a8f1-af48833c11eb")
+		)
+		(pin "2"
+			(uuid "4d0c4f9f-b435-4d30-95d7-23d9f87d5f48")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D83")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "afcc8d67-6ed8-4a82-aef7-417b4229ad61")
+		(property "Reference" "RC7-4"
+			(at 180.34 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "982715f0-55ee-4146-b98e-756e5b630dca")
+		)
+		(pin "2"
+			(uuid "7f384a84-9632-4ac9-a8b6-05778cf49f62")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b05bbd1d-9d65-4ef7-a639-885ae69d8b01")
+		(property "Reference" "RC8-0"
+			(at 200.66 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "16c6866c-1d06-4257-9cde-9d9c6f4c3642")
+		)
+		(pin "2"
+			(uuid "70b152f6-7e7d-4a93-9ef0-b6ec51ff9b25")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b2cc8c06-500a-41ac-a412-7baf61e0f24c")
+		(property "Reference" "RC6-3"
+			(at 160.02 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a77d5cb-df53-4102-99ed-4829fa686656")
+		)
+		(pin "2"
+			(uuid "22df81c2-2a06-44e2-bed1-a6d6c14df76a")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 146.05 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3573dc3-ef18-4f4c-817b-c984ae7cfae9")
+		(property "Reference" "DS5"
+			(at 137.16 146.685 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 137.16 144.145 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "813e7cf6-f821-4e03-95cc-308010bed54e")
+		)
+		(pin "2"
+			(uuid "9669a028-42d7-436f-8ec5-bc3423db62d6")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b39d56f9-3079-43e4-bb1b-80277fdae425")
+		(property "Reference" "RC4-2"
+			(at 119.38 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b205d044-9ffa-4dce-82fd-f51ba622a818")
+		)
+		(pin "2"
+			(uuid "29ce7588-4a17-4be4-9207-ea3ed2669aa1")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c497a9-b81f-4161-88cf-2e58ddb4cdd8")
+		(property "Reference" "RC3-4"
+			(at 99.06 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae78f0d3-f75a-49c8-ab9b-8a9831e434d7")
+		)
+		(pin "2"
+			(uuid "a59e897c-0784-437d-9243-baf91d40a453")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b92624bc-936a-4bc6-ac7c-dbc9faa7208a")
+		(property "Reference" "D8"
+			(at 30.48 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0ef02d0f-103e-468b-b30c-fac4e90fb218")
+		)
+		(pin "2"
+			(uuid "aa510cff-115d-4ad1-9c78-bf1246172261")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba3c5bf2-9824-404a-befe-7584c286e012")
+		(property "Reference" "D48"
+			(at 111.76 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "38e4de38-525a-4e2c-8e51-9d4770973903")
+		)
+		(pin "2"
+			(uuid "e71e068d-4f7e-493a-960b-e49aa171ca56")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D48")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba927934-b2e1-4953-b21b-54ef02be8935")
+		(property "Reference" "RC0-5"
+			(at 38.1 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cadba0a-3bb3-40cd-acea-644da4b3e05f")
+		)
+		(pin "2"
+			(uuid "1368ebac-096c-415f-acaf-9afb071e729f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bb2c72f0-a908-44e7-b7d5-67df52eed516")
+		(property "Reference" "DS4"
+			(at 116.84 126.365 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 116.84 123.825 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5ab0b348-3e2a-4517-90b3-fad111de6205")
+		)
+		(pin "2"
+			(uuid "6e7351bb-5d09-464f-9e8d-535ba0f5c6f3")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bbc3ae57-e1db-475c-9bc3-18c822e7531a")
+		(property "Reference" "D28"
+			(at 71.12 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90783402-edc5-4638-ae16-d31c3aaf5e2b")
+		)
+		(pin "2"
+			(uuid "f9e9c399-273d-43fc-9007-1e5ca67fea38")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D28")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be02506a-2bb1-4713-b046-f0327dae72de")
+		(property "Reference" "RC0-1"
+			(at 38.1 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97a92abd-708c-465e-baf7-79fa35370a7c")
+		)
+		(pin "2"
+			(uuid "c9056b1e-419e-478d-9fc4-be1e95902d28")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be554787-60ed-4b8f-b7bc-2220fcd28430")
+		(property "Reference" "RC8-3"
+			(at 200.66 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "76eac86e-4d5a-4833-a702-c89fc5eb96e0")
+		)
+		(pin "2"
+			(uuid "6e41d262-c7fe-4c54-b525-59ae026a918d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d")
+		(property "Reference" "RC5-2"
+			(at 139.7 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f22c39d-012a-4297-b61c-1ff841801333")
+		)
+		(pin "2"
+			(uuid "adbe8c88-ad34-405b-866a-efb64899002f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c11b6807-83e7-46af-9d7e-9d56aab4109c")
+		(property "Reference" "D46"
+			(at 111.76 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46")
+		)
+		(pin "2"
+			(uuid "6764bae9-067c-4178-897e-2c25048ade8b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D46")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c164cb58-7d29-400c-b219-f07036f5e8c9")
+		(property "Reference" "RC0-3"
+			(at 38.1 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92164ea1-76d0-4223-80cc-32c093c14fcd")
+		)
+		(pin "2"
+			(uuid "e615b2e5-6986-47ac-8f35-da60c20b811c")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c43b92c2-4283-44f7-8cb3-665623564383")
+		(property "Reference" "D42"
+			(at 111.76 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0929e13-ab77-4737-9d55-142bd9901b1c")
+		)
+		(pin "2"
+			(uuid "0f45988c-1752-479c-97d5-fbada14f9a42")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D42")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c72dd108-be98-47d5-b809-561778aa3212")
+		(property "Reference" "RC2-5"
+			(at 78.74 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d2f0fd-ce69-4d4e-a4ab-163c1691ef24")
+		)
+		(pin "2"
+			(uuid "03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c7f185b3-c785-4ddb-9c6f-f854c93057c1")
+		(property "Reference" "D85"
+			(at 193.04 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b8f08018-67e0-4945-91d2-9a40292e0a1a")
+		)
+		(pin "2"
+			(uuid "096b6293-e540-4273-b6aa-9e314016c840")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D85")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe")
+		(property "Reference" "D50"
+			(at 132.08 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a606860e-126b-4f3e-bcfe-a2dfa8adc9c8")
+		)
+		(pin "2"
+			(uuid "59120505-a333-4c63-8904-aa379cfb043b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D50")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c996541a-3b07-4fed-9687-afa9b7ffb878")
+		(property "Reference" "RC7-5"
+			(at 180.34 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "560b334e-ed5f-40a2-b100-5974e92ce94c")
+		)
+		(pin "2"
+			(uuid "55bbe733-1ff6-4a73-b892-49d49c6c0fc9")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce521a1c-e123-4f49-866e-f4f51848f864")
+		(property "Reference" "RC7-2"
+			(at 180.34 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2a9b15ea-df9e-4ef0-a128-13d2e129d7f7")
+		)
+		(pin "2"
+			(uuid "e9530707-f705-4741-a308-e08f558f67a1")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e")
+		(property "Reference" "D51"
+			(at 132.08 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48596e1c-4629-46bb-98c1-de11cd41e539")
+		)
+		(pin "2"
+			(uuid "f7decfb7-c4ef-4861-ba8a-043f44f3b09e")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D51")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf81ef85-b58f-422a-b88a-7b7914aa3581")
+		(property "Reference" "D12"
+			(at 50.8 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e34c154b-a3cb-467d-891b-2f2891056190")
+		)
+		(pin "2"
+			(uuid "dc926c49-c915-470d-b2b5-00749f3505bb")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d40b4fbb-e58c-433e-b2c5-236bb8aa92c5")
+		(property "Reference" "D1"
+			(at 30.48 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90049b07-ff34-407c-ad1c-bcb8b89b241c")
+		)
+		(pin "2"
+			(uuid "7bd5d68f-4902-47f7-bc35-be0973d0d904")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578")
+		(property "Reference" "RC5-0"
+			(at 139.7 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e5729530-792d-44f2-80ff-f6315aae335e")
+		)
+		(pin "2"
+			(uuid "01f42ec4-9037-47c0-8fc0-8f7345fd0a2b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d69b760e-d231-449e-ae78-5289569bfcf8")
+		(property "Reference" "RC4-8"
+			(at 119.38 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b2174dcf-3936-44c4-b9c9-8a8c2ffd5559")
+		)
+		(pin "2"
+			(uuid "553bf002-fd89-4554-b1c2-ed094fd5fe57")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d7b98385-4339-43e1-a83a-6daba8def1f8")
+		(property "Reference" "RC0-8"
+			(at 38.1 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c3a8852b-59c8-4849-9f9f-edc39c43f8e6")
+		)
+		(pin "2"
+			(uuid "f4bfef10-0157-4077-9c8b-8858eccf5c1a")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69")
+		(property "Reference" "RC2-1"
+			(at 78.74 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba2015a3-c3ad-44cf-b530-b2a60bac2c12")
+		)
+		(pin "2"
+			(uuid "12bdf482-8bd0-4b7d-a511-fcaadc8ab54d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "daefbaa6-3e17-4eca-837b-024ccac5fc10")
+		(property "Reference" "D14"
+			(at 50.8 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12e5236e-b23d-4e38-9768-e28d1693b6eb")
+		)
+		(pin "2"
+			(uuid "1be4fe23-ac83-4b50-b43f-2e4b33c335d7")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "df14ac0c-5b64-41d1-ac61-954e84a88f4b")
+		(property "Reference" "D47"
+			(at 111.76 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7284aa2f-4456-4e07-9251-a86b7acd95b1")
+		)
+		(pin "2"
+			(uuid "c06243a0-5a23-4af5-88df-f2a88bfb1da0")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D47")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e214b496-153e-40f8-93df-30f96574576d")
+		(property "Reference" "RC6-8"
+			(at 160.02 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "762c516c-df17-4ae0-8f7f-03315e74925e")
+		)
+		(pin "2"
+			(uuid "874fed4d-cc1d-47bf-b14e-533fedfc9875")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e255666b-19cd-45a4-b5c1-8997235eb1ad")
+		(property "Reference" "D72"
+			(at 172.72 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92803ca1-7814-4c2f-986c-c7a2afaea4b2")
+		)
+		(pin "2"
+			(uuid "f1e544c9-5e94-460f-960c-d30fdb857f44")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D72")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e433e872-70f0-4e5b-b473-1ebd1af79f33")
+		(property "Reference" "D84"
+			(at 193.04 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2c838395-b13b-44f3-9cda-ae0061827054")
+		)
+		(pin "2"
+			(uuid "b7abe52a-50b6-4b31-8da0-3b0e1433e922")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D84")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e490f25a-1360-4f95-aa79-5f1d93892bb3")
+		(property "Reference" "RC3-5"
+			(at 99.06 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "056973a8-92e3-49be-9b21-fe961241d12f")
+		)
+		(pin "2"
+			(uuid "01c4c06b-d45d-4ffb-ad72-57ca7686fd55")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e6262d19-9b35-41b6-845a-39c20b831416")
+		(property "Reference" "D76"
+			(at 172.72 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8324bd70-bd5e-4513-bc52-cc4e838003e8")
+		)
+		(pin "2"
+			(uuid "64285f25-2c5b-4231-8d94-7ba284d5a2d2")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D76")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e97aeea5-7475-4b9f-a312-6f51452496a5")
+		(property "Reference" "RC8-4"
+			(at 200.66 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b5d442a-c78e-4d0d-8f8c-3cc6c91bf307")
+		)
+		(pin "2"
+			(uuid "4b2eebd0-ccb3-482c-8c43-2690e285e66f")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 105.41 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b")
+		(property "Reference" "DS3"
+			(at 96.52 106.045 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 96.52 103.505 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "738869bf-f410-43b7-b7e7-4e927d69911a")
+		)
+		(pin "2"
+			(uuid "71649a24-87f4-49fb-9896-e50c64c03a31")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb153eb2-74b0-4cb9-b105-af356654d60d")
+		(property "Reference" "D24"
+			(at 71.12 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "77c4fd5e-5c79-4799-aab6-2f07a57c7df3")
+		)
+		(pin "2"
+			(uuid "a062346b-452b-46dc-a106-fab01848555d")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D24")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ee3742e9-8e22-4413-88a6-b893a7cb3439")
+		(property "Reference" "RC8-6"
+			(at 200.66 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12157fba-1ac0-4b59-9ef4-f0b7f556fda2")
+		)
+		(pin "2"
+			(uuid "a6fa6d7f-615c-410e-9188-d1867808891a")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ef64a689-efe5-479a-a53a-19c9f4177765")
+		(property "Reference" "D74"
+			(at 172.72 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fc4be4a8-3bcc-4a9b-8dca-654b73020c91")
+		)
+		(pin "2"
+			(uuid "982449b6-25db-4afc-abf2-592e07b23449")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D74")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1920e34-64a4-41c9-8680-7fa42f5dfb9d")
+		(property "Reference" "RC2-0"
+			(at 78.74 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9242378-4df5-4b90-afbf-1098ccb8067f")
+		)
+		(pin "2"
+			(uuid "a135b9b9-316d-4cb2-a5a5-8d618a00a752")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1a5bcca-72b0-4fb1-9570-8abc0f731fb7")
+		(property "Reference" "RC1-7"
+			(at 58.42 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "058cb33f-3013-4884-ba52-2b175c6e6f25")
+		)
+		(pin "2"
+			(uuid "cb54004f-a1b9-489e-9cdf-00b812c2d5fa")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f735328c-2a24-4fb3-983d-b3e512d5a5cf")
+		(property "Reference" "RC8-5"
+			(at 200.66 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "af0d403b-f1be-40d9-bf46-12c29a8b07f1")
+		)
+		(pin "2"
+			(uuid "cf12207d-8835-4b4d-855b-207eb48891b5")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f9c61822-7d54-487f-93d1-920e041f55a6")
+		(property "Reference" "RC8-2"
+			(at 200.66 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffd61ace-0250-4fd9-8d0c-c2c917d0d4b5")
+		)
+		(pin "2"
+			(uuid "d354ba15-00ca-4efb-954b-871f951259db")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc941f43-b642-4fef-8515-f8f851adced2")
+		(property "Reference" "D13"
+			(at 50.8 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c")
+		)
+		(pin "2"
+			(uuid "ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fcc35b13-8da5-4271-981a-5470b3add3e5")
+		(property "Reference" "D25"
+			(at 71.12 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0f0d662a-16b3-4c76-b4ee-49de18b57b47")
+		)
+		(pin "2"
+			(uuid "ba9a1f4c-173e-4b32-907f-fe9b31df718b")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fd13d6af-afdf-4367-a43b-1889348eabd8")
+		(property "Reference" "RC0-6"
+			(at 38.1 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "854af50a-a007-4ba3-a405-76f0f99e9817")
+		)
+		(pin "2"
+			(uuid "bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142")
+		)
+		(instances
+			(project "round-robin-10-72"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/round-robin-10-72.kicad_sch
+++ b/round-robin-10-72.kicad_sch
@@ -3157,7 +3157,7 @@
 			)
 		)
 	)
-	(global_label "IO 5"
+	(global_label "IO 6"
 		(shape bidirectional)
 		(at 165.1 25.4 90)
 		(fields_autoplaced yes)
@@ -3169,12 +3169,12 @@
 		)
 		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 165.1 17.2705 90)
+			(at 165.1 17.1911 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 				(hide yes)
 			)
 		)

--- a/round-robin-11-90.kicad_sch
+++ b/round-robin-11-90.kicad_sch
@@ -3801,7 +3801,7 @@
 			)
 		)
 	)
-	(global_label "IO 5"
+	(global_label "IO 6"
 		(shape bidirectional)
 		(at 165.1 25.4 90)
 		(fields_autoplaced yes)
@@ -3813,12 +3813,12 @@
 		)
 		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 165.1 17.2705 90)
+			(at 165.1 17.1911 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 				(hide yes)
 			)
 		)

--- a/round-robin-11-90.kicad_sch
+++ b/round-robin-11-90.kicad_sch
@@ -1,7521 +1,20277 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid cbac505e-77a6-4a00-a758-435de33cca16)
-
-  (paper "A3" portrait)
-
-  (lib_symbols
-    (symbol "Diode:1N4148" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "1N4148" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Device" "D" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Pins" "1=K 2=A" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "100V 0.15A standard switching diode, DO-35" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "D*DO?35*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "1N4148_0_1"
-        (polyline
-          (pts
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "1N4148_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 1.27 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "SW_Push" (at 0 -1.524 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "switch normally-open pushbutton push-button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Push button switch, generic, two pins" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SW_Push_0_1"
-        (circle (center -2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 3.048)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 0 180) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 165.1 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 00d75863-bb9f-4d4c-ae8f-f64498ed1533)
-  )
-  (junction (at 246.38 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 04d157fc-c063-40ca-ad05-26c77c1c313c)
-  )
-  (junction (at 185.42 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 05e510f3-8ca9-490a-bdc5-77faace67735)
-  )
-  (junction (at 104.14 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 06a6d1a8-0f12-4174-b63e-d35d8ca618bf)
-  )
-  (junction (at 43.18 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 06e66b38-0070-40a1-8fc5-70306b17897f)
-  )
-  (junction (at 165.1 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 09e82fd3-a43f-4071-83d2-fb0a65931c0e)
-  )
-  (junction (at 195.58 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0a12de08-1706-4b9c-a033-35ba5807ef7b)
-  )
-  (junction (at 63.5 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0a9113d4-8a8c-4abc-b886-f22c92ad18dc)
-  )
-  (junction (at 165.1 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 0a95c2d4-251b-4df1-a8c0-c0fc6241e43d)
-  )
-  (junction (at 124.46 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29)
-  )
-  (junction (at 73.66 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0c7244ee-ddfb-470b-a70b-1cfc53f83773)
-  )
-  (junction (at 134.62 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 0c73479c-4e07-428a-85f3-93341c42ca57)
-  )
-  (junction (at 93.98 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5f3a7a-dc5d-4973-8743-eafaa1c1a462)
-  )
-  (junction (at 43.18 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 10cae212-bc64-40b9-b44f-13fd4a0406a6)
-  )
-  (junction (at 53.34 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 122dbfee-176c-4f21-802f-09581864dffb)
-  )
-  (junction (at 215.9 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 125985d5-ea14-4dfe-aae0-18ae62d080c5)
-  )
-  (junction (at 83.82 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1278b5e3-5eff-46d6-a162-44fde2066970)
-  )
-  (junction (at 53.34 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 14bb4fc2-d7df-49aa-b10e-882abdd2aa5f)
-  )
-  (junction (at 185.42 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 15daf298-357b-4f73-8767-34988eed6eb8)
-  )
-  (junction (at 104.14 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 17f3773a-2c02-426d-bcd6-7a35c59a710a)
-  )
-  (junction (at 205.74 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1943e8ad-b21d-4f7c-9e48-baf07472bdf8)
-  )
-  (junction (at 114.3 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 1a11ada5-19c8-45ac-810c-daedbb80ad5b)
-  )
-  (junction (at 195.58 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 1a6176d3-a6a6-4f72-9be0-2812f8861a46)
-  )
-  (junction (at 73.66 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1c386ee6-5b9d-4eae-92b5-9440e81067f6)
-  )
-  (junction (at 246.38 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 216bc563-0bc0-4447-af79-7933fdef7d63)
-  )
-  (junction (at 93.98 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 21e320b6-a0c4-4d5d-babf-ee5274120507)
-  )
-  (junction (at 185.42 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 23554013-cd0d-4767-9f22-8c19a7d8c5ca)
-  )
-  (junction (at 154.94 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 23916c3a-0d37-416a-91d3-82a34b3ade4a)
-  )
-  (junction (at 165.1 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 2501dc30-a271-4271-9ca6-b085328a23ec)
-  )
-  (junction (at 215.9 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 2626f828-e375-4e39-b9f5-57d32786f5fd)
-  )
-  (junction (at 73.66 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 2654ce54-6e59-4c49-bfbf-12326c83c638)
-  )
-  (junction (at 226.06 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 28c72d93-951d-432a-abf9-c3f05af6b90f)
-  )
-  (junction (at 154.94 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 2af4d5cf-36e8-471b-be0a-21fb2d03facc)
-  )
-  (junction (at 124.46 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 2b2b66bc-905d-4b48-89f5-1c62f6c27dbb)
-  )
-  (junction (at 134.62 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 2c5878fe-fb0a-42a4-a883-ea4209708ea5)
-  )
-  (junction (at 175.26 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 2cae1312-83d6-4b55-a6a7-5303ad6d6c6c)
-  )
-  (junction (at 154.94 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 2cf168f3-fe97-43f2-b72e-223dd4e6b386)
-  )
-  (junction (at 73.66 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 2f562ace-9050-4ec1-bf70-b5691b93259e)
-  )
-  (junction (at 73.66 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 30c9eca3-7c32-4704-8819-3599d7b84f53)
-  )
-  (junction (at 93.98 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 31a1b16e-8174-4fea-bc42-9c75ed9182a0)
-  )
-  (junction (at 83.82 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3)
-  )
-  (junction (at 114.3 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 347306fc-87ef-43e1-a98f-ca29ac9473e6)
-  )
-  (junction (at 124.46 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 352af8be-9d08-4866-961e-b8632013179f)
-  )
-  (junction (at 104.14 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 356b49b0-20ac-4c33-8df8-9b27dee0b312)
-  )
-  (junction (at 175.26 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 357aa667-d746-4e3e-ab2a-484493e6765a)
-  )
-  (junction (at 215.9 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 35d34a6d-9a4e-4a3b-8466-f5ffc597cfe1)
-  )
-  (junction (at 246.38 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c)
-  )
-  (junction (at 175.26 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 39869536-29f6-4e84-a33a-473fa8fb0f36)
-  )
-  (junction (at 185.42 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 3abcfbc6-0288-48d7-a0e0-144f99e6dd30)
-  )
-  (junction (at 144.78 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 3d987483-3b5e-44fb-b675-40705bf855c1)
-  )
-  (junction (at 134.62 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 3ddd9e62-5556-463c-9539-c0d582cc40e9)
-  )
-  (junction (at 43.18 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 4420dc63-3aee-4086-92ad-39d849507e61)
-  )
-  (junction (at 215.9 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 459e2fd2-0437-406d-b9bb-4b3872c36b3e)
-  )
-  (junction (at 205.74 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 4788fde7-f606-4229-8a7b-9fa04f56d3d4)
-  )
-  (junction (at 114.3 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 490a89d7-a161-4f1a-9b45-a55729d9d59b)
-  )
-  (junction (at 124.46 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4c74baef-72cb-4cdf-b4eb-a3d28782257d)
-  )
-  (junction (at 53.34 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 4c7a50e9-7650-493b-b0a7-057b900a13a7)
-  )
-  (junction (at 63.5 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9)
-  )
-  (junction (at 165.1 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 4df4e0a7-6e46-4c32-959d-094f3457d75b)
-  )
-  (junction (at 43.18 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 4e641ba8-cbcf-42cf-89f0-ac977902bf98)
-  )
-  (junction (at 73.66 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 4fc826ad-ef7b-406a-9b89-76eb2c211523)
-  )
-  (junction (at 53.34 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 4fce0301-62b3-4ef1-9bae-8d55ea745d66)
-  )
-  (junction (at 185.42 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 508ddd33-e065-44a5-a999-5944a523ef76)
-  )
-  (junction (at 175.26 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 50f2ad43-aa07-4fd1-8d58-f22d767da31f)
-  )
-  (junction (at 185.42 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 51c7f5d6-d0e7-40a3-b648-cddc977cf840)
-  )
-  (junction (at 195.58 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 51dbbda9-bf1e-445e-9a43-5f378a7d2f7f)
-  )
-  (junction (at 53.34 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 53bb27f5-9b54-4704-b90e-33b3053be6c4)
-  )
-  (junction (at 114.3 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 5b35d564-88c3-4b41-864f-a4f82bc4c871)
-  )
-  (junction (at 43.18 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 5bfc49c0-36f2-431c-81ea-cf78c71d7681)
-  )
-  (junction (at 215.9 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 609da949-dc88-4120-abd9-ca9d5f99505d)
-  )
-  (junction (at 83.82 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 6540c8f5-821c-412a-807a-c3ef62138fbb)
-  )
-  (junction (at 63.5 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 65600a9a-e392-4668-8020-aa25d35ebf98)
-  )
-  (junction (at 104.14 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 65f27e9a-164b-490a-b847-29af22012c0c)
-  )
-  (junction (at 63.5 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 670a793c-4c48-41d1-9f07-66b1d7d84b06)
-  )
-  (junction (at 83.82 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 672e2ce9-8f2c-43ff-9498-0e342bc1c65e)
-  )
-  (junction (at 215.9 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 6784984b-dd7d-4cfa-a87f-6cbcb1e61ab6)
-  )
-  (junction (at 175.26 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 69e63d66-faab-411c-9093-a81235a7547c)
-  )
-  (junction (at 63.5 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 6b0b87a9-8a81-4bd1-ac24-ffcd6512236b)
-  )
-  (junction (at 43.18 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6bfc7531-8adc-4c87-bf8a-788404262765)
-  )
-  (junction (at 134.62 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1)
-  )
-  (junction (at 154.94 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 6ff7fc69-ca50-4b66-851e-eb36da3cadd8)
-  )
-  (junction (at 63.5 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 712da204-b8e1-4637-b967-521ccf7b108c)
-  )
-  (junction (at 73.66 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 71e77471-d824-448e-a6de-31cce05e17c2)
-  )
-  (junction (at 205.74 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 72e4e912-d3a6-49dd-a5cd-3717c5b10d71)
-  )
-  (junction (at 73.66 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 742ecb41-f257-40d3-a6f3-d155d6036628)
-  )
-  (junction (at 226.06 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 77bb30a6-a1de-4dd1-a9f1-aff61d4e98ac)
-  )
-  (junction (at 93.98 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 782ee96d-a257-4c78-ac0f-a3b5279bef37)
-  )
-  (junction (at 53.34 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 7943e9ed-5e22-49d3-a238-47d875f3e823)
-  )
-  (junction (at 43.18 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 7dbcae2f-e000-4aff-92b3-5518ea113182)
-  )
-  (junction (at 104.14 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 822096c9-a5b4-460b-8639-9bbf1bb1a2fa)
-  )
-  (junction (at 93.98 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 84442e81-a253-49f6-ab0f-8ece0b39f637)
-  )
-  (junction (at 53.34 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 86d88f2b-6e5b-493a-b3a4-5436a8374fae)
-  )
-  (junction (at 104.14 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 88441b0d-9a40-4e18-8fc9-814cc1cb4d3e)
-  )
-  (junction (at 185.42 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 8a6c81db-4db5-4eb7-a06a-31575c90f62f)
-  )
-  (junction (at 83.82 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 8bf191a4-2dcd-4018-b67a-91aef9fad846)
-  )
-  (junction (at 144.78 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 8d88bb99-f0e4-4a81-b464-31814877675a)
-  )
-  (junction (at 195.58 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 8de5a888-7283-4e9f-99ef-73d74bb27108)
-  )
-  (junction (at 205.74 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 90d2cc8f-50ae-48a5-81ff-9df8ee53f514)
-  )
-  (junction (at 205.74 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 91635678-4449-4ed4-88c1-10b19deef1b0)
-  )
-  (junction (at 246.38 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 95b0c111-7d27-49ee-a08f-b6f35d9d5b54)
-  )
-  (junction (at 93.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 96a12dd2-d02f-4a86-aa6d-3a7015c06462)
-  )
-  (junction (at 195.58 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 98319cb9-c3ce-4829-b82f-df8af9cb7381)
-  )
-  (junction (at 134.62 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 99c67f58-7bde-4417-a08c-823e6af847f2)
-  )
-  (junction (at 93.98 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 9a57387e-9b4d-41d6-99cb-8b5046a4210a)
-  )
-  (junction (at 215.9 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 9b94e996-7198-48de-9ff9-0a29d6599658)
-  )
-  (junction (at 124.46 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9d2b0f02-b19d-4907-8835-9e7f8a8b9c34)
-  )
-  (junction (at 226.06 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 9e2bd5cb-7b23-4384-a3c5-2d4acf752984)
-  )
-  (junction (at 93.98 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid a2db7df7-b835-49df-98be-3c291238016c)
-  )
-  (junction (at 185.42 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid a3593416-7fea-415d-a48b-ed5f49c771b2)
-  )
-  (junction (at 114.3 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid a47737c8-d0f1-4d7f-a269-cdad9b41d18b)
-  )
-  (junction (at 63.5 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid a6cd881c-1146-4d92-9184-bf83a80c20c4)
-  )
-  (junction (at 165.1 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid a7400bf6-86c3-4d41-886e-57235a457a4c)
-  )
-  (junction (at 63.5 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid a77fc968-ce7b-41bf-ae47-af3789c36215)
-  )
-  (junction (at 165.1 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid a9baaad2-c62c-4b79-a10b-261651ef4961)
-  )
-  (junction (at 246.38 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid a9ece8f4-f868-428b-b7ff-a3dc07b47d6c)
-  )
-  (junction (at 144.78 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid aa4f9edb-d8b6-45e2-8d16-270f3c9fc990)
-  )
-  (junction (at 104.14 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid ab0811a2-347a-4a90-b4d0-f1b1ba038333)
-  )
-  (junction (at 195.58 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid ac27d187-5d39-4e20-a98d-006d06095529)
-  )
-  (junction (at 226.06 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid ac7cf2c1-f0eb-4f3a-bdfc-60426aa052ac)
-  )
-  (junction (at 124.46 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid b1e2ebf4-6a50-4b42-af1b-0294cfee2751)
-  )
-  (junction (at 83.82 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b23bc3a0-3ebe-44a5-9126-8b5c4d648e08)
-  )
-  (junction (at 205.74 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid b3d0ee10-bd96-4305-9675-c2f1f7a7662b)
-  )
-  (junction (at 114.3 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid b5ce3eda-e357-44e1-9c69-f84009fc7a87)
-  )
-  (junction (at 154.94 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid b7093823-b63a-4a1a-b279-5afe0127ec9d)
-  )
-  (junction (at 246.38 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b98759bc-77be-4dce-9aa2-cc5ce3889034)
-  )
-  (junction (at 154.94 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b995f4ca-5e8d-4350-aff6-b7bea568d7f5)
-  )
-  (junction (at 53.34 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3)
-  )
-  (junction (at 205.74 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bb9843d1-ea35-45a8-bd3d-5b381b0dc875)
-  )
-  (junction (at 175.26 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid bbd2fe65-aac5-437c-9177-9832921486d5)
-  )
-  (junction (at 175.26 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid bcf6a98c-2d79-4afb-9a5e-6558bb743cec)
-  )
-  (junction (at 226.06 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid bdaa210f-5df4-43b3-b2cb-9563b1c2f196)
-  )
-  (junction (at 154.94 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid be75ea2d-b3b9-4fd0-812b-104329fac661)
-  )
-  (junction (at 144.78 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid befc6138-873b-4406-bc9e-e5a72f7f36fe)
-  )
-  (junction (at 175.26 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid bf44b855-bf79-4ceb-a9a9-021d72c7f67c)
-  )
-  (junction (at 83.82 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0)
-  )
-  (junction (at 134.62 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid c29c26fc-c285-45ba-9e88-4c2a02375307)
-  )
-  (junction (at 165.1 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid c331d35d-23c9-43ea-b243-b660cb5f4bdb)
-  )
-  (junction (at 134.62 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid c3f1775c-0d63-41d3-b7d8-a4c96d241ce3)
-  )
-  (junction (at 93.98 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c41e97f8-87c8-4e82-92ed-e4644d6f526e)
-  )
-  (junction (at 124.46 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid c51de65b-dd06-4a71-8763-eab77eba6638)
-  )
-  (junction (at 246.38 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c56d20e0-377b-42bf-89fc-25b698ca10b4)
-  )
-  (junction (at 114.3 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c5afc93c-0846-4cf9-8f93-4c8f2232c9fa)
-  )
-  (junction (at 215.9 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c749e970-c6bb-4721-8468-39c6437ef420)
-  )
-  (junction (at 83.82 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid c7d88142-1b7e-4dd1-b026-f2267e06dab1)
-  )
-  (junction (at 43.18 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid c8f222f6-943e-4d7d-919b-3278ca0ede33)
-  )
-  (junction (at 195.58 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c9e3ffd4-a7b6-4729-8189-cdaba274ef13)
-  )
-  (junction (at 144.78 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cc2d9922-84c9-42ce-883b-c028a251c101)
-  )
-  (junction (at 246.38 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid cc477f6c-44d3-44d1-b104-0f5c17b8e6fa)
-  )
-  (junction (at 124.46 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid cd054c4e-f9d4-4701-a538-16740432e58d)
-  )
-  (junction (at 226.06 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cd48bbd4-ca90-4b55-bc6b-cf9da8cf6333)
-  )
-  (junction (at 195.58 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid cf841124-1985-4dfd-858c-868589098888)
-  )
-  (junction (at 63.5 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid cfd86ddc-0810-4057-8a79-4468ec7b2424)
-  )
-  (junction (at 205.74 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d07b66d1-3d51-4607-8fd1-974bbf8f9371)
-  )
-  (junction (at 53.34 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid d328f077-6d93-4470-a2b2-f4c9287daff0)
-  )
-  (junction (at 215.9 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid d36ca894-6805-484d-8f86-5039b03b9346)
-  )
-  (junction (at 205.74 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid d3f7612d-781e-42f5-a5f0-fe2744aa5d60)
-  )
-  (junction (at 144.78 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid d4ac21a4-2c41-454b-9f76-4f3d030f7ac8)
-  )
-  (junction (at 83.82 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid d5a179bd-82b1-4661-aebc-4c4d4801bdff)
-  )
-  (junction (at 144.78 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d5b7ef4f-419a-421c-a02d-fd71016e6c97)
-  )
-  (junction (at 154.94 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid d774ae68-7d44-45a8-babf-4a5136fe82a1)
-  )
-  (junction (at 185.42 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d8d69513-50ec-441c-a953-5a6c226b729f)
-  )
-  (junction (at 226.06 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid dc26fb26-3b4c-4f5f-8838-a826029b5e11)
-  )
-  (junction (at 195.58 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid dc8b09d2-1c55-4758-be69-6f8072d6abe0)
-  )
-  (junction (at 114.3 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid dcab5abe-0f5a-44d8-b554-722164ca6a23)
-  )
-  (junction (at 154.94 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid dded6bb5-453a-4491-9278-65d2368e4bc0)
-  )
-  (junction (at 93.98 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid dece07f3-2868-47c6-b119-0ca286e7cc50)
-  )
-  (junction (at 175.26 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid e3827bb6-d8e8-410a-8c19-3e64c8191b94)
-  )
-  (junction (at 154.94 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid e46432a2-96f1-448e-8928-bfcbbf445ca9)
-  )
-  (junction (at 215.9 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid e55cb9f7-7fdb-471f-8c22-7af22a3199f5)
-  )
-  (junction (at 175.26 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid e66342f0-16d5-4367-b00a-d7cf257720d9)
-  )
-  (junction (at 226.06 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid e7e968af-bf0e-4847-a623-74d007921b9f)
-  )
-  (junction (at 165.1 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid ed20875e-b9a5-4926-97e0-c3921a5eb1cd)
-  )
-  (junction (at 114.3 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid ee17efa1-5df9-47d0-aec2-a440d8b33e4c)
-  )
-  (junction (at 104.14 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid f0d84c95-52f0-41cd-8742-4de83021f783)
-  )
-  (junction (at 134.62 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid f1379b2f-59c4-4b61-a98f-3645b6e5fe6b)
-  )
-  (junction (at 104.14 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid f24e6016-cf0c-4fe9-b584-ca06dfdbe767)
-  )
-  (junction (at 134.62 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid f299a1cc-612f-4d6b-9276-fe837e4e91d9)
-  )
-  (junction (at 134.62 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid f368e14e-0af5-4e13-a581-f1a139c24e5c)
-  )
-  (junction (at 43.18 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid f6f817c6-438a-4497-93b1-8dc1f36a395c)
-  )
-  (junction (at 226.06 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid f70d9535-4e8c-4a08-92e9-2c160ff79eff)
-  )
-  (junction (at 53.34 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid f7606fcd-7602-4f5d-b31b-5fb97e1ca534)
-  )
-  (junction (at 124.46 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd)
-  )
-  (junction (at 144.78 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid f8b3b54a-7c03-49e4-8762-b4ef31db5afd)
-  )
-  (junction (at 246.38 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fa2795fd-0138-4010-b310-3d5e73c1be1c)
-  )
-  (junction (at 195.58 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid fb315348-48a4-4210-8623-991734f6ee66)
-  )
-  (junction (at 73.66 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fbda2010-a213-45bb-958d-0c9446d51e42)
-  )
-  (junction (at 73.66 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid fc393c80-fb90-44e5-ac86-763463fd8acd)
-  )
-  (junction (at 114.3 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid fc6abd7a-92c0-4b05-85ed-b3bd910676e1)
-  )
-  (junction (at 144.78 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid fdc0071f-cdad-424a-87db-7bd8a0569159)
-  )
-
-  (wire (pts (xy 83.82 60.96) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 022d84d0-7bcb-4024-8618-6f3a7f7b41aa)
-  )
-  (wire (pts (xy 144.78 25.4) (xy 144.78 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0406a358-3219-4537-99c7-cfb994e5303c)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0429bfe1-2992-4c6f-bb22-b2e8e5724910)
-  )
-  (wire (pts (xy 205.74 182.88) (xy 205.74 203.2))
-    (stroke (width 0) (type default))
-    (uuid 04f743f4-6844-43ab-a149-4db3a42e61b3)
-  )
-  (wire (pts (xy 185.42 203.2) (xy 185.42 223.52))
-    (stroke (width 0) (type default))
-    (uuid 054d0701-89e5-4918-a35c-1668152b63f2)
-  )
-  (wire (pts (xy 205.74 203.2) (xy 205.74 223.52))
-    (stroke (width 0) (type default))
-    (uuid 0698b251-ec3b-4a4c-821a-adad423d20ba)
-  )
-  (wire (pts (xy 185.42 162.56) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid 070c607f-224b-4963-a847-a5abbe4e2e9d)
-  )
-  (wire (pts (xy 73.66 109.22) (xy 93.98 109.22))
-    (stroke (width 0) (type default))
-    (uuid 07ee4d30-e80a-41ae-829d-e3cecf87d77e)
-  )
-  (wire (pts (xy 226.06 81.28) (xy 226.06 101.6))
-    (stroke (width 0) (type default))
-    (uuid 0805b235-8597-4158-8971-28b691867ce0)
-  )
-  (wire (pts (xy 114.3 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0897e94f-d1e3-47ff-89f6-5de7a1349783)
-  )
-  (wire (pts (xy 226.06 182.88) (xy 226.06 203.2))
-    (stroke (width 0) (type default))
-    (uuid 08999926-6e91-4cd1-80de-7963ec46f28b)
-  )
-  (wire (pts (xy 175.26 109.22) (xy 195.58 109.22))
-    (stroke (width 0) (type default))
-    (uuid 0a962d83-8897-42a2-883b-90f8b3b46e9e)
-  )
-  (wire (pts (xy 246.38 68.58) (xy 246.38 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0aee33c0-3781-43dc-99cb-690f399192cd)
-  )
-  (wire (pts (xy 154.94 48.26) (xy 175.26 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0b08be29-0149-48a5-b5a3-9614befb1784)
-  )
-  (wire (pts (xy 195.58 203.2) (xy 205.74 203.2))
-    (stroke (width 0) (type default))
-    (uuid 0bbfe73f-3f00-4157-8def-4fa012c6902e)
-  )
-  (wire (pts (xy 53.34 231.14) (xy 73.66 231.14))
-    (stroke (width 0) (type default))
-    (uuid 0cfcf878-b8da-4ac7-be72-6319dfc721fd)
-  )
-  (wire (pts (xy 43.18 182.88) (xy 43.18 203.2))
-    (stroke (width 0) (type default))
-    (uuid 0e0cdb3f-d11e-41fa-b224-dbdc3dd27130)
-  )
-  (wire (pts (xy 43.18 40.64) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0f76c070-bcf8-4924-a8c5-3abe13c36f41)
-  )
-  (wire (pts (xy 63.5 81.28) (xy 63.5 101.6))
-    (stroke (width 0) (type default))
-    (uuid 11ef6261-91ba-4d4c-99ef-8991b7c91dc8)
-  )
-  (wire (pts (xy 104.14 101.6) (xy 104.14 121.92))
-    (stroke (width 0) (type default))
-    (uuid 12080e73-a151-4804-ac9b-ac3ac13653e9)
-  )
-  (wire (pts (xy 73.66 48.26) (xy 93.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 12a939e2-2ab8-4d74-a5c9-6d61a9528b6e)
-  )
-  (wire (pts (xy 63.5 182.88) (xy 63.5 203.2))
-    (stroke (width 0) (type default))
-    (uuid 13961bb6-28aa-4ee0-a270-8bc7b0339a4b)
-  )
-  (wire (pts (xy 154.94 68.58) (xy 175.26 68.58))
-    (stroke (width 0) (type default))
-    (uuid 14d9635b-ccaf-4f8c-a2a6-101eb19eb42d)
-  )
-  (wire (pts (xy 134.62 210.82) (xy 154.94 210.82))
-    (stroke (width 0) (type default))
-    (uuid 150130ef-d28d-4782-b4fc-0c67b58e9b8e)
-  )
-  (wire (pts (xy 93.98 190.5) (xy 114.3 190.5))
-    (stroke (width 0) (type default))
-    (uuid 1767f007-bd12-458a-9e69-f01cc8a5ed24)
-  )
-  (wire (pts (xy 205.74 142.24) (xy 205.74 162.56))
-    (stroke (width 0) (type default))
-    (uuid 18ccb399-8ad2-4b42-b317-de1e9939e9e9)
-  )
-  (wire (pts (xy 104.14 25.4) (xy 104.14 40.64))
-    (stroke (width 0) (type default))
-    (uuid 1af5b449-9a68-414b-a41f-d6f6cba715a8)
-  )
-  (wire (pts (xy 165.1 203.2) (xy 165.1 223.52))
-    (stroke (width 0) (type default))
-    (uuid 1bc4e1a4-fd5a-4e45-a9b9-9fd07d45de91)
-  )
-  (wire (pts (xy 73.66 81.28) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 1c0140d1-6775-49db-9fd5-7ecf63ae1284)
-  )
-  (wire (pts (xy 114.3 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid 211f763f-7ef6-4fb5-98df-2e2ff37faa42)
-  )
-  (wire (pts (xy 215.9 190.5) (xy 238.76 190.5))
-    (stroke (width 0) (type default))
-    (uuid 21e9b220-b0aa-4b7e-876c-6512dad6a1e2)
-  )
-  (wire (pts (xy 63.5 40.64) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 23f46f84-f16d-4b0b-b463-c2c0244adcc0)
-  )
-  (wire (pts (xy 83.82 203.2) (xy 83.82 223.52))
-    (stroke (width 0) (type default))
-    (uuid 24025a56-ae5c-4c1a-a354-e66bbbcc4688)
-  )
-  (wire (pts (xy 33.02 129.54) (xy 53.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid 24da3fea-844d-4666-b730-f8d7b708f242)
-  )
-  (wire (pts (xy 185.42 40.64) (xy 185.42 60.96))
-    (stroke (width 0) (type default))
-    (uuid 265c8115-55ea-4d09-95c1-3178314bfa04)
-  )
-  (wire (pts (xy 53.34 129.54) (xy 73.66 129.54))
-    (stroke (width 0) (type default))
-    (uuid 26f78b89-ba4b-4b48-90d1-1245694ead6f)
-  )
-  (wire (pts (xy 83.82 162.56) (xy 83.82 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2703e5ce-9651-45e1-8bd6-144e60387b78)
-  )
-  (wire (pts (xy 33.02 109.22) (xy 53.34 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2832f642-62e7-4a51-b112-f728658e7714)
-  )
-  (wire (pts (xy 195.58 68.58) (xy 215.9 68.58))
-    (stroke (width 0) (type default))
-    (uuid 28f7b63d-6686-4459-afe8-f6dd162a4f81)
-  )
-  (wire (pts (xy 53.34 68.58) (xy 73.66 68.58))
-    (stroke (width 0) (type default))
-    (uuid 29a0e612-9a4c-422c-a9b8-8a9fe3879b8a)
-  )
-  (wire (pts (xy 215.9 149.86) (xy 238.76 149.86))
-    (stroke (width 0) (type default))
-    (uuid 29b6abf5-e762-402b-a7ef-754a71930101)
-  )
-  (wire (pts (xy 83.82 101.6) (xy 83.82 121.92))
-    (stroke (width 0) (type default))
-    (uuid 2a44e441-f6d5-4994-b7ba-34283a1facc7)
-  )
-  (wire (pts (xy 124.46 121.92) (xy 124.46 142.24))
-    (stroke (width 0) (type default))
-    (uuid 2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0)
-  )
-  (wire (pts (xy 114.3 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 2a65926a-d988-49f6-92e7-6e4d5936462f)
-  )
-  (wire (pts (xy 195.58 170.18) (xy 215.9 170.18))
-    (stroke (width 0) (type default))
-    (uuid 2ada3dc7-0276-4fb5-993b-c6f072f33b85)
-  )
-  (wire (pts (xy 165.1 162.56) (xy 165.1 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2afd7500-0a15-4710-acc0-4f03472785c3)
-  )
-  (wire (pts (xy 165.1 60.96) (xy 165.1 81.28))
-    (stroke (width 0) (type default))
-    (uuid 2b8c9def-eaec-4abd-b08a-c3613e6389df)
-  )
-  (wire (pts (xy 53.34 109.22) (xy 73.66 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd)
-  )
-  (wire (pts (xy 124.46 25.4) (xy 124.46 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3115f7a7-e786-49c1-9e4c-25c171cfeb33)
-  )
-  (wire (pts (xy 73.66 68.58) (xy 93.98 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3197b37c-ee5b-406a-ab67-08670d4b8c09)
-  )
-  (wire (pts (xy 215.9 223.52) (xy 226.06 223.52))
-    (stroke (width 0) (type default))
-    (uuid 331adf6b-edc7-41b1-8701-a50d3af94787)
-  )
-  (wire (pts (xy 165.1 182.88) (xy 165.1 203.2))
-    (stroke (width 0) (type default))
-    (uuid 335e6f69-208d-4946-a709-07b34240cbfe)
-  )
-  (wire (pts (xy 175.26 231.14) (xy 195.58 231.14))
-    (stroke (width 0) (type default))
-    (uuid 34d9b895-8709-4ae3-8234-e9c042dd7992)
-  )
-  (wire (pts (xy 154.94 88.9) (xy 175.26 88.9))
-    (stroke (width 0) (type default))
-    (uuid 35f5724f-e5dd-4205-b169-9ef9f7b3efa2)
-  )
-  (wire (pts (xy 195.58 149.86) (xy 215.9 149.86))
-    (stroke (width 0) (type default))
-    (uuid 38c60e5d-a6e0-4b17-9178-ac6efdd97384)
-  )
-  (wire (pts (xy 63.5 60.96) (xy 63.5 81.28))
-    (stroke (width 0) (type default))
-    (uuid 397f8ae6-f8de-4848-93b9-bc08977c0634)
-  )
-  (wire (pts (xy 53.34 60.96) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 39a93c24-4e85-400f-b634-4894827c3230)
-  )
-  (wire (pts (xy 246.38 210.82) (xy 246.38 231.14))
-    (stroke (width 0) (type default))
-    (uuid 3a9fab7b-7f53-4445-b1a0-755685a5b87b)
-  )
-  (wire (pts (xy 134.62 68.58) (xy 154.94 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3b15c81d-3687-4710-9aa6-d57ee4885603)
-  )
-  (wire (pts (xy 63.5 121.92) (xy 63.5 142.24))
-    (stroke (width 0) (type default))
-    (uuid 3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5)
-  )
-  (wire (pts (xy 114.3 190.5) (xy 134.62 190.5))
-    (stroke (width 0) (type default))
-    (uuid 3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb)
-  )
-  (wire (pts (xy 195.58 109.22) (xy 215.9 109.22))
-    (stroke (width 0) (type default))
-    (uuid 3d4e19e8-2fb5-4e22-930a-612c1a48f37c)
-  )
-  (wire (pts (xy 226.06 25.4) (xy 226.06 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3e8a4dda-891b-4819-a0ec-6d09bab41776)
-  )
-  (wire (pts (xy 154.94 231.14) (xy 175.26 231.14))
-    (stroke (width 0) (type default))
-    (uuid 3f7461c6-c2c3-4fe0-b1c0-d702c7e88622)
-  )
-  (wire (pts (xy 226.06 60.96) (xy 226.06 81.28))
-    (stroke (width 0) (type default))
-    (uuid 40278c5a-7892-4426-82ce-3b5f75d33db8)
-  )
-  (wire (pts (xy 73.66 170.18) (xy 93.98 170.18))
-    (stroke (width 0) (type default))
-    (uuid 40ad23e4-b284-4d51-a92e-26a2272af251)
-  )
-  (wire (pts (xy 165.1 121.92) (xy 165.1 142.24))
-    (stroke (width 0) (type default))
-    (uuid 411efa8a-c2b6-469e-b517-3b3f24ffe025)
-  )
-  (wire (pts (xy 73.66 190.5) (xy 93.98 190.5))
-    (stroke (width 0) (type default))
-    (uuid 432577d5-87d0-4924-a72a-e407dd2ee4b0)
-  )
-  (wire (pts (xy 134.62 170.18) (xy 154.94 170.18))
-    (stroke (width 0) (type default))
-    (uuid 44b0d7a3-542f-48ea-8a2f-25ca02bd7f05)
-  )
-  (wire (pts (xy 53.34 170.18) (xy 73.66 170.18))
-    (stroke (width 0) (type default))
-    (uuid 4554fe48-1b8d-466c-b3f4-c87fb3d79947)
-  )
-  (wire (pts (xy 43.18 60.96) (xy 43.18 81.28))
-    (stroke (width 0) (type default))
-    (uuid 456f0365-d37d-43a2-afac-d06c44cc48af)
-  )
-  (wire (pts (xy 154.94 129.54) (xy 175.26 129.54))
-    (stroke (width 0) (type default))
-    (uuid 462b3865-9668-49d6-a9d9-1406a843104e)
-  )
-  (wire (pts (xy 114.3 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid 473d672b-6459-459b-93fc-780e5d8f9818)
-  )
-  (wire (pts (xy 226.06 121.92) (xy 226.06 142.24))
-    (stroke (width 0) (type default))
-    (uuid 4905f532-fc39-4175-9bc0-d3b0b2aab86e)
-  )
-  (wire (pts (xy 124.46 81.28) (xy 124.46 101.6))
-    (stroke (width 0) (type default))
-    (uuid 495f9334-ca7f-4aa5-8d75-09576f1afa2c)
-  )
-  (wire (pts (xy 104.14 182.88) (xy 104.14 203.2))
-    (stroke (width 0) (type default))
-    (uuid 4bc89a8f-f8d9-4d47-a286-fb87f34a3ba1)
-  )
-  (wire (pts (xy 63.5 203.2) (xy 63.5 223.52))
-    (stroke (width 0) (type default))
-    (uuid 4d757dc1-e039-4666-8204-33ddd2c3d535)
-  )
-  (wire (pts (xy 165.1 81.28) (xy 165.1 101.6))
-    (stroke (width 0) (type default))
-    (uuid 50f7b113-f5f8-43e0-9da7-2a02dc224210)
-  )
-  (wire (pts (xy 246.38 190.5) (xy 246.38 210.82))
-    (stroke (width 0) (type default))
-    (uuid 5194f352-1f61-4ee5-af2e-f0eb341e3d13)
-  )
-  (wire (pts (xy 195.58 48.26) (xy 215.9 48.26))
-    (stroke (width 0) (type default))
-    (uuid 52932ef5-0b57-4b4e-99a0-5bd14e9f6829)
-  )
-  (wire (pts (xy 226.06 162.56) (xy 226.06 182.88))
-    (stroke (width 0) (type default))
-    (uuid 530fd8d7-df39-43ed-b05c-34496eb7d3a1)
-  )
-  (wire (pts (xy 33.02 190.5) (xy 53.34 190.5))
-    (stroke (width 0) (type default))
-    (uuid 55243e41-6164-4661-b707-a6f503f12968)
-  )
-  (wire (pts (xy 53.34 190.5) (xy 73.66 190.5))
-    (stroke (width 0) (type default))
-    (uuid 557847f5-42a8-4c4a-a4d9-d21678c28920)
-  )
-  (wire (pts (xy 104.14 60.96) (xy 104.14 81.28))
-    (stroke (width 0) (type default))
-    (uuid 5837ecd4-cf70-4c14-9c7b-bb5f05f8274a)
-  )
-  (wire (pts (xy 93.98 231.14) (xy 114.3 231.14))
-    (stroke (width 0) (type default))
-    (uuid 59384b6c-2072-4474-b0f7-71a68de7f080)
-  )
-  (wire (pts (xy 104.14 81.28) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid 5b6ae0de-21c8-4433-a4e0-a3b552474fb0)
-  )
-  (wire (pts (xy 154.94 190.5) (xy 175.26 190.5))
-    (stroke (width 0) (type default))
-    (uuid 5baecb37-4d65-4174-bd66-a5145576e2b9)
-  )
-  (wire (pts (xy 154.94 149.86) (xy 175.26 149.86))
-    (stroke (width 0) (type default))
-    (uuid 5bf40b1a-0569-4c54-9cc9-b9bf89658c72)
-  )
-  (wire (pts (xy 134.62 48.26) (xy 154.94 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5d63c1a3-5086-42ca-8afa-60afe2472b23)
-  )
-  (wire (pts (xy 93.98 210.82) (xy 114.3 210.82))
-    (stroke (width 0) (type default))
-    (uuid 5f73184b-d2cf-4b7b-afcf-f14e002f7ce1)
-  )
-  (wire (pts (xy 53.34 88.9) (xy 73.66 88.9))
-    (stroke (width 0) (type default))
-    (uuid 60b5d548-d07f-40b1-8e16-72d513f499f2)
-  )
-  (wire (pts (xy 124.46 203.2) (xy 124.46 223.52))
-    (stroke (width 0) (type default))
-    (uuid 62806607-b508-4eb1-86e9-30fc018db27c)
-  )
-  (wire (pts (xy 33.02 210.82) (xy 53.34 210.82))
-    (stroke (width 0) (type default))
-    (uuid 6329f5e0-c3e3-42c6-b639-2bebe7a40e8b)
-  )
-  (wire (pts (xy 195.58 210.82) (xy 215.9 210.82))
-    (stroke (width 0) (type default))
-    (uuid 63344b6a-026f-4395-b562-d9979a7e5b8f)
-  )
-  (wire (pts (xy 93.98 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6414e19f-a27a-435d-a47f-a63cba9086f1)
-  )
-  (wire (pts (xy 134.62 109.22) (xy 154.94 109.22))
-    (stroke (width 0) (type default))
-    (uuid 64344100-c91d-4b5c-a8eb-9406d47360dd)
-  )
-  (wire (pts (xy 154.94 109.22) (xy 175.26 109.22))
-    (stroke (width 0) (type default))
-    (uuid 650e246e-9637-4cff-aa82-0f918369ac6f)
-  )
-  (wire (pts (xy 33.02 68.58) (xy 53.34 68.58))
-    (stroke (width 0) (type default))
-    (uuid 68161b0c-a285-475d-a645-59648d12bc07)
-  )
-  (wire (pts (xy 134.62 149.86) (xy 154.94 149.86))
-    (stroke (width 0) (type default))
-    (uuid 690a405c-1ac3-4b57-a93b-778dda168d2c)
-  )
-  (wire (pts (xy 134.62 190.5) (xy 154.94 190.5))
-    (stroke (width 0) (type default))
-    (uuid 6b21e6c7-ab97-41de-aae4-339e943db88e)
-  )
-  (wire (pts (xy 134.62 231.14) (xy 154.94 231.14))
-    (stroke (width 0) (type default))
-    (uuid 6b5263f0-0631-4b01-9161-0e209326bf8d)
-  )
-  (wire (pts (xy 165.1 40.64) (xy 165.1 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc)
-  )
-  (wire (pts (xy 195.58 129.54) (xy 215.9 129.54))
-    (stroke (width 0) (type default))
-    (uuid 6de11233-64b7-40cd-8526-970a6c43cb30)
-  )
-  (wire (pts (xy 205.74 40.64) (xy 205.74 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6f1d74d1-18f8-4f5b-8c5d-e1587ab09b83)
-  )
-  (wire (pts (xy 246.38 149.86) (xy 246.38 170.18))
-    (stroke (width 0) (type default))
-    (uuid 6f77a68c-1e32-433a-820e-9683e6fd5e12)
-  )
-  (wire (pts (xy 205.74 162.56) (xy 205.74 182.88))
-    (stroke (width 0) (type default))
-    (uuid 7083b47b-e7bb-4169-bf41-06719234452e)
-  )
-  (wire (pts (xy 246.38 88.9) (xy 246.38 109.22))
-    (stroke (width 0) (type default))
-    (uuid 70c6e975-f457-4759-9791-1d1de45afbb3)
-  )
-  (wire (pts (xy 134.62 129.54) (xy 154.94 129.54))
-    (stroke (width 0) (type default))
-    (uuid 70f3f37d-4259-413e-b59a-babccfdc3a89)
-  )
-  (wire (pts (xy 43.18 121.92) (xy 43.18 142.24))
-    (stroke (width 0) (type default))
-    (uuid 727cc522-ef34-45d4-b711-997054ff0b37)
-  )
-  (wire (pts (xy 33.02 48.26) (xy 53.34 48.26))
-    (stroke (width 0) (type default))
-    (uuid 737596e8-f579-4b1f-aa71-a489d8ba56da)
-  )
-  (wire (pts (xy 93.98 149.86) (xy 114.3 149.86))
-    (stroke (width 0) (type default))
-    (uuid 770cc50c-0085-42e2-b068-cd0ae3b59919)
-  )
-  (wire (pts (xy 246.38 25.4) (xy 246.38 48.26))
-    (stroke (width 0) (type default))
-    (uuid 794205f1-2f7e-4200-b59c-c02481b0416f)
-  )
-  (wire (pts (xy 73.66 88.9) (xy 93.98 88.9))
-    (stroke (width 0) (type default))
-    (uuid 79a42c80-d7a4-4e03-9070-f9fff835a239)
-  )
-  (wire (pts (xy 33.02 40.64) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid 7a4231d0-fb4b-4c65-9cc1-75d3ed714150)
-  )
-  (wire (pts (xy 195.58 88.9) (xy 215.9 88.9))
-    (stroke (width 0) (type default))
-    (uuid 7c26a162-db98-4260-be20-c438c861d890)
-  )
-  (wire (pts (xy 185.42 142.24) (xy 185.42 162.56))
-    (stroke (width 0) (type default))
-    (uuid 7caa1de0-1c5d-4933-9515-38159a29c856)
-  )
-  (wire (pts (xy 104.14 203.2) (xy 104.14 223.52))
-    (stroke (width 0) (type default))
-    (uuid 8487a4c1-7c32-44ea-a841-69a619e14d61)
-  )
-  (wire (pts (xy 165.1 25.4) (xy 165.1 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8506f273-12d6-426d-910b-0c9eecbe3765)
-  )
-  (wire (pts (xy 134.62 88.9) (xy 154.94 88.9))
-    (stroke (width 0) (type default))
-    (uuid 86d6e974-6898-4932-91cb-e8a4c4c283b7)
-  )
-  (wire (pts (xy 215.9 88.9) (xy 238.76 88.9))
-    (stroke (width 0) (type default))
-    (uuid 8703162e-62ad-4314-bd1a-c51105c1574a)
-  )
-  (wire (pts (xy 104.14 162.56) (xy 104.14 182.88))
-    (stroke (width 0) (type default))
-    (uuid 8c3cf446-d0cc-4b1b-9218-75f38db02fb3)
-  )
-  (wire (pts (xy 215.9 129.54) (xy 238.76 129.54))
-    (stroke (width 0) (type default))
-    (uuid 8c43e497-1549-4f9e-8686-7a4351f1f35f)
-  )
-  (wire (pts (xy 53.34 210.82) (xy 73.66 210.82))
-    (stroke (width 0) (type default))
-    (uuid 8d25f923-67ff-47ea-9485-05bc5282bdab)
-  )
-  (wire (pts (xy 93.98 48.26) (xy 114.3 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8d73bae8-988b-435b-a882-ae9668b41d7e)
-  )
-  (wire (pts (xy 104.14 142.24) (xy 104.14 162.56))
-    (stroke (width 0) (type default))
-    (uuid 8dd624a1-3da3-42c1-929d-9366cd043e3d)
-  )
-  (wire (pts (xy 246.38 48.26) (xy 246.38 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8f339462-56e0-4361-9d9b-983c75fb21ef)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 53.34 88.9))
-    (stroke (width 0) (type default))
-    (uuid 909384ab-bc1c-47d8-a34d-c3d137febfc2)
-  )
-  (wire (pts (xy 124.46 101.6) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91eea887-ea8a-4221-ba92-e5ec1caacc4f)
-  )
-  (wire (pts (xy 215.9 48.26) (xy 238.76 48.26))
-    (stroke (width 0) (type default))
-    (uuid 93a432e7-b427-461e-ad5f-cc7bda1f8bc4)
-  )
-  (wire (pts (xy 124.46 142.24) (xy 124.46 162.56))
-    (stroke (width 0) (type default))
-    (uuid 94397688-ce0e-48d4-a59c-7257120bf834)
-  )
-  (wire (pts (xy 185.42 60.96) (xy 185.42 81.28))
-    (stroke (width 0) (type default))
-    (uuid 96776fa9-dbd1-46ef-91bd-e95f23cda112)
-  )
-  (wire (pts (xy 175.26 170.18) (xy 195.58 170.18))
-    (stroke (width 0) (type default))
-    (uuid 969acf2b-33fe-4e89-abf2-451f22e884f4)
-  )
-  (wire (pts (xy 205.74 101.6) (xy 205.74 121.92))
-    (stroke (width 0) (type default))
-    (uuid 97a65ef9-5994-4805-9e12-ca2b38a42461)
-  )
-  (wire (pts (xy 215.9 68.58) (xy 238.76 68.58))
-    (stroke (width 0) (type default))
-    (uuid 9a462111-1607-4c46-9a00-175a4d0331ab)
-  )
-  (wire (pts (xy 114.3 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 9c79c76c-a95b-401f-9edb-a06a0cceaa4b)
-  )
-  (wire (pts (xy 185.42 182.88) (xy 185.42 203.2))
-    (stroke (width 0) (type default))
-    (uuid 9d4fc90e-2670-42d9-b5a8-2138817fee8a)
-  )
-  (wire (pts (xy 53.34 48.26) (xy 73.66 48.26))
-    (stroke (width 0) (type default))
-    (uuid 9d5ec847-5716-4125-b40b-fdbd3a1587a7)
-  )
-  (wire (pts (xy 165.1 101.6) (xy 165.1 121.92))
-    (stroke (width 0) (type default))
-    (uuid 9f711890-a6d6-4440-8bc1-ed469cb6acc4)
-  )
-  (wire (pts (xy 83.82 182.88) (xy 83.82 203.2))
-    (stroke (width 0) (type default))
-    (uuid a0b86442-47da-481e-aac6-2c18430e056b)
-  )
-  (wire (pts (xy 93.98 101.6) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid a226d887-7662-4dbd-b58b-e683f5d85955)
-  )
-  (wire (pts (xy 114.3 231.14) (xy 134.62 231.14))
-    (stroke (width 0) (type default))
-    (uuid a2aaec3e-8eba-49bd-8096-322f6bbfda7c)
-  )
-  (wire (pts (xy 195.58 190.5) (xy 215.9 190.5))
-    (stroke (width 0) (type default))
-    (uuid a2f7e7c7-60d9-4682-87fe-fb69953ed6aa)
-  )
-  (wire (pts (xy 124.46 40.64) (xy 124.46 60.96))
-    (stroke (width 0) (type default))
-    (uuid a67c0815-f186-4f70-926f-1b264c84d8d8)
-  )
-  (wire (pts (xy 154.94 162.56) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid a803bbba-64cc-448d-a04f-7f03127ebddd)
-  )
-  (wire (pts (xy 226.06 101.6) (xy 226.06 121.92))
-    (stroke (width 0) (type default))
-    (uuid a8d4ba45-df5e-48fe-a1d7-c8d45db9b645)
-  )
-  (wire (pts (xy 53.34 149.86) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid aac914ea-c9a3-4a8f-94e1-1f91cdd136a3)
-  )
-  (wire (pts (xy 93.98 129.54) (xy 114.3 129.54))
-    (stroke (width 0) (type default))
-    (uuid ab578e4e-a4bf-4ab4-80fc-d97d4aea6370)
-  )
-  (wire (pts (xy 215.9 170.18) (xy 238.76 170.18))
-    (stroke (width 0) (type default))
-    (uuid ab5a382d-ce16-4f08-a729-c04a9ee1a1bc)
-  )
-  (wire (pts (xy 114.3 210.82) (xy 134.62 210.82))
-    (stroke (width 0) (type default))
-    (uuid abd1d27d-b9d9-4cf6-b486-65a2a8efef41)
-  )
-  (wire (pts (xy 175.26 88.9) (xy 195.58 88.9))
-    (stroke (width 0) (type default))
-    (uuid acc95df4-5464-4718-a58a-e43a56e1893a)
-  )
-  (wire (pts (xy 83.82 121.92) (xy 83.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73)
-  )
-  (wire (pts (xy 175.26 48.26) (xy 195.58 48.26))
-    (stroke (width 0) (type default))
-    (uuid adf35dfa-3831-4e3a-9fdd-7a4ac7f5230d)
-  )
-  (wire (pts (xy 93.98 68.58) (xy 114.3 68.58))
-    (stroke (width 0) (type default))
-    (uuid aea6a633-b213-403d-b447-42d91d3ab4da)
-  )
-  (wire (pts (xy 175.26 68.58) (xy 195.58 68.58))
-    (stroke (width 0) (type default))
-    (uuid b2797b5c-16d1-4c35-814c-4b30f0a6683b)
-  )
-  (wire (pts (xy 114.3 170.18) (xy 134.62 170.18))
-    (stroke (width 0) (type default))
-    (uuid b3e14390-7dc6-416b-bbd5-cdf868192ca4)
-  )
-  (wire (pts (xy 73.66 129.54) (xy 93.98 129.54))
-    (stroke (width 0) (type default))
-    (uuid b3f6f053-44f0-4391-9873-b6231b8014db)
-  )
-  (wire (pts (xy 154.94 210.82) (xy 175.26 210.82))
-    (stroke (width 0) (type default))
-    (uuid b78fdc14-2c27-4eca-a54c-9e333096c8b6)
-  )
-  (wire (pts (xy 144.78 101.6) (xy 144.78 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7b2475f-30dc-4ea2-b799-96c21242154c)
-  )
-  (wire (pts (xy 175.26 210.82) (xy 195.58 210.82))
-    (stroke (width 0) (type default))
-    (uuid b7c3f0e9-4787-4050-9c72-cdbaf3e08cfe)
-  )
-  (wire (pts (xy 83.82 81.28) (xy 83.82 101.6))
-    (stroke (width 0) (type default))
-    (uuid b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5)
-  )
-  (wire (pts (xy 246.38 170.18) (xy 246.38 190.5))
-    (stroke (width 0) (type default))
-    (uuid ba045c1c-f33c-4ee8-bfe6-db2af30446e4)
-  )
-  (wire (pts (xy 43.18 101.6) (xy 43.18 121.92))
-    (stroke (width 0) (type default))
-    (uuid bb49a3de-620b-45ad-a54c-29dcceaf0796)
-  )
-  (wire (pts (xy 144.78 121.92) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid bf12198a-9e62-45c3-b466-f5d86de75219)
-  )
-  (wire (pts (xy 73.66 210.82) (xy 93.98 210.82))
-    (stroke (width 0) (type default))
-    (uuid c007dc03-0700-44f8-b7e3-69868fe31a12)
-  )
-  (wire (pts (xy 205.74 60.96) (xy 205.74 81.28))
-    (stroke (width 0) (type default))
-    (uuid c0bbd51b-0041-4026-a546-37b4ba305884)
-  )
-  (wire (pts (xy 63.5 25.4) (xy 63.5 40.64))
-    (stroke (width 0) (type default))
-    (uuid c1a940de-fa49-4106-a8b9-697952eec2a2)
-  )
-  (wire (pts (xy 104.14 121.92) (xy 104.14 142.24))
-    (stroke (width 0) (type default))
-    (uuid c298ba49-6974-4340-859f-5d5a2b4132ff)
-  )
-  (wire (pts (xy 124.46 182.88) (xy 124.46 203.2))
-    (stroke (width 0) (type default))
-    (uuid c3555de4-415f-4041-a3dd-bd91effa102c)
-  )
-  (wire (pts (xy 175.26 182.88) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid c3f1f747-e966-4c2c-8090-4f190e07864a)
-  )
-  (wire (pts (xy 215.9 210.82) (xy 238.76 210.82))
-    (stroke (width 0) (type default))
-    (uuid c47e1aaa-477d-4221-9341-1084abdcfc96)
-  )
-  (wire (pts (xy 124.46 162.56) (xy 124.46 182.88))
-    (stroke (width 0) (type default))
-    (uuid c6080a0e-4059-4120-b2e7-12c9aff607b7)
-  )
-  (wire (pts (xy 215.9 231.14) (xy 238.76 231.14))
-    (stroke (width 0) (type default))
-    (uuid c722c2d7-b406-487d-93db-8a7895592b31)
-  )
-  (wire (pts (xy 124.46 60.96) (xy 124.46 81.28))
-    (stroke (width 0) (type default))
-    (uuid c950d145-c024-47a8-ba57-97efd7bb658b)
-  )
-  (wire (pts (xy 175.26 149.86) (xy 195.58 149.86))
-    (stroke (width 0) (type default))
-    (uuid ca3290da-38da-422f-ab90-d843d9ab6e32)
-  )
-  (wire (pts (xy 144.78 142.24) (xy 144.78 162.56))
-    (stroke (width 0) (type default))
-    (uuid ca92ed7f-ae97-4c0c-81e4-820de1c001c1)
-  )
-  (wire (pts (xy 246.38 109.22) (xy 246.38 129.54))
-    (stroke (width 0) (type default))
-    (uuid cdde081d-7bdd-42e6-869e-3ff07b8b464b)
-  )
-  (wire (pts (xy 185.42 121.92) (xy 185.42 142.24))
-    (stroke (width 0) (type default))
-    (uuid cee2f4f4-6cbc-4838-b71a-3189173bbcfe)
-  )
-  (wire (pts (xy 83.82 40.64) (xy 83.82 60.96))
-    (stroke (width 0) (type default))
-    (uuid cff15ec3-f29c-4d36-8776-64c5d29be534)
-  )
-  (wire (pts (xy 83.82 25.4) (xy 83.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid d1088709-a9b9-4e05-8ea2-f87942ee2796)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 93.98 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1347903-ae03-46a2-a707-154093060583)
-  )
-  (wire (pts (xy 195.58 231.14) (xy 215.9 231.14))
-    (stroke (width 0) (type default))
-    (uuid d212462e-72b0-4fc0-81a2-e9aa2cbc9694)
-  )
-  (wire (pts (xy 144.78 40.64) (xy 144.78 60.96))
-    (stroke (width 0) (type default))
-    (uuid d2183fb3-afd3-46ca-955e-993ea31aa5d3)
-  )
-  (wire (pts (xy 185.42 25.4) (xy 185.42 40.64))
-    (stroke (width 0) (type default))
-    (uuid d2951d7e-82c5-4b56-9a90-ca8ae6d71e44)
-  )
-  (wire (pts (xy 205.74 25.4) (xy 205.74 40.64))
-    (stroke (width 0) (type default))
-    (uuid d4107bae-81df-4028-a211-ea4ab3232bfc)
-  )
-  (wire (pts (xy 226.06 142.24) (xy 226.06 162.56))
-    (stroke (width 0) (type default))
-    (uuid d4fda796-f5de-4013-bf1e-6a92a02b00f9)
-  )
-  (wire (pts (xy 43.18 162.56) (xy 43.18 182.88))
-    (stroke (width 0) (type default))
-    (uuid d56982aa-6580-4d04-83ea-6bf3a85282cc)
-  )
-  (wire (pts (xy 185.42 101.6) (xy 185.42 121.92))
-    (stroke (width 0) (type default))
-    (uuid d675b927-bdff-4eac-82e7-3f468caedaf2)
-  )
-  (wire (pts (xy 43.18 142.24) (xy 43.18 162.56))
-    (stroke (width 0) (type default))
-    (uuid d76ad758-0ae0-4ce6-9f67-c689c066c744)
-  )
-  (wire (pts (xy 144.78 182.88) (xy 144.78 203.2))
-    (stroke (width 0) (type default))
-    (uuid d8747c5c-1650-4a8e-b6a0-4fa4acd098ae)
-  )
-  (wire (pts (xy 205.74 81.28) (xy 205.74 101.6))
-    (stroke (width 0) (type default))
-    (uuid d920ca82-8ad7-4105-a47d-6c01f55c13d9)
-  )
-  (wire (pts (xy 33.02 149.86) (xy 53.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid da80b027-904b-4ca2-99c6-5937c80c825c)
-  )
-  (wire (pts (xy 63.5 142.24) (xy 63.5 162.56))
-    (stroke (width 0) (type default))
-    (uuid db492971-48ff-4667-996c-f5d540a20741)
-  )
-  (wire (pts (xy 205.74 121.92) (xy 205.74 142.24))
-    (stroke (width 0) (type default))
-    (uuid dc91af22-52c4-4234-961f-adc3ed363a9c)
-  )
-  (wire (pts (xy 165.1 142.24) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid dccfde3a-ff1d-42ec-97d5-a8f6cccea832)
-  )
-  (wire (pts (xy 33.02 170.18) (xy 53.34 170.18))
-    (stroke (width 0) (type default))
-    (uuid de8e54c6-84d9-47e5-8f08-dc3e96b8afdb)
-  )
-  (wire (pts (xy 43.18 81.28) (xy 43.18 101.6))
-    (stroke (width 0) (type default))
-    (uuid df5c3763-e66c-46c4-9070-0f73d8115bc4)
-  )
-  (wire (pts (xy 246.38 129.54) (xy 246.38 149.86))
-    (stroke (width 0) (type default))
-    (uuid dfb5a082-e4d5-46ea-8dc8-c65064cd598b)
-  )
-  (wire (pts (xy 226.06 203.2) (xy 226.06 223.52))
-    (stroke (width 0) (type default))
-    (uuid e006a777-74b0-4f5f-bb4c-3ab7b31924c0)
-  )
-  (wire (pts (xy 93.98 170.18) (xy 114.3 170.18))
-    (stroke (width 0) (type default))
-    (uuid e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb)
-  )
-  (wire (pts (xy 144.78 81.28) (xy 144.78 101.6))
-    (stroke (width 0) (type default))
-    (uuid e444742a-24b1-4bbf-b7ee-438e6dffc9cc)
-  )
-  (wire (pts (xy 175.26 190.5) (xy 195.58 190.5))
-    (stroke (width 0) (type default))
-    (uuid e5e38d44-8bf0-426b-a99f-727527ca9657)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid e6d06035-ccb7-4d3e-ae70-d73150e65bbb)
-  )
-  (wire (pts (xy 114.3 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa)
-  )
-  (wire (pts (xy 63.5 101.6) (xy 63.5 121.92))
-    (stroke (width 0) (type default))
-    (uuid edeeb0d9-51cc-411d-aac4-77f10b619702)
-  )
-  (wire (pts (xy 43.18 203.2) (xy 43.18 223.52))
-    (stroke (width 0) (type default))
-    (uuid ee312ce0-2ae6-4337-8d15-666961b7d179)
-  )
-  (wire (pts (xy 154.94 170.18) (xy 175.26 170.18))
-    (stroke (width 0) (type default))
-    (uuid ee36c21a-970c-453e-93f8-ab4961c20f44)
-  )
-  (wire (pts (xy 104.14 40.64) (xy 104.14 60.96))
-    (stroke (width 0) (type default))
-    (uuid ef5c9f05-d71b-4562-9939-852432c066c5)
-  )
-  (wire (pts (xy 144.78 162.56) (xy 144.78 182.88))
-    (stroke (width 0) (type default))
-    (uuid efa47227-d3f9-4214-af64-a7e9107c0edb)
-  )
-  (wire (pts (xy 144.78 203.2) (xy 144.78 223.52))
-    (stroke (width 0) (type default))
-    (uuid f09677ca-cfdb-4119-9431-13dd6580ce71)
-  )
-  (wire (pts (xy 144.78 60.96) (xy 144.78 81.28))
-    (stroke (width 0) (type default))
-    (uuid f0ce7c2b-d80c-49f2-bf63-62b750f7ca47)
-  )
-  (wire (pts (xy 73.66 231.14) (xy 93.98 231.14))
-    (stroke (width 0) (type default))
-    (uuid f2cc3c58-efff-41fa-a09a-222ad0afe609)
-  )
-  (wire (pts (xy 63.5 162.56) (xy 63.5 182.88))
-    (stroke (width 0) (type default))
-    (uuid f5658dea-a5b6-4ba9-9360-11c3315c15be)
-  )
-  (wire (pts (xy 134.62 142.24) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid f781a362-e0d4-48be-9d13-5686e05b406f)
-  )
-  (wire (pts (xy 215.9 109.22) (xy 238.76 109.22))
-    (stroke (width 0) (type default))
-    (uuid f8283c82-a0d8-4f0c-bd6f-e9575336c7df)
-  )
-  (wire (pts (xy 33.02 231.14) (xy 53.34 231.14))
-    (stroke (width 0) (type default))
-    (uuid f8f8e54e-33a9-4d2a-b35e-9b373b3563c7)
-  )
-  (wire (pts (xy 175.26 129.54) (xy 195.58 129.54))
-    (stroke (width 0) (type default))
-    (uuid f940918e-7aa4-499c-8be1-c536835b2ed6)
-  )
-  (wire (pts (xy 226.06 40.64) (xy 226.06 60.96))
-    (stroke (width 0) (type default))
-    (uuid fa54e42a-1d6a-433e-bb23-df8ec8cd3dca)
-  )
-  (wire (pts (xy 43.18 25.4) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid fa765e67-a220-4a00-944c-7663298f0ead)
-  )
-  (wire (pts (xy 83.82 142.24) (xy 83.82 162.56))
-    (stroke (width 0) (type default))
-    (uuid fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b)
-  )
-  (wire (pts (xy 185.42 81.28) (xy 185.42 101.6))
-    (stroke (width 0) (type default))
-    (uuid ffe6085a-a7be-4653-b911-c10de4574454)
-  )
-
-  (global_label "IO 3" (shape bidirectional) (at 104.14 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 24ec698b-5cae-4571-b9c4-c0e35d64a64d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 104.14 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 1" (shape bidirectional) (at 63.5 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2d4b15a5-8b6c-4ca3-a7bb-7848c8036590)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 63.5 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 9" (shape bidirectional) (at 226.06 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 388f2ae3-3697-4b0d-bb82-8cc7f8e58abf)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 226.06 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 7" (shape bidirectional) (at 185.42 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 45d4e03e-6cff-41ce-b946-708382da0601)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 185.42 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 0" (shape bidirectional) (at 43.18 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 465a517d-f0e1-4825-8675-1cce54bfa7a5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 43.18 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "INTR" (shape bidirectional) (at 246.38 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4e12b932-2346-4e84-b5a4-80468334f3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 254.57 25.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "IO 2" (shape bidirectional) (at 83.82 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 70d42e66-a74c-4de2-af96-d1860851d3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 83.82 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 165.1 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 89461221-a936-49a3-bf5d-18ec120f3e0c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 165.1 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 144.78 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d44cceb0-f409-4e5f-a98a-9feead2e845d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 8" (shape bidirectional) (at 205.74 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid e036ec60-274a-4de6-9324-dafd5b920142)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 205.74 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 4" (shape bidirectional) (at 124.46 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f36f49e4-227f-479f-b914-786aa44dd568)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 124.46 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 190.5 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0188dba3-054f-4958-9440-27c9ca673633)
-    (property "Reference" "DI7" (at 242.57 186.69 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 193.04 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid deea1889-824f-4f7a-a6be-9546db353c85))
-    (pin "2" (uuid 2080be86-a538-40a8-8f30-ead2a96d02d3))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0263b847-a932-4a31-9f35-35bb23f7000d)
-    (property "Reference" "D62" (at 152.4 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc2e60ca-c74f-4e4b-a0a0-9705327e9578))
-    (pin "2" (uuid d12efbfe-85ac-442f-8c0f-ddbe5646c7d5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D62") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 64.77 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 04430572-8314-4d21-974c-22350cead1a6)
-    (property "Reference" "DS1" (at 55.88 65.405 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 55.88 62.865 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e433df4-9fec-4cfb-b60f-eebca7c574cf))
-    (pin "2" (uuid 9bcc1487-0612-4bdb-a2de-a8b2f590b28f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 44.45 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080aaa87-0974-4a77-bf63-185495f411a0)
-    (property "Reference" "DS0" (at 35.56 45.085 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 35.56 42.545 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bfacad1-28fd-4f2e-93dc-68f478b8a6ba))
-    (pin "2" (uuid 376f73f9-79fa-4153-ae38-31ed5446db52))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09606075-7d6f-4679-9228-3a303ca4f40c)
-    (property "Reference" "RC9-1" (at 220.98 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f5b128f-eb55-44dc-974a-3ac8a1869c2d))
-    (pin "2" (uuid 9783c397-46c8-4a54-ad23-28d37f071b25))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09d14922-c46a-4bf1-bb2c-1d224060568c)
-    (property "Reference" "D40" (at 111.76 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2f1a1d2-df3d-4680-9706-2ca411fa6890))
-    (pin "2" (uuid f58fd788-6016-46e7-b903-3606dd2ec21d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D40") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 149.86 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0d18473f-e37a-4136-b721-5a2e40e4f8ed)
-    (property "Reference" "DI5" (at 242.57 146.05 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 152.4 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d5a885ca-5076-44e6-9a84-d07474947dde))
-    (pin "2" (uuid 047b5b54-de8b-4afc-abc2-c6d1f2d17bd2))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 170.18 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0ef17723-f7f8-4fdb-8913-5a4ceefbc065)
-    (property "Reference" "DI6" (at 242.57 166.37 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 172.72 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df5a6b10-ba48-4f34-96ce-3832d480a7ee))
-    (pin "2" (uuid 59f34a55-6ac4-496d-8c40-1b8f1eafbcb5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0f5e4226-91a2-4a41-9aae-518534f05932)
-    (property "Reference" "RC7-9" (at 180.34 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e144b30-8fd2-4ccc-b8e5-b1ca3fb409ba))
-    (pin "2" (uuid 0e4a0bb0-3e0e-44e1-9c80-03f9a9aa8952))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0fadd319-be81-4c25-8d23-e7495a114aa7)
-    (property "Reference" "RC4-0" (at 119.38 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid efb1c47f-fe25-4bea-8081-43d3c19de5cd))
-    (pin "2" (uuid 9138c970-6e3d-46df-9354-5174df2a4e52))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ff76361-9578-4f9f-a20c-f042e24a7755)
-    (property "Reference" "D5" (at 30.48 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06))
-    (pin "2" (uuid cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 11f01cd8-f751-497f-9599-50fe1fc0a618)
-    (property "Reference" "RC5-4" (at 139.7 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc28293-fab9-4f93-b3d5-ca9ee69110c4))
-    (pin "2" (uuid 088ac770-af1e-4c4f-ad11-5b44a20594d8))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 13ddd48d-7d2b-415d-b8fa-15c71e245acc)
-    (property "Reference" "D61" (at 152.4 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 745d89b9-e75a-40ae-97bc-d1eadf220f02))
-    (pin "2" (uuid 7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D61") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 17d027e3-2b58-470b-9fc5-f21e547cdc82)
-    (property "Reference" "RC8-1" (at 200.66 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7f893b29-9b1f-44b8-bac5-e11991e6b604))
-    (pin "2" (uuid 6b5e04e4-6889-4e49-9600-35d15ee54578))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 19f0de4f-d7ab-4f51-9796-79808aba650f)
-    (property "Reference" "D97" (at 213.36 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ad12892f-d26f-4434-82fd-3de2937c1d41))
-    (pin "2" (uuid 8b061bcb-2b37-4d89-bd19-fcd574e79f03))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D97") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1b13866a-6fbf-441b-9c64-56258379f43a)
-    (property "Reference" "D65" (at 152.4 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c70f4670-9685-4aab-ac4f-4ebaf44d5847))
-    (pin "2" (uuid 8b9c860d-59e1-424e-a148-1aa2c0db4056))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D65") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a)
-    (property "Reference" "RC6-4" (at 160.02 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3427b432-e194-40af-9dcb-04dccafe2b0f))
-    (pin "2" (uuid 8af48a1b-2c49-47d9-959c-ee33cdd6f977))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d4decb6-e690-4f06-b8aa-6dd29b7f2622)
-    (property "Reference" "D58" (at 132.08 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0a89d11-f9ed-4dad-a764-70b931421ce9))
-    (pin "2" (uuid e072fab0-4e83-437a-8387-943f8bcc1213))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D58") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1e5f084d-4db5-48ad-a2a3-76f186559614)
-    (property "Reference" "RC3-1" (at 99.06 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa))
-    (pin "2" (uuid 40b7f115-b5d7-4fa0-b12b-c1c7b6866feb))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 210.82 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 210fa303-e6c4-43b3-8ff0-f2f9178c950d)
-    (property "Reference" "DI8" (at 242.57 207.01 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 213.36 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cad82d1c-a62b-40c6-a2ae-61d28ed2d913))
-    (pin "2" (uuid ca0c8c70-cbfc-4421-833b-b58ab5f50511))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 213aaf81-8580-4880-9130-4c9d596a7095)
-    (property "Reference" "D90" (at 213.36 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 441dc052-fc8b-4f81-9c35-f08ea1ca4cf5))
-    (pin "2" (uuid b7690702-7874-4b26-89ba-a175fce3360b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D90") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 213dd8be-31f7-488d-b5dc-6770d78fccd5)
-    (property "Reference" "RC9-6" (at 220.98 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 593996ed-485e-495f-9d29-6951be77f078))
-    (pin "2" (uuid fa5ec1f4-4786-4d7c-9bb1-ab1ce7ad3038))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 22a72d93-d5b5-4a6b-95f6-755ac10ccf50)
-    (property "Reference" "RC4-7" (at 119.38 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 18c97ab1-62df-42bc-9dfa-dba3415ee8e2))
-    (pin "2" (uuid ff0eb9a3-538a-4ebf-a42b-97fe870ddfea))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 244b7f9d-3923-4908-be6d-02c49eb4663c)
-    (property "Reference" "RC2-3" (at 78.74 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d79440a-2f90-4c0b-8d60-528615b0bd65))
-    (pin "2" (uuid 7f1d0566-f385-4126-b190-2379308ed05b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 166.37 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2518146c-59f4-45b7-a4fa-f618686ab064)
-    (property "Reference" "DS6" (at 157.48 167.005 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 157.48 164.465 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cee2f461-8f62-48d8-ac7b-1698deb984c1))
-    (pin "2" (uuid 460b9088-619c-4166-a615-45e17ecf1f0d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2519cd5e-8ecf-41a4-a9d0-5b856882cb05)
-    (property "Reference" "D63" (at 152.4 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ea1c9827-ebfa-43f1-b2c6-5a572466713e))
-    (pin "2" (uuid 0496ba9c-818c-4d39-979a-e8785e06d12a))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D63") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 28137b00-0d76-493b-92b8-23037474163f)
-    (property "Reference" "RC1-3" (at 58.42 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3))
-    (pin "2" (uuid 41d35b0f-21b5-4da8-92df-229c816b63c5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2a208574-f638-4917-a68f-bc3ff176d324)
-    (property "Reference" "D75" (at 172.72 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 503e8179-7a4a-4075-8fcf-2d7bb00a3908))
-    (pin "2" (uuid a744b0f2-49c4-46a7-9ec2-cefb21173879))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D75") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c50947a-4bb9-43c2-b65c-4726e224b6b0)
-    (property "Reference" "RC3-0" (at 99.06 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b))
-    (pin "2" (uuid 30241adf-a2e7-4976-a53a-5c267616618e))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2cd8f716-5a6b-4cee-ad2e-612d075ffebf)
-    (property "Reference" "RC5-9" (at 139.7 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f37bc637-a5fa-420e-ae7d-11681e40308a))
-    (pin "2" (uuid 97b6ff47-ae10-45e9-81f0-a4902039b249))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2e38accc-5291-44a5-82e8-9bec928b99c0)
-    (property "Reference" "D18" (at 50.8 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20ca8cf6-b241-4581-b5e1-dadf97a2cf3f))
-    (pin "2" (uuid dc0b457e-4296-4b82-a953-b255f1e09c5c))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D18") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2f872c45-59ae-4f02-abee-114e38b97a80)
-    (property "Reference" "D87" (at 193.04 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4139db20-9977-4a84-b30c-e04c47ec888a))
-    (pin "2" (uuid bdc078b6-22f8-427e-a1f3-872c3722a746))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D87") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30340eba-9ed0-42ff-b11f-98a864f7223e)
-    (property "Reference" "RC1-4" (at 58.42 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aa956a67-c26e-4a57-9ddb-59688a6476ad))
-    (pin "2" (uuid 23cd0d93-5050-40ea-9d49-879bbcbb8bcd))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30b60f6a-8d20-44dd-b832-1906a957c513)
-    (property "Reference" "D54" (at 132.08 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c2ad1a4-b254-49a0-8435-d3a374353ffc))
-    (pin "2" (uuid 27a3cb64-baf1-430a-b797-bd52c0e46cbe))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D54") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 310fec10-f10c-41d7-9446-87c12744e146)
-    (property "Reference" "D26" (at 71.12 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e1d524d3-5d24-4c87-b480-74c57a74b567))
-    (pin "2" (uuid c0e9aa05-6318-4fdc-abee-cb43875c8e46))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D26") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35827986-7004-4f70-a10a-6ceb42f33d9f)
-    (property "Reference" "RC1-2" (at 58.42 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 879d3b07-b41e-4233-b196-e223f635bdf3))
-    (pin "2" (uuid 641f8ea7-6306-4550-92c8-e3cc0ed3e5a5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3598234f-e6ed-4eb6-b25a-52bde6e19729)
-    (property "Reference" "D82" (at 193.04 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f8d7980-fcb9-49ec-8704-044fa4175b07))
-    (pin "2" (uuid e2992df7-1f75-4c2b-bd16-ce868f4adf82))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D82") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 369ff51e-db51-4132-aa26-7b5d981cba74)
-    (property "Reference" "D17" (at 50.8 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9b5adb2f-c180-494e-86cd-ef0a68591be2))
-    (pin "2" (uuid 24774a87-3207-4ab9-a94d-2b9e1b568e65))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D17") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 37da2014-affc-4731-b642-c4245ff411f2)
-    (property "Reference" "RC5-7" (at 139.7 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ac410347-ba8b-493b-832e-a3f9e3359951))
-    (pin "2" (uuid 4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976)
-    (property "Reference" "D43" (at 111.76 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7d6fb6c4-b36c-4ff1-879b-43826c273a72))
-    (pin "2" (uuid 198c65f6-b3df-4780-9f6d-1c910e870a1b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D43") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3a9b19be-43ef-409c-9489-c069efbfa3ee)
-    (property "Reference" "RC0-7" (at 38.1 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 898cdd62-8ad6-4d58-b6f7-f4db79a4cca2))
-    (pin "2" (uuid 277b2226-c100-403c-a519-ef9cdc3923fe))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ac53e86-aa26-4394-9e99-e33f3c863b14)
-    (property "Reference" "RC7-1" (at 180.34 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e6efb38c-f391-43d6-9511-8c7da50b3d51))
-    (pin "2" (uuid 03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ad37b9b-353e-40fc-ac40-f5195f3dc605)
-    (property "Reference" "RC1-8" (at 58.42 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3efa7b0a-a125-48e1-96a0-b756f7dea902))
-    (pin "2" (uuid e99d0060-9d73-4fee-8521-d18593d0656b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef0222e-2eac-4930-ac36-0f395f4593b6)
-    (property "Reference" "RC1-0" (at 58.42 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f0b9b8-9322-4d89-a423-dd3d807d99ff))
-    (pin "2" (uuid ce54609e-9d1d-4a3b-81a2-5a384dbe41c8))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef86e49-a152-4515-afb0-4098f497c742)
-    (property "Reference" "D31" (at 91.44 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a))
-    (pin "2" (uuid b917ad78-96a8-428f-ad4f-d49149b5b97b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D31") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 402f0f46-5eb8-421b-9b9f-01a54b5cfa87)
-    (property "Reference" "RC4-1" (at 119.38 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cb206c0-1fab-4ac5-b301-f9678369525b))
-    (pin "2" (uuid b99c2ecc-04a5-4c54-a491-d99fe2562dcc))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 40d8058d-714e-4f99-a508-f64f9c8b575b)
-    (property "Reference" "D60" (at 152.4 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 66710233-d2ab-4921-aa86-488ee87fbb3a))
-    (pin "2" (uuid a9636da9-222c-478f-bc5b-71d3f0473300))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D60") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 411a5386-edd0-4032-883d-ba445f257b99)
-    (property "Reference" "D93" (at 213.36 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 21f0660e-6a0c-4492-a9e5-01821c71a5fe))
-    (pin "2" (uuid 096c2860-22cd-4d22-bbb5-2c4452c158a3))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D93") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 430b936d-b8ad-4c28-b93d-4046aec980c7)
-    (property "Reference" "D67" (at 152.4 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9255475-7a77-44cc-9bd9-589d63ced82b))
-    (pin "2" (uuid 9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D67") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 433f3f09-0867-41a3-8ac6-5f00bd3314fc)
-    (property "Reference" "D32" (at 91.44 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 11a29637-fd50-4473-bb70-d4116312a4f5))
-    (pin "2" (uuid 53f6307d-8380-45e9-b3fa-4d05a2bd575d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44499808-710f-44ae-bed2-0632db78b8c8)
-    (property "Reference" "D71" (at 172.72 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8805b31-9770-4092-b10a-101cf112fd76))
-    (pin "2" (uuid 9f3056b1-b197-421f-9d54-08cf5cc88970))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D71") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4461a601-2e4b-4cf8-8094-5e4d8e990676)
-    (property "Reference" "RC5-8" (at 139.7 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f54d1c0f-d68b-4769-9ef7-ac6475687d30))
-    (pin "2" (uuid 49768dd5-fbea-4db4-9154-60b22afd8a29))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44de9323-bd5d-49cd-bf0a-70392801309d)
-    (property "Reference" "D45" (at 111.76 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb2b185b-5d98-46b8-8516-9e5c980291cf))
-    (pin "2" (uuid f730da3b-5ef9-4abc-8c8d-0794fe3feb87))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D45") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 454ad926-1c6a-4aa4-b6f8-25297463de18)
-    (property "Reference" "RC3-2" (at 99.06 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f0aebfce-7e76-40f1-83ef-5914b8ebbcc7))
-    (pin "2" (uuid 744fce2b-a15c-45a6-92b0-e880efafb5f6))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 48.26 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46348ccc-126c-461a-8e39-f93f389ddaa7)
-    (property "Reference" "DI0" (at 242.57 44.45 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 50.8 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c86bf5fa-c113-44c1-b93d-7a5d4ac11904))
-    (pin "2" (uuid dbd8322f-50c7-4271-821c-b0005fd066b2))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4a7f7b3d-918b-431a-b79d-c66494b3ec50)
-    (property "Reference" "D52" (at 132.08 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd114d76-87b2-4089-b211-b7b541ac42b3))
-    (pin "2" (uuid a360aa38-116c-4dd0-a569-f6a7a5a88a05))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D52") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4d978207-10b9-4a43-a474-2e66421925a0)
-    (property "Reference" "D64" (at 152.4 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 27529674-e97c-460d-9de8-89cd61c8a6eb))
-    (pin "2" (uuid 57e77ee6-e62d-402e-a614-a833da3fbafb))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D64") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4e9036c3-3848-485b-8b45-7e377c05efba)
-    (property "Reference" "D86" (at 193.04 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cebd91c6-213c-407e-8871-b40d23e32e3c))
-    (pin "2" (uuid 209631a2-8c98-4e88-8a48-286a9aadd110))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D86") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 50dfbd73-3671-493b-8466-ba295a53891e)
-    (property "Reference" "D69" (at 152.4 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12473813-984c-45f7-a1ec-6b60de9f4230))
-    (pin "2" (uuid ef3a08d5-f80f-45b3-9407-fe76d147d1fb))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D69") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 50e4b379-7602-45c8-aa05-dfc9b3f70f58)
-    (property "Reference" "RC9-2" (at 220.98 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6d506f53-ffcf-4d12-ae8f-d5b7539fbeba))
-    (pin "2" (uuid 3324ce76-0743-47e2-af09-b4daae2fb475))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5466fd2d-f22f-409b-b7da-f8d297aeb7a2)
-    (property "Reference" "RC6-5" (at 160.02 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffdd8419-9afa-4f38-bfbf-7dc4e869b438))
-    (pin "2" (uuid 0db27643-51f5-4634-a791-2c4813885195))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5518d7f7-6de1-409b-a6d0-90efa78c0b82)
-    (property "Reference" "D7" (at 30.48 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9bdf2265-17dd-4712-9f75-996577068823))
-    (pin "2" (uuid cd2654f9-f2c1-4ff7-bbce-8fe664862762))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 553a576d-44a1-4bad-9211-394526206f63)
-    (property "Reference" "D41" (at 111.76 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4a035e61-91c9-41ba-9328-bc9b284e86c2))
-    (pin "2" (uuid 8628539f-d3cd-4957-a6bb-5c605649e715))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D41") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55c4f5cb-c530-414c-92f5-fbf9e58a8885)
-    (property "Reference" "D37" (at 91.44 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64d90630-a755-4eae-b416-80d8ff93fde4))
-    (pin "2" (uuid 77e4ef56-5ac3-4295-aacb-04ae680de9b7))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D37") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55dc1959-7c17-496b-b079-56725e7400ff)
-    (property "Reference" "RC7-6" (at 180.34 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d91f51f-9558-44e7-9b69-c9ba25dbac1f))
-    (pin "2" (uuid f7ee2403-2740-4116-96fa-c5f3c0c9f293))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 563bf078-cf50-4f0f-84d6-a83a0feddd45)
-    (property "Reference" "D70" (at 172.72 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 91318668-36ae-48a7-a13c-18d4c2f08036))
-    (pin "2" (uuid 29b99e4d-eeeb-4f18-b49f-b44a360c9eac))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D70") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 207.01 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5642ac65-20dd-447b-a5a3-1b21218d5bac)
-    (property "Reference" "DS8" (at 198.12 207.645 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 198.12 205.105 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6d406bb4-8771-4842-b48d-4d5e1f3de0cf))
-    (pin "2" (uuid bcdb56a4-4458-438f-b33a-abdcc29a1ebf))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 568f737d-6752-4b16-be92-273eb7ac8c9d)
-    (property "Reference" "D98" (at 213.36 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 96fa163e-1e2c-4d82-ada6-6b53530a015e))
-    (pin "2" (uuid eef2dd73-ade2-4fd8-a1e4-1b0837b59db5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D98") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 68.58 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5692cd7d-67c7-4fe7-8b4d-c8bc86968b31)
-    (property "Reference" "DI1" (at 242.57 64.77 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9abe1fc5-b3c1-424f-8519-d12916c57a11))
-    (pin "2" (uuid 168b1203-c5fc-4b69-b8e5-94d0bdc27e41))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 57e7516d-643d-4cd1-9646-d8696e387a16)
-    (property "Reference" "D38" (at 91.44 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c0d30413-2127-456f-a30c-24a92d981ac9))
-    (pin "2" (uuid a92161f1-81a1-4199-93bf-ab8287ab6d27))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D38") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5924da97-d274-4fb5-b277-06f309e62438)
-    (property "Reference" "D79" (at 172.72 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eb3328cf-70d1-402a-9b12-5297b037e47d))
-    (pin "2" (uuid 44a70a68-2fd3-413e-8aa0-d6527cb0cab5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D79") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59263e5e-1eeb-458b-9b02-ca162d4a65d7)
-    (property "Reference" "D21" (at 71.12 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2372f523-257f-414c-92f4-8d433cfbee15))
-    (pin "2" (uuid 21891727-1d09-4cab-bd90-75c57b141f7c))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D21") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59fdee43-9b65-471d-9ea8-5dc40dc65f6e)
-    (property "Reference" "D35" (at 91.44 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5834d436-0e26-481b-a20d-40fa6346502e))
-    (pin "2" (uuid 59af1ddc-701f-49c0-b6cd-778072695c5c))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D35") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5aeb247f-6f79-4df2-b767-9ca89069182c)
-    (property "Reference" "D56" (at 132.08 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d46c0cdd-d9c1-44c1-ba6c-034fc547ff01))
-    (pin "2" (uuid 53f3e198-3ef2-40c4-a8f7-298435eddd0b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D56") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5c60f960-fb0a-46f6-9aff-5d8144586231)
-    (property "Reference" "RC4-6" (at 119.38 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 990f1ee1-d6da-4ae8-809a-1911d8099a4c))
-    (pin "2" (uuid a8276c00-b61f-4db4-8f4f-e51e512de654))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5f21a75c-b9ee-47bf-adcf-39a03e42660f)
-    (property "Reference" "D15" (at 50.8 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1))
-    (pin "2" (uuid 7a8a84c2-38d2-473b-955d-81dd816a398e))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D15") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5fa8cce4-fbbf-4784-a459-71364b77e1a7)
-    (property "Reference" "RC0-2" (at 38.1 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cb7750fa-a378-43a3-a1c6-638c32a1c79e))
-    (pin "2" (uuid 67dfe958-6bd5-4618-98a3-d513db4ad5c0))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5ff7733c-a36f-4b29-a8e7-bdf79fabdf72)
-    (property "Reference" "D4" (at 30.48 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ed6062e9-f00a-474a-840f-39685bd66d70))
-    (pin "2" (uuid c0e85db4-b88d-4383-8de6-9f7370be62a6))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61b2e3fc-583b-407b-beff-dd8441f2f403)
-    (property "Reference" "RC2-6" (at 78.74 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 752f308d-4723-4468-9745-81de18307ba3))
-    (pin "2" (uuid 3267c09c-2818-42d7-96a9-6aaa2d6c4a92))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6368f5d6-df20-4a23-a72c-e29e990ea131)
-    (property "Reference" "D36" (at 91.44 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cd72461-15a2-466d-828d-9560639fb78b))
-    (pin "2" (uuid e26d27e6-f81a-4557-bc98-f3f953d25d26))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D36") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 64616073-76e8-465f-9707-663a78749bf1)
-    (property "Reference" "RC7-3" (at 180.34 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0925180b-4c04-468a-84a3-7e0c543a243b))
-    (pin "2" (uuid 000c5508-f583-4022-ad6d-ee3a9a754164))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6692c134-d619-4b90-b4c4-ab21aa3df3a5)
-    (property "Reference" "RC8-7" (at 200.66 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 453a02c7-7770-40fc-8f21-06b63fd625f1))
-    (pin "2" (uuid 3ebf9656-8129-4c66-8b10-67f0c0e2bb28))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 227.33 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 678223ff-e0fe-486b-b260-417e9028494d)
-    (property "Reference" "DS9" (at 218.44 227.965 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 218.44 225.425 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6cfbc946-abd5-4358-933d-727d4186f547))
-    (pin "2" (uuid b5044718-d927-48a8-a198-355f14c09004))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 67aba0e0-2c92-4816-99a5-9091230a7899)
-    (property "Reference" "RC3-6" (at 99.06 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9c252319-dc79-4365-afaa-77dcde3e6c4e))
-    (pin "2" (uuid a5f35312-d094-4f22-9eb9-0edc1f8fb9c4))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 68966b55-0a95-4b34-bc89-5c7298da3231)
-    (property "Reference" "D95" (at 213.36 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2fe5baba-e2be-4676-a63d-cc166ce0c4ba))
-    (pin "2" (uuid 72f97c9f-1d3c-4a38-bcaa-aad4f2a66c32))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D95") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6aa79de9-555a-4ed1-93d3-b801685ebd28)
-    (property "Reference" "D53" (at 132.08 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2031fe-ef72-48a9-afa6-c06144a31b2c))
-    (pin "2" (uuid 7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D53") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6b349af3-e96d-42ed-a60b-1fcc6b2649ce)
-    (property "Reference" "D92" (at 213.36 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bb4396c1-91b0-45de-ba96-3d4f74f6cf48))
-    (pin "2" (uuid b8385798-a88a-45df-851b-dcd7d4329aec))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D92") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6bdaf872-00b8-4813-a1b1-3be3a6e9f042)
-    (property "Reference" "RC2-9" (at 78.74 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b47928c2-316d-4b2a-9b65-93bc5a6a16f7))
-    (pin "2" (uuid 4fe94ff2-bac5-49bb-b97c-9a9ebef4c923))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6ef4f980-15ce-420f-b02f-d66ae810e188)
-    (property "Reference" "D78" (at 172.72 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 680d9493-5437-446a-836f-9ed5bb999bdf))
-    (pin "2" (uuid d64a76a9-3b5d-48b1-9a48-ee12b0cd1ab7))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D78") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 70d661b8-51f1-49b8-ad84-9ce8d120c0fc)
-    (property "Reference" "RC6-2" (at 160.02 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2175ea2-22e6-4720-ab54-24959d43a616))
-    (pin "2" (uuid 63a1bf12-3f2f-4dc8-8a86-7932361b8306))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 712ade27-46b2-4d0c-b658-ec3775a1c528)
-    (property "Reference" "RC3-8" (at 99.06 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4811e298-73bc-4ac1-af58-3ae7f508d1d7))
-    (pin "2" (uuid ac21b718-c133-4ed3-a2f4-c437b7879cce))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 72047ccc-8813-4e13-ae4a-04618a9ab771)
-    (property "Reference" "D23" (at 71.12 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84))
-    (pin "2" (uuid 6dee3493-b1eb-401e-abb4-cbdef0ef3867))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D23") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7295efa3-e253-4b6b-ad8d-641bcea1e272)
-    (property "Reference" "D68" (at 152.4 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0450f5cb-94f5-4de3-b50e-da553aca1ff3))
-    (pin "2" (uuid 47f460cc-5812-4c14-b97e-030930a4c1aa))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D68") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7322809e-8332-47c6-af41-fcf3bbcec7d0)
-    (property "Reference" "D34" (at 91.44 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e3b096d1-dbd9-4fb8-8775-725a7aed0bc4))
-    (pin "2" (uuid 63756bb0-b693-4bbc-82da-e89a6b927e71))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D34") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 75e13388-d7c5-4583-8a3d-9b2d5836631d)
-    (property "Reference" "RC9-0" (at 220.98 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df3fb1ca-e1d7-4dba-9f10-debc4bd28da0))
-    (pin "2" (uuid 8e4b1d03-6eb1-4014-a87e-35bcdd8c8002))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 76054860-648b-474e-9b4d-cc9d83653495)
-    (property "Reference" "D10" (at 50.8 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d7e8bc-1ac3-4327-ab17-369de6ee755c))
-    (pin "2" (uuid c8283bba-c907-48e0-9745-e0818ca7ab04))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 77aa25a5-82c7-42c3-9d55-8606dd65ffa8)
-    (property "Reference" "RC5-1" (at 139.7 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51db5d58-5004-4c9c-b8d1-c184bfb493da))
-    (pin "2" (uuid 16d6f605-4627-49bd-9180-8203902febfd))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7876e2e4-9d5a-416f-b97a-e958a989e5b8)
-    (property "Reference" "D16" (at 50.8 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8bd5710-8f18-4748-9b3c-a975f78342a1))
-    (pin "2" (uuid da0aa924-203b-4985-9bff-4185f3555d43))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D16") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7b85c895-ed2f-4daf-bbd5-9b0e9148eed9)
-    (property "Reference" "RC7-8" (at 180.34 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6604866-4e4a-4cb4-bf09-ea0fa22fde38))
-    (pin "2" (uuid 0729bbae-70ee-4c7e-8da7-29c0812b5be7))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8010e136-1dd3-496f-b7ef-81fb0c8b419e)
-    (property "Reference" "D20" (at 71.12 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5aa5bf69-e040-48d4-81fc-332aff45c2f9))
-    (pin "2" (uuid f5458189-75e2-45c3-bf32-0320ebe63391))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D20") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80c46ab4-724f-418d-bb6f-e89792097e1a)
-    (property "Reference" "RC2-4" (at 78.74 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc0fd3d-897b-4e06-ac65-16066b68709e))
-    (pin "2" (uuid b7b98128-d37a-4ac7-b049-5cf9bdd5aadb))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 814545b5-c5a6-4c45-83b2-5c1b5ef43a22)
-    (property "Reference" "D57" (at 132.08 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid adc35f03-9c02-4ca4-bbc5-866d317a7469))
-    (pin "2" (uuid f05a395b-0185-4ab8-bf1d-fa0561316ad4))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D57") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 81912d5a-1def-44e9-a6ef-abaf3ecd517d)
-    (property "Reference" "RC6-1" (at 160.02 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fa9aca31-bd8b-4e2e-8b86-05d191575df9))
-    (pin "2" (uuid fce38bd6-fb8f-42a6-8d68-ecda7f1a588f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 820f9c2f-0705-41a0-aa6a-3a211d61773f)
-    (property "Reference" "RC6-7" (at 160.02 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eb135129-1d78-4d36-9389-941aee94da0a))
-    (pin "2" (uuid 2a32e7b7-f134-4c47-a153-d8fce8404094))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83cc3bf3-09a0-4d14-be9d-180ca479485f)
-    (property "Reference" "D73" (at 172.72 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 22a68b69-e4e9-436e-b154-616fe8bb66c2))
-    (pin "2" (uuid b8e81b5d-9257-4482-8c33-cdfcb13c22e7))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D73") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83fb734e-dbcd-4939-9bb9-d97efd05ec97)
-    (property "Reference" "RC5-6" (at 139.7 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7315a9fc-fd63-46c2-90db-bee656dc7568))
-    (pin "2" (uuid f2997912-9551-49e9-aab8-387875819f56))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8408f1ce-a660-4217-a7dd-6677d6fa5c0c)
-    (property "Reference" "D96" (at 213.36 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eaa398b7-f50e-4597-99f7-b1dcab75a526))
-    (pin "2" (uuid 5719d7b4-74f2-42c4-b1c6-34b59ae5b787))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D96") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 84146f81-04f3-4efb-b753-bdc596c8e7a9)
-    (property "Reference" "RC4-3" (at 119.38 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 774ced50-3b17-48fe-b2d7-22681b1dd1f7))
-    (pin "2" (uuid bad310c0-ca25-47d0-b27e-42438b959c7b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8475a219-4e20-438a-84d8-4847d5d45c64)
-    (property "Reference" "RC9-5" (at 220.98 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8668fb6-f91a-4502-9f57-a2869aa9f6f1))
-    (pin "2" (uuid 8e2e3508-e150-49c5-a82e-0ccd478af757))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 86602dfb-ea19-4060-ad39-496c613a47cb)
-    (property "Reference" "D30" (at 91.44 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 02958e5d-18b7-48f3-9883-661ceaa75da5))
-    (pin "2" (uuid abed4b13-9431-40c7-848f-b30c05e39dfd))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D30") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8af20987-c3c2-465e-8640-61ab0bd7d8fa)
-    (property "Reference" "D81" (at 193.04 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f42cdbf-02ba-4b39-8586-bbff1b6ed80b))
-    (pin "2" (uuid 7d939371-3ab1-4f18-b55f-07048dcfe21f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D81") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8b2b0803-8190-43b4-9c0d-a9a9edc27829)
-    (property "Reference" "RC2-7" (at 78.74 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8e9f64d-5849-4a62-8bf4-dafc65fcdd75))
-    (pin "2" (uuid e45fa11d-c755-4d62-baa5-974f973ba20f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8c168cda-0a39-478d-9d71-1073400c7ed7)
-    (property "Reference" "RC1-5" (at 58.42 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d2851af-db15-44cf-8e07-da339bdc18b2))
-    (pin "2" (uuid 94b381a2-7c19-4916-9f9a-ee00221d04d3))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 129.54 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7)
-    (property "Reference" "DI4" (at 242.57 125.73 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c02807d6-1705-4325-bcb0-203f4e9a5baa))
-    (pin "2" (uuid d6c46059-bf9c-4959-836e-e4d33dcc5edd))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8eb7a7fa-054b-460a-a80c-73a56219fecd)
-    (property "Reference" "RC7-0" (at 180.34 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be9c1065-912d-49b5-8f2f-271b4a0c1db2))
-    (pin "2" (uuid 626f5614-e69d-4277-acf6-7ff35b08ddb4))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 90049005-7b99-4d2f-9282-dbf53b76b55d)
-    (property "Reference" "RC3-7" (at 99.06 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 62acb361-e48a-40de-9689-6c103c4c7663))
-    (pin "2" (uuid f3ee11cf-4f81-4591-ab5d-f41aece910dc))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 186.69 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 91a5d9b4-63df-4567-88f7-1d2f7ac8c33d)
-    (property "Reference" "DS7" (at 177.8 187.325 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 177.8 184.785 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2ec7f316-054f-444d-9c0b-c2c6e1d51faf))
-    (pin "2" (uuid e22dc61a-a86f-42a7-9c26-623bb8233a05))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 92030355-9e31-45db-a9ef-a705772288a6)
-    (property "Reference" "RC6-9" (at 160.02 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 83a62e7f-2925-4bbe-9dad-6089ad98ff2d))
-    (pin "2" (uuid c1b87b81-e623-49b5-bacd-1c525772e150))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 933178a7-83a9-4f29-88ef-1e369645dcaa)
-    (property "Reference" "RC2-8" (at 78.74 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4d133f2b-f4f1-4994-a89d-7141989cf18e))
-    (pin "2" (uuid 9ed70267-ef82-4b49-85af-67297365ea60))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 93921179-259f-4393-a6ae-bfcb2df690b6)
-    (property "Reference" "D80" (at 193.04 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d32d457e-c0ce-46dc-ac4a-08e965633eab))
-    (pin "2" (uuid 0645b564-d7c5-4845-82b9-8702f3f470a4))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D80") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 93dd9936-9573-4973-8fb2-a71d5e19f115)
-    (property "Reference" "D94" (at 213.36 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7beb185a-6309-4671-8dd9-da0c3ef9bc52))
-    (pin "2" (uuid baeb1083-702e-43e8-9a5d-760812497130))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D94") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9578a4b6-1a56-40b7-be8d-56404ef59fdf)
-    (property "Reference" "RC1-6" (at 58.42 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0b899b44-3ae3-40be-a452-1f16eaa5f4af))
-    (pin "2" (uuid 11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 109.22 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 957e7a82-ca9c-46a8-bca9-099b05fe7e8f)
-    (property "Reference" "DI3" (at 242.57 105.41 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 111.76 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc53fac9-006c-4101-8113-949ab8e05afb))
-    (pin "2" (uuid f6122429-5885-4b7a-b72a-162ca49c70c2))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9789c79d-d74e-4c16-a474-31201e3b4997)
-    (property "Reference" "RC0-9" (at 38.1 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9b4d335e-fe84-4869-8670-3368a7ef15e9))
-    (pin "2" (uuid 3a372e91-311a-4276-8504-54c40aee2304))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 98a45ae1-6346-4607-b0c8-1479c51b1f75)
-    (property "Reference" "D49" (at 111.76 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 245fa70b-724d-4379-9c74-b8f5c8d9569d))
-    (pin "2" (uuid 964a681d-53eb-46ee-b5d9-73ca4400bb74))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D49") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9af5b930-d274-4b05-b0bf-e2c27b7e71dd)
-    (property "Reference" "D6" (at 30.48 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bdad3d4-58ec-438c-beb8-3eea36a29d95))
-    (pin "2" (uuid 5ff4e8af-dd18-4010-b183-21b8178cd684))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 88.9 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd)
-    (property "Reference" "DI2" (at 242.57 85.09 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 91.44 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a))
-    (pin "2" (uuid 81e4b9c6-9b09-4e38-94e9-cebdeae457ee))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9e96ab02-44ee-4ac7-8251-0d309b7409ad)
-    (property "Reference" "RC5-3" (at 139.7 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd85b120-1be2-4f17-a3d7-505a734afc72))
-    (pin "2" (uuid 666e03ce-bf1c-4b58-ac4e-f01557ca11fd))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a026138b-aabb-432d-b516-5341ad9fe06b)
-    (property "Reference" "D39" (at 91.44 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6257e834-355d-4e0b-a5bb-744bef7d141f))
-    (pin "2" (uuid 8be7ee86-36bb-4b87-9942-9d15d9003e1c))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D39") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a3969e5a-abe0-44e9-adf1-6255946e3f4c)
-    (property "Reference" "RC6-0" (at 160.02 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bc4d6aea-ec1e-45c7-842c-68cd7e21336f))
-    (pin "2" (uuid f785fa77-0ac2-41ff-9704-1acbb4a72c84))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a400377f-e146-4099-97e7-db21e16d5759)
-    (property "Reference" "D3" (at 30.48 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bfc71c1-6349-4b3f-bf89-22c83277904e))
-    (pin "2" (uuid dafd4b6c-6c2f-41e0-95ab-05ead276d86d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a4f847ba-a334-4631-aef3-ca47db1a1700)
-    (property "Reference" "D29" (at 71.12 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc5b522c-bddd-4a8d-8ded-7fc36acfc178))
-    (pin "2" (uuid 8e96df26-db08-4a3c-92ce-ba5029c624ac))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D29") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a576c983-0812-4f76-8327-d260ce9c2826)
-    (property "Reference" "D27" (at 71.12 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c11deb1a-dbe0-4d39-8303-331b09dd3cc0))
-    (pin "2" (uuid 9251c46a-97e6-41c1-9326-a6a8b52abc12))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D27") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a71b771b-4e14-4d95-98e7-86a6250f569e)
-    (property "Reference" "RC0-4" (at 38.1 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 95049e61-b78e-490f-86e1-aba711db5c19))
-    (pin "2" (uuid 6e474ba8-5b88-41c8-9259-b0ebfb6012f0))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid aac180ff-c5e7-4a0e-9a07-44c1b3bcc7fe)
-    (property "Reference" "D59" (at 132.08 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6b5d04d-906d-4f18-b7a3-382b3a768815))
-    (pin "2" (uuid d74367e2-5126-4fe7-ac31-7039cd9552e5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D59") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid abf3c9d9-a279-4546-abcf-5e4f6862bc48)
-    (property "Reference" "D2" (at 30.48 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3499f31-3593-4cd9-977b-3b6479091d7b))
-    (pin "2" (uuid 17f09d49-1093-4838-8e5c-8fc4c42e5d05))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac10b530-144b-4dfc-ab37-ad7a8ced8612)
-    (property "Reference" "RC4-5" (at 119.38 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6c95156-54b9-4f54-a278-f808b4871687))
-    (pin "2" (uuid c3dc8d92-1759-4195-a3c9-81260bc6d8b1))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac95bba7-885e-446e-b059-0ba3c38e43f7)
-    (property "Reference" "D19" (at 50.8 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 63ad0fd9-4009-4287-bfa1-9dc63b978ef3))
-    (pin "2" (uuid d7eafe2c-7576-4ddd-821f-8f8bca43ff92))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D19") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 85.09 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid accba515-4e8d-4804-afea-f36f436141c3)
-    (property "Reference" "DS2" (at 76.2 85.725 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 76.2 83.185 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 034e4344-7cda-43bc-a12a-f56b6e8f68f5))
-    (pin "2" (uuid 6f0bef00-c613-46da-9667-752b92174ad1))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ad352cc7-0ffd-4a04-82ac-bc693299cd86)
-    (property "Reference" "D83" (at 193.04 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9662d2b8-61ec-4840-a8f1-af48833c11eb))
-    (pin "2" (uuid 4d0c4f9f-b435-4d30-95d7-23d9f87d5f48))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D83") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ae019221-3fd0-468c-9cf0-dac8d7470e8e)
-    (property "Reference" "RC9-3" (at 220.98 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be20235f-2999-4595-bedf-c52cf23b7bd1))
-    (pin "2" (uuid f57afa4c-8044-4217-b32d-12bed3437591))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid afcc8d67-6ed8-4a82-aef7-417b4229ad61)
-    (property "Reference" "RC7-4" (at 180.34 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 982715f0-55ee-4146-b98e-756e5b630dca))
-    (pin "2" (uuid 7f384a84-9632-4ac9-a8b6-05778cf49f62))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b05bbd1d-9d65-4ef7-a639-885ae69d8b01)
-    (property "Reference" "RC8-0" (at 200.66 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 16c6866c-1d06-4257-9cde-9d9c6f4c3642))
-    (pin "2" (uuid 70b152f6-7e7d-4a93-9ef0-b6ec51ff9b25))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b2cc8c06-500a-41ac-a412-7baf61e0f24c)
-    (property "Reference" "RC6-3" (at 160.02 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0a77d5cb-df53-4102-99ed-4829fa686656))
-    (pin "2" (uuid 22df81c2-2a06-44e2-bed1-a6d6c14df76a))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 146.05 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3573dc3-ef18-4f4c-817b-c984ae7cfae9)
-    (property "Reference" "DS5" (at 137.16 146.685 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 137.16 144.145 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 813e7cf6-f821-4e03-95cc-308010bed54e))
-    (pin "2" (uuid 9669a028-42d7-436f-8ec5-bc3423db62d6))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b39d56f9-3079-43e4-bb1b-80277fdae425)
-    (property "Reference" "RC4-2" (at 119.38 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b205d044-9ffa-4dce-82fd-f51ba622a818))
-    (pin "2" (uuid 29ce7588-4a17-4be4-9207-ea3ed2669aa1))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3c497a9-b81f-4161-88cf-2e58ddb4cdd8)
-    (property "Reference" "RC3-4" (at 99.06 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ae78f0d3-f75a-49c8-ab9b-8a9831e434d7))
-    (pin "2" (uuid a59e897c-0784-437d-9243-baf91d40a453))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b92624bc-936a-4bc6-ac7c-dbc9faa7208a)
-    (property "Reference" "D8" (at 30.48 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0ef02d0f-103e-468b-b30c-fac4e90fb218))
-    (pin "2" (uuid aa510cff-115d-4ad1-9c78-bf1246172261))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba3c5bf2-9824-404a-befe-7584c286e012)
-    (property "Reference" "D48" (at 111.76 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 38e4de38-525a-4e2c-8e51-9d4770973903))
-    (pin "2" (uuid e71e068d-4f7e-493a-960b-e49aa171ca56))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D48") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba927934-b2e1-4953-b21b-54ef02be8935)
-    (property "Reference" "RC0-5" (at 38.1 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cadba0a-3bb3-40cd-acea-644da4b3e05f))
-    (pin "2" (uuid 1368ebac-096c-415f-acaf-9afb071e729f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bb2c72f0-a908-44e7-b7d5-67df52eed516)
-    (property "Reference" "DS4" (at 116.84 126.365 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 116.84 123.825 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5ab0b348-3e2a-4517-90b3-fad111de6205))
-    (pin "2" (uuid 6e7351bb-5d09-464f-9e8d-535ba0f5c6f3))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bbc3ae57-e1db-475c-9bc3-18c822e7531a)
-    (property "Reference" "D28" (at 71.12 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90783402-edc5-4638-ae16-d31c3aaf5e2b))
-    (pin "2" (uuid f9e9c399-273d-43fc-9007-1e5ca67fea38))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D28") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be02506a-2bb1-4713-b046-f0327dae72de)
-    (property "Reference" "RC0-1" (at 38.1 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 97a92abd-708c-465e-baf7-79fa35370a7c))
-    (pin "2" (uuid c9056b1e-419e-478d-9fc4-be1e95902d28))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be554787-60ed-4b8f-b7bc-2220fcd28430)
-    (property "Reference" "RC8-3" (at 200.66 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 76eac86e-4d5a-4833-a702-c89fc5eb96e0))
-    (pin "2" (uuid 6e41d262-c7fe-4c54-b525-59ae026a918d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d)
-    (property "Reference" "RC5-2" (at 139.7 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f22c39d-012a-4297-b61c-1ff841801333))
-    (pin "2" (uuid adbe8c88-ad34-405b-866a-efb64899002f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bf639842-72e9-4bdd-be11-7972d8d5c3c4)
-    (property "Reference" "RC3-9" (at 99.06 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8015b627-c562-4073-8a9c-3d88306d5597))
-    (pin "2" (uuid b34e9dd8-5aad-496e-81b0-f2f5cb3bdb66))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c11b6807-83e7-46af-9d7e-9d56aab4109c)
-    (property "Reference" "D46" (at 111.76 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46))
-    (pin "2" (uuid 6764bae9-067c-4178-897e-2c25048ade8b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D46") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c164cb58-7d29-400c-b219-f07036f5e8c9)
-    (property "Reference" "RC0-3" (at 38.1 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92164ea1-76d0-4223-80cc-32c093c14fcd))
-    (pin "2" (uuid e615b2e5-6986-47ac-8f35-da60c20b811c))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c43b92c2-4283-44f7-8cb3-665623564383)
-    (property "Reference" "D42" (at 111.76 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0929e13-ab77-4737-9d55-142bd9901b1c))
-    (pin "2" (uuid 0f45988c-1752-479c-97d5-fbada14f9a42))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D42") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c64cc71e-aae1-49fa-83d0-4d8a51355bc6)
-    (property "Reference" "D9" (at 30.48 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 328932ea-b1f6-431f-8c23-8a2d8eae8bba))
-    (pin "2" (uuid 10eab654-b7fb-42dd-bf39-41b39e8328d6))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c72dd108-be98-47d5-b809-561778aa3212)
-    (property "Reference" "RC2-5" (at 78.74 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d2f0fd-ce69-4d4e-a4ab-163c1691ef24))
-    (pin "2" (uuid 03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c7f185b3-c785-4ddb-9c6f-f854c93057c1)
-    (property "Reference" "D85" (at 193.04 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b8f08018-67e0-4945-91d2-9a40292e0a1a))
-    (pin "2" (uuid 096b6293-e540-4273-b6aa-9e314016c840))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D85") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe)
-    (property "Reference" "D50" (at 132.08 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a606860e-126b-4f3e-bcfe-a2dfa8adc9c8))
-    (pin "2" (uuid 59120505-a333-4c63-8904-aa379cfb043b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D50") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c996541a-3b07-4fed-9687-afa9b7ffb878)
-    (property "Reference" "RC7-5" (at 180.34 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 560b334e-ed5f-40a2-b100-5974e92ce94c))
-    (pin "2" (uuid 55bbe733-1ff6-4a73-b892-49d49c6c0fc9))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce521a1c-e123-4f49-866e-f4f51848f864)
-    (property "Reference" "RC7-2" (at 180.34 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2a9b15ea-df9e-4ef0-a128-13d2e129d7f7))
-    (pin "2" (uuid e9530707-f705-4741-a308-e08f558f67a1))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e)
-    (property "Reference" "D51" (at 132.08 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48596e1c-4629-46bb-98c1-de11cd41e539))
-    (pin "2" (uuid f7decfb7-c4ef-4861-ba8a-043f44f3b09e))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D51") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cf81ef85-b58f-422a-b88a-7b7914aa3581)
-    (property "Reference" "D12" (at 50.8 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e34c154b-a3cb-467d-891b-2f2891056190))
-    (pin "2" (uuid dc926c49-c915-470d-b2b5-00749f3505bb))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D12") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d2e0ab87-3807-4a88-be47-f5c2586bfeb9)
-    (property "Reference" "RC1-9" (at 58.42 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 905c7978-373b-43c6-894f-f9da59358409))
-    (pin "2" (uuid 9dabc73f-860c-4bde-9950-7e2511b1e9b3))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d352da38-bdf9-428f-a8d9-8df6c9a36ec3)
-    (property "Reference" "D89" (at 193.04 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4c3fc4a6-4570-4b34-b7cc-c9d681cef14a))
-    (pin "2" (uuid 7d95533d-af2b-4a4c-b205-9385c93624cd))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D89") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d40b4fbb-e58c-433e-b2c5-236bb8aa92c5)
-    (property "Reference" "D1" (at 30.48 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90049b07-ff34-407c-ad1c-bcb8b89b241c))
-    (pin "2" (uuid 7bd5d68f-4902-47f7-bc35-be0973d0d904))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578)
-    (property "Reference" "RC5-0" (at 139.7 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5729530-792d-44f2-80ff-f6315aae335e))
-    (pin "2" (uuid 01f42ec4-9037-47c0-8fc0-8f7345fd0a2b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d69b760e-d231-449e-ae78-5289569bfcf8)
-    (property "Reference" "RC4-8" (at 119.38 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b2174dcf-3936-44c4-b9c9-8a8c2ffd5559))
-    (pin "2" (uuid 553bf002-fd89-4554-b1c2-ed094fd5fe57))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d7b98385-4339-43e1-a83a-6daba8def1f8)
-    (property "Reference" "RC0-8" (at 38.1 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c3a8852b-59c8-4849-9f9f-edc39c43f8e6))
-    (pin "2" (uuid f4bfef10-0157-4077-9c8b-8858eccf5c1a))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69)
-    (property "Reference" "RC2-1" (at 78.74 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ba2015a3-c3ad-44cf-b530-b2a60bac2c12))
-    (pin "2" (uuid 12bdf482-8bd0-4b7d-a511-fcaadc8ab54d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid daefbaa6-3e17-4eca-837b-024ccac5fc10)
-    (property "Reference" "D14" (at 50.8 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12e5236e-b23d-4e38-9768-e28d1693b6eb))
-    (pin "2" (uuid 1be4fe23-ac83-4b50-b43f-2e4b33c335d7))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D14") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid de9b7bb1-afa1-4e19-b963-4516a18a17bf)
-    (property "Reference" "D91" (at 213.36 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6167a490-f64e-4925-8d8a-b4543a48c019))
-    (pin "2" (uuid b78fba3b-33a1-4c3a-941e-dc9814c91e24))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D91") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid df14ac0c-5b64-41d1-ac61-954e84a88f4b)
-    (property "Reference" "D47" (at 111.76 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7284aa2f-4456-4e07-9251-a86b7acd95b1))
-    (pin "2" (uuid c06243a0-5a23-4af5-88df-f2a88bfb1da0))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D47") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e214b496-153e-40f8-93df-30f96574576d)
-    (property "Reference" "RC6-8" (at 160.02 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 762c516c-df17-4ae0-8f7f-03315e74925e))
-    (pin "2" (uuid 874fed4d-cc1d-47bf-b14e-533fedfc9875))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e255666b-19cd-45a4-b5c1-8997235eb1ad)
-    (property "Reference" "D72" (at 172.72 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92803ca1-7814-4c2f-986c-c7a2afaea4b2))
-    (pin "2" (uuid f1e544c9-5e94-460f-960c-d30fdb857f44))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D72") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e345b77c-4943-4943-8fff-9d2c0a863651)
-    (property "Reference" "RC9-8" (at 220.98 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3c5bbf7f-11d9-45e3-9492-3b3f4802883c))
-    (pin "2" (uuid 8e4fc19e-5f68-43e8-b4a4-baf188b4cd3a))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e433e872-70f0-4e5b-b473-1ebd1af79f33)
-    (property "Reference" "D84" (at 193.04 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2c838395-b13b-44f3-9cda-ae0061827054))
-    (pin "2" (uuid b7abe52a-50b6-4b31-8da0-3b0e1433e922))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D84") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e4362acf-dcaf-47ae-b824-45cc81be26fd)
-    (property "Reference" "RC9-4" (at 220.98 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 59031059-0660-4b8b-bc7c-d25dfdf99292))
-    (pin "2" (uuid 8d191698-0ba8-4bfd-9183-392ad5be38af))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e490f25a-1360-4f95-aa79-5f1d93892bb3)
-    (property "Reference" "RC3-5" (at 99.06 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 056973a8-92e3-49be-9b21-fe961241d12f))
-    (pin "2" (uuid 01c4c06b-d45d-4ffb-ad72-57ca7686fd55))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e6262d19-9b35-41b6-845a-39c20b831416)
-    (property "Reference" "D76" (at 172.72 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8324bd70-bd5e-4513-bc52-cc4e838003e8))
-    (pin "2" (uuid 64285f25-2c5b-4231-8d94-7ba284d5a2d2))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D76") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e97aeea5-7475-4b9f-a312-6f51452496a5)
-    (property "Reference" "RC8-4" (at 200.66 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b5d442a-c78e-4d0d-8f8c-3cc6c91bf307))
-    (pin "2" (uuid 4b2eebd0-ccb3-482c-8c43-2690e285e66f))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 105.41 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b)
-    (property "Reference" "DS3" (at 96.52 106.045 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 96.52 103.505 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 738869bf-f410-43b7-b7e7-4e927d69911a))
-    (pin "2" (uuid 71649a24-87f4-49fb-9896-e50c64c03a31))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb153eb2-74b0-4cb9-b105-af356654d60d)
-    (property "Reference" "D24" (at 71.12 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77c4fd5e-5c79-4799-aab6-2f07a57c7df3))
-    (pin "2" (uuid a062346b-452b-46dc-a106-fab01848555d))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D24") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 242.57 231.14 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid ec0ebda2-e0b5-4648-83ee-afd68a4093ad)
-    (property "Reference" "DI9" (at 242.57 227.33 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 244.475 233.68 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 242.57 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 242.57 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 242.57 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 242.57 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 941790dd-6c84-4d17-8c86-cd053db9749e))
-    (pin "2" (uuid 1cfb4960-1c24-46af-9168-505412fc1763))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ee3742e9-8e22-4413-88a6-b893a7cb3439)
-    (property "Reference" "RC8-6" (at 200.66 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12157fba-1ac0-4b59-9ef4-f0b7f556fda2))
-    (pin "2" (uuid a6fa6d7f-615c-410e-9188-d1867808891a))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eeca0e5b-e9f9-4790-9c32-e398887f1254)
-    (property "Reference" "RC8-9" (at 200.66 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ee863615-0428-4134-aa77-1d7c4e3647ad))
-    (pin "2" (uuid 7b155375-a70f-42ef-9309-987f1f53d011))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ef64a689-efe5-479a-a53a-19c9f4177765)
-    (property "Reference" "D74" (at 172.72 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fc4be4a8-3bcc-4a9b-8dca-654b73020c91))
-    (pin "2" (uuid 982449b6-25db-4afc-abf2-592e07b23449))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D74") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1920e34-64a4-41c9-8680-7fa42f5dfb9d)
-    (property "Reference" "RC2-0" (at 78.74 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9242378-4df5-4b90-afbf-1098ccb8067f))
-    (pin "2" (uuid a135b9b9-316d-4cb2-a5a5-8d618a00a752))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1a5bcca-72b0-4fb1-9570-8abc0f731fb7)
-    (property "Reference" "RC1-7" (at 58.42 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 058cb33f-3013-4884-ba52-2b175c6e6f25))
-    (pin "2" (uuid cb54004f-a1b9-489e-9cdf-00b812c2d5fa))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f31d54be-89a7-479b-90a6-e9bcd6257412)
-    (property "Reference" "RC9-7" (at 220.98 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f83ff9f6-7715-4e86-b4bf-0de9179fec70))
-    (pin "2" (uuid 2a257b84-25fd-4cd2-9e3d-5ac106f662f8))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f735328c-2a24-4fb3-983d-b3e512d5a5cf)
-    (property "Reference" "RC8-5" (at 200.66 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid af0d403b-f1be-40d9-bf46-12c29a8b07f1))
-    (pin "2" (uuid cf12207d-8835-4b4d-855b-207eb48891b5))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f93938b2-5ce6-4ad4-aef1-bcec2b0c3413)
-    (property "Reference" "RC4-9" (at 119.38 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb557f65-fb80-44d7-9e25-f09389e948a7))
-    (pin "2" (uuid ef20bae4-a01f-4ba7-8d51-cad542d569ba))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f9c61822-7d54-487f-93d1-920e041f55a6)
-    (property "Reference" "RC8-2" (at 200.66 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffd61ace-0250-4fd9-8d0c-c2c917d0d4b5))
-    (pin "2" (uuid d354ba15-00ca-4efb-954b-871f951259db))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fc941f43-b642-4fef-8515-f8f851adced2)
-    (property "Reference" "D13" (at 50.8 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c))
-    (pin "2" (uuid ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D13") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fcc35b13-8da5-4271-981a-5470b3add3e5)
-    (property "Reference" "D25" (at 71.12 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0d662a-16b3-4c76-b4ee-49de18b57b47))
-    (pin "2" (uuid ba9a1f4c-173e-4b32-907f-fe9b31df718b))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D25") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fd13d6af-afdf-4367-a43b-1889348eabd8)
-    (property "Reference" "RC0-6" (at 38.1 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 854af50a-a007-4ba3-a405-76f0f99e9817))
-    (pin "2" (uuid bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142))
-    (instances
-      (project "round-robin-11-90"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "cbac505e-77a6-4a00-a758-435de33cca16")
+	(paper "A3" portrait)
+	(lib_symbols
+		(symbol "Diode:1N4148"
+			(pin_numbers hide)
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "1N4148"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "100V 0.15A standard switching diode, DO-35"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Device" "D"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "D*DO?35*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "1N4148_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "1N4148_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 165.1 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "00d75863-bb9f-4d4c-ae8f-f64498ed1533")
+	)
+	(junction
+		(at 246.38 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "04d157fc-c063-40ca-ad05-26c77c1c313c")
+	)
+	(junction
+		(at 185.42 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "05e510f3-8ca9-490a-bdc5-77faace67735")
+	)
+	(junction
+		(at 104.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06a6d1a8-0f12-4174-b63e-d35d8ca618bf")
+	)
+	(junction
+		(at 43.18 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06e66b38-0070-40a1-8fc5-70306b17897f")
+	)
+	(junction
+		(at 165.1 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "09e82fd3-a43f-4071-83d2-fb0a65931c0e")
+	)
+	(junction
+		(at 195.58 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a12de08-1706-4b9c-a033-35ba5807ef7b")
+	)
+	(junction
+		(at 63.5 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a9113d4-8a8c-4abc-b886-f22c92ad18dc")
+	)
+	(junction
+		(at 165.1 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a95c2d4-251b-4df1-a8c0-c0fc6241e43d")
+	)
+	(junction
+		(at 124.46 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29")
+	)
+	(junction
+		(at 73.66 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c7244ee-ddfb-470b-a70b-1cfc53f83773")
+	)
+	(junction
+		(at 134.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c73479c-4e07-428a-85f3-93341c42ca57")
+	)
+	(junction
+		(at 93.98 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5f3a7a-dc5d-4973-8743-eafaa1c1a462")
+	)
+	(junction
+		(at 43.18 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "10cae212-bc64-40b9-b44f-13fd4a0406a6")
+	)
+	(junction
+		(at 53.34 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "122dbfee-176c-4f21-802f-09581864dffb")
+	)
+	(junction
+		(at 215.9 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "125985d5-ea14-4dfe-aae0-18ae62d080c5")
+	)
+	(junction
+		(at 83.82 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1278b5e3-5eff-46d6-a162-44fde2066970")
+	)
+	(junction
+		(at 53.34 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14bb4fc2-d7df-49aa-b10e-882abdd2aa5f")
+	)
+	(junction
+		(at 185.42 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "15daf298-357b-4f73-8767-34988eed6eb8")
+	)
+	(junction
+		(at 104.14 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17f3773a-2c02-426d-bcd6-7a35c59a710a")
+	)
+	(junction
+		(at 205.74 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1943e8ad-b21d-4f7c-9e48-baf07472bdf8")
+	)
+	(junction
+		(at 114.3 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a11ada5-19c8-45ac-810c-daedbb80ad5b")
+	)
+	(junction
+		(at 195.58 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a6176d3-a6a6-4f72-9be0-2812f8861a46")
+	)
+	(junction
+		(at 73.66 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c386ee6-5b9d-4eae-92b5-9440e81067f6")
+	)
+	(junction
+		(at 246.38 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "216bc563-0bc0-4447-af79-7933fdef7d63")
+	)
+	(junction
+		(at 93.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21e320b6-a0c4-4d5d-babf-ee5274120507")
+	)
+	(junction
+		(at 185.42 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23554013-cd0d-4767-9f22-8c19a7d8c5ca")
+	)
+	(junction
+		(at 154.94 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23916c3a-0d37-416a-91d3-82a34b3ade4a")
+	)
+	(junction
+		(at 165.1 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2501dc30-a271-4271-9ca6-b085328a23ec")
+	)
+	(junction
+		(at 215.9 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2626f828-e375-4e39-b9f5-57d32786f5fd")
+	)
+	(junction
+		(at 73.66 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2654ce54-6e59-4c49-bfbf-12326c83c638")
+	)
+	(junction
+		(at 226.06 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "28c72d93-951d-432a-abf9-c3f05af6b90f")
+	)
+	(junction
+		(at 154.94 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2af4d5cf-36e8-471b-be0a-21fb2d03facc")
+	)
+	(junction
+		(at 124.46 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2b2b66bc-905d-4b48-89f5-1c62f6c27dbb")
+	)
+	(junction
+		(at 134.62 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c5878fe-fb0a-42a4-a883-ea4209708ea5")
+	)
+	(junction
+		(at 175.26 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2cae1312-83d6-4b55-a6a7-5303ad6d6c6c")
+	)
+	(junction
+		(at 154.94 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2cf168f3-fe97-43f2-b72e-223dd4e6b386")
+	)
+	(junction
+		(at 73.66 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2f562ace-9050-4ec1-bf70-b5691b93259e")
+	)
+	(junction
+		(at 73.66 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30c9eca3-7c32-4704-8819-3599d7b84f53")
+	)
+	(junction
+		(at 93.98 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "31a1b16e-8174-4fea-bc42-9c75ed9182a0")
+	)
+	(junction
+		(at 83.82 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3")
+	)
+	(junction
+		(at 114.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "347306fc-87ef-43e1-a98f-ca29ac9473e6")
+	)
+	(junction
+		(at 124.46 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "352af8be-9d08-4866-961e-b8632013179f")
+	)
+	(junction
+		(at 104.14 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "356b49b0-20ac-4c33-8df8-9b27dee0b312")
+	)
+	(junction
+		(at 175.26 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "357aa667-d746-4e3e-ab2a-484493e6765a")
+	)
+	(junction
+		(at 215.9 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "35d34a6d-9a4e-4a3b-8466-f5ffc597cfe1")
+	)
+	(junction
+		(at 246.38 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c")
+	)
+	(junction
+		(at 175.26 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "39869536-29f6-4e84-a33a-473fa8fb0f36")
+	)
+	(junction
+		(at 185.42 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3abcfbc6-0288-48d7-a0e0-144f99e6dd30")
+	)
+	(junction
+		(at 144.78 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3d987483-3b5e-44fb-b675-40705bf855c1")
+	)
+	(junction
+		(at 134.62 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ddd9e62-5556-463c-9539-c0d582cc40e9")
+	)
+	(junction
+		(at 43.18 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4420dc63-3aee-4086-92ad-39d849507e61")
+	)
+	(junction
+		(at 215.9 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "459e2fd2-0437-406d-b9bb-4b3872c36b3e")
+	)
+	(junction
+		(at 205.74 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4788fde7-f606-4229-8a7b-9fa04f56d3d4")
+	)
+	(junction
+		(at 114.3 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "490a89d7-a161-4f1a-9b45-a55729d9d59b")
+	)
+	(junction
+		(at 124.46 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c74baef-72cb-4cdf-b4eb-a3d28782257d")
+	)
+	(junction
+		(at 53.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c7a50e9-7650-493b-b0a7-057b900a13a7")
+	)
+	(junction
+		(at 63.5 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9")
+	)
+	(junction
+		(at 165.1 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4df4e0a7-6e46-4c32-959d-094f3457d75b")
+	)
+	(junction
+		(at 43.18 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e641ba8-cbcf-42cf-89f0-ac977902bf98")
+	)
+	(junction
+		(at 73.66 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fc826ad-ef7b-406a-9b89-76eb2c211523")
+	)
+	(junction
+		(at 53.34 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fce0301-62b3-4ef1-9bae-8d55ea745d66")
+	)
+	(junction
+		(at 185.42 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "508ddd33-e065-44a5-a999-5944a523ef76")
+	)
+	(junction
+		(at 175.26 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "50f2ad43-aa07-4fd1-8d58-f22d767da31f")
+	)
+	(junction
+		(at 185.42 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "51c7f5d6-d0e7-40a3-b648-cddc977cf840")
+	)
+	(junction
+		(at 195.58 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "51dbbda9-bf1e-445e-9a43-5f378a7d2f7f")
+	)
+	(junction
+		(at 53.34 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53bb27f5-9b54-4704-b90e-33b3053be6c4")
+	)
+	(junction
+		(at 114.3 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b35d564-88c3-4b41-864f-a4f82bc4c871")
+	)
+	(junction
+		(at 43.18 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5bfc49c0-36f2-431c-81ea-cf78c71d7681")
+	)
+	(junction
+		(at 215.9 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "609da949-dc88-4120-abd9-ca9d5f99505d")
+	)
+	(junction
+		(at 83.82 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6540c8f5-821c-412a-807a-c3ef62138fbb")
+	)
+	(junction
+		(at 63.5 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "65600a9a-e392-4668-8020-aa25d35ebf98")
+	)
+	(junction
+		(at 104.14 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "65f27e9a-164b-490a-b847-29af22012c0c")
+	)
+	(junction
+		(at 63.5 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "670a793c-4c48-41d1-9f07-66b1d7d84b06")
+	)
+	(junction
+		(at 83.82 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "672e2ce9-8f2c-43ff-9498-0e342bc1c65e")
+	)
+	(junction
+		(at 215.9 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6784984b-dd7d-4cfa-a87f-6cbcb1e61ab6")
+	)
+	(junction
+		(at 175.26 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "69e63d66-faab-411c-9093-a81235a7547c")
+	)
+	(junction
+		(at 63.5 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6b0b87a9-8a81-4bd1-ac24-ffcd6512236b")
+	)
+	(junction
+		(at 43.18 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6bfc7531-8adc-4c87-bf8a-788404262765")
+	)
+	(junction
+		(at 134.62 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1")
+	)
+	(junction
+		(at 154.94 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6ff7fc69-ca50-4b66-851e-eb36da3cadd8")
+	)
+	(junction
+		(at 63.5 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "712da204-b8e1-4637-b967-521ccf7b108c")
+	)
+	(junction
+		(at 73.66 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71e77471-d824-448e-a6de-31cce05e17c2")
+	)
+	(junction
+		(at 205.74 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "72e4e912-d3a6-49dd-a5cd-3717c5b10d71")
+	)
+	(junction
+		(at 73.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "742ecb41-f257-40d3-a6f3-d155d6036628")
+	)
+	(junction
+		(at 226.06 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77bb30a6-a1de-4dd1-a9f1-aff61d4e98ac")
+	)
+	(junction
+		(at 93.98 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "782ee96d-a257-4c78-ac0f-a3b5279bef37")
+	)
+	(junction
+		(at 53.34 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7943e9ed-5e22-49d3-a238-47d875f3e823")
+	)
+	(junction
+		(at 43.18 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7dbcae2f-e000-4aff-92b3-5518ea113182")
+	)
+	(junction
+		(at 104.14 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "822096c9-a5b4-460b-8639-9bbf1bb1a2fa")
+	)
+	(junction
+		(at 93.98 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84442e81-a253-49f6-ab0f-8ece0b39f637")
+	)
+	(junction
+		(at 53.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "86d88f2b-6e5b-493a-b3a4-5436a8374fae")
+	)
+	(junction
+		(at 104.14 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "88441b0d-9a40-4e18-8fc9-814cc1cb4d3e")
+	)
+	(junction
+		(at 185.42 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8a6c81db-4db5-4eb7-a06a-31575c90f62f")
+	)
+	(junction
+		(at 83.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bf191a4-2dcd-4018-b67a-91aef9fad846")
+	)
+	(junction
+		(at 144.78 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d88bb99-f0e4-4a81-b464-31814877675a")
+	)
+	(junction
+		(at 195.58 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8de5a888-7283-4e9f-99ef-73d74bb27108")
+	)
+	(junction
+		(at 205.74 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "90d2cc8f-50ae-48a5-81ff-9df8ee53f514")
+	)
+	(junction
+		(at 205.74 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "91635678-4449-4ed4-88c1-10b19deef1b0")
+	)
+	(junction
+		(at 246.38 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95b0c111-7d27-49ee-a08f-b6f35d9d5b54")
+	)
+	(junction
+		(at 93.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96a12dd2-d02f-4a86-aa6d-3a7015c06462")
+	)
+	(junction
+		(at 195.58 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "98319cb9-c3ce-4829-b82f-df8af9cb7381")
+	)
+	(junction
+		(at 134.62 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99c67f58-7bde-4417-a08c-823e6af847f2")
+	)
+	(junction
+		(at 93.98 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9a57387e-9b4d-41d6-99cb-8b5046a4210a")
+	)
+	(junction
+		(at 215.9 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9b94e996-7198-48de-9ff9-0a29d6599658")
+	)
+	(junction
+		(at 124.46 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9d2b0f02-b19d-4907-8835-9e7f8a8b9c34")
+	)
+	(junction
+		(at 226.06 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9e2bd5cb-7b23-4384-a3c5-2d4acf752984")
+	)
+	(junction
+		(at 93.98 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a2db7df7-b835-49df-98be-3c291238016c")
+	)
+	(junction
+		(at 185.42 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a3593416-7fea-415d-a48b-ed5f49c771b2")
+	)
+	(junction
+		(at 114.3 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a47737c8-d0f1-4d7f-a269-cdad9b41d18b")
+	)
+	(junction
+		(at 63.5 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a6cd881c-1146-4d92-9184-bf83a80c20c4")
+	)
+	(junction
+		(at 165.1 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a7400bf6-86c3-4d41-886e-57235a457a4c")
+	)
+	(junction
+		(at 63.5 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a77fc968-ce7b-41bf-ae47-af3789c36215")
+	)
+	(junction
+		(at 165.1 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9baaad2-c62c-4b79-a10b-261651ef4961")
+	)
+	(junction
+		(at 246.38 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9ece8f4-f868-428b-b7ff-a3dc07b47d6c")
+	)
+	(junction
+		(at 144.78 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aa4f9edb-d8b6-45e2-8d16-270f3c9fc990")
+	)
+	(junction
+		(at 104.14 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ab0811a2-347a-4a90-b4d0-f1b1ba038333")
+	)
+	(junction
+		(at 195.58 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ac27d187-5d39-4e20-a98d-006d06095529")
+	)
+	(junction
+		(at 226.06 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ac7cf2c1-f0eb-4f3a-bdfc-60426aa052ac")
+	)
+	(junction
+		(at 124.46 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b1e2ebf4-6a50-4b42-af1b-0294cfee2751")
+	)
+	(junction
+		(at 83.82 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b23bc3a0-3ebe-44a5-9126-8b5c4d648e08")
+	)
+	(junction
+		(at 205.74 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b3d0ee10-bd96-4305-9675-c2f1f7a7662b")
+	)
+	(junction
+		(at 114.3 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b5ce3eda-e357-44e1-9c69-f84009fc7a87")
+	)
+	(junction
+		(at 154.94 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b7093823-b63a-4a1a-b279-5afe0127ec9d")
+	)
+	(junction
+		(at 246.38 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b98759bc-77be-4dce-9aa2-cc5ce3889034")
+	)
+	(junction
+		(at 154.94 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b995f4ca-5e8d-4350-aff6-b7bea568d7f5")
+	)
+	(junction
+		(at 53.34 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3")
+	)
+	(junction
+		(at 205.74 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb9843d1-ea35-45a8-bd3d-5b381b0dc875")
+	)
+	(junction
+		(at 175.26 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bbd2fe65-aac5-437c-9177-9832921486d5")
+	)
+	(junction
+		(at 175.26 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bcf6a98c-2d79-4afb-9a5e-6558bb743cec")
+	)
+	(junction
+		(at 226.06 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bdaa210f-5df4-43b3-b2cb-9563b1c2f196")
+	)
+	(junction
+		(at 154.94 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be75ea2d-b3b9-4fd0-812b-104329fac661")
+	)
+	(junction
+		(at 144.78 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "befc6138-873b-4406-bc9e-e5a72f7f36fe")
+	)
+	(junction
+		(at 175.26 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf44b855-bf79-4ceb-a9a9-021d72c7f67c")
+	)
+	(junction
+		(at 83.82 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0")
+	)
+	(junction
+		(at 134.62 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c29c26fc-c285-45ba-9e88-4c2a02375307")
+	)
+	(junction
+		(at 165.1 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c331d35d-23c9-43ea-b243-b660cb5f4bdb")
+	)
+	(junction
+		(at 134.62 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c3f1775c-0d63-41d3-b7d8-a4c96d241ce3")
+	)
+	(junction
+		(at 93.98 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c41e97f8-87c8-4e82-92ed-e4644d6f526e")
+	)
+	(junction
+		(at 124.46 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c51de65b-dd06-4a71-8763-eab77eba6638")
+	)
+	(junction
+		(at 246.38 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c56d20e0-377b-42bf-89fc-25b698ca10b4")
+	)
+	(junction
+		(at 114.3 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c5afc93c-0846-4cf9-8f93-4c8f2232c9fa")
+	)
+	(junction
+		(at 215.9 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c749e970-c6bb-4721-8468-39c6437ef420")
+	)
+	(junction
+		(at 83.82 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c7d88142-1b7e-4dd1-b026-f2267e06dab1")
+	)
+	(junction
+		(at 43.18 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8f222f6-943e-4d7d-919b-3278ca0ede33")
+	)
+	(junction
+		(at 195.58 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c9e3ffd4-a7b6-4729-8189-cdaba274ef13")
+	)
+	(junction
+		(at 144.78 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc2d9922-84c9-42ce-883b-c028a251c101")
+	)
+	(junction
+		(at 246.38 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc477f6c-44d3-44d1-b104-0f5c17b8e6fa")
+	)
+	(junction
+		(at 124.46 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cd054c4e-f9d4-4701-a538-16740432e58d")
+	)
+	(junction
+		(at 226.06 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cd48bbd4-ca90-4b55-bc6b-cf9da8cf6333")
+	)
+	(junction
+		(at 195.58 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cf841124-1985-4dfd-858c-868589098888")
+	)
+	(junction
+		(at 63.5 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cfd86ddc-0810-4057-8a79-4468ec7b2424")
+	)
+	(junction
+		(at 205.74 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d07b66d1-3d51-4607-8fd1-974bbf8f9371")
+	)
+	(junction
+		(at 53.34 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d328f077-6d93-4470-a2b2-f4c9287daff0")
+	)
+	(junction
+		(at 215.9 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d36ca894-6805-484d-8f86-5039b03b9346")
+	)
+	(junction
+		(at 205.74 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d3f7612d-781e-42f5-a5f0-fe2744aa5d60")
+	)
+	(junction
+		(at 144.78 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d4ac21a4-2c41-454b-9f76-4f3d030f7ac8")
+	)
+	(junction
+		(at 83.82 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5a179bd-82b1-4661-aebc-4c4d4801bdff")
+	)
+	(junction
+		(at 144.78 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b7ef4f-419a-421c-a02d-fd71016e6c97")
+	)
+	(junction
+		(at 154.94 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d774ae68-7d44-45a8-babf-4a5136fe82a1")
+	)
+	(junction
+		(at 185.42 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d8d69513-50ec-441c-a953-5a6c226b729f")
+	)
+	(junction
+		(at 226.06 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dc26fb26-3b4c-4f5f-8838-a826029b5e11")
+	)
+	(junction
+		(at 195.58 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dc8b09d2-1c55-4758-be69-6f8072d6abe0")
+	)
+	(junction
+		(at 114.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcab5abe-0f5a-44d8-b554-722164ca6a23")
+	)
+	(junction
+		(at 154.94 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dded6bb5-453a-4491-9278-65d2368e4bc0")
+	)
+	(junction
+		(at 93.98 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dece07f3-2868-47c6-b119-0ca286e7cc50")
+	)
+	(junction
+		(at 175.26 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e3827bb6-d8e8-410a-8c19-3e64c8191b94")
+	)
+	(junction
+		(at 154.94 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e46432a2-96f1-448e-8928-bfcbbf445ca9")
+	)
+	(junction
+		(at 215.9 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e55cb9f7-7fdb-471f-8c22-7af22a3199f5")
+	)
+	(junction
+		(at 175.26 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e66342f0-16d5-4367-b00a-d7cf257720d9")
+	)
+	(junction
+		(at 226.06 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e7e968af-bf0e-4847-a623-74d007921b9f")
+	)
+	(junction
+		(at 165.1 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ed20875e-b9a5-4926-97e0-c3921a5eb1cd")
+	)
+	(junction
+		(at 114.3 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee17efa1-5df9-47d0-aec2-a440d8b33e4c")
+	)
+	(junction
+		(at 104.14 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f0d84c95-52f0-41cd-8742-4de83021f783")
+	)
+	(junction
+		(at 134.62 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f1379b2f-59c4-4b61-a98f-3645b6e5fe6b")
+	)
+	(junction
+		(at 104.14 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f24e6016-cf0c-4fe9-b584-ca06dfdbe767")
+	)
+	(junction
+		(at 134.62 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f299a1cc-612f-4d6b-9276-fe837e4e91d9")
+	)
+	(junction
+		(at 134.62 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f368e14e-0af5-4e13-a581-f1a139c24e5c")
+	)
+	(junction
+		(at 43.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6f817c6-438a-4497-93b1-8dc1f36a395c")
+	)
+	(junction
+		(at 226.06 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f70d9535-4e8c-4a08-92e9-2c160ff79eff")
+	)
+	(junction
+		(at 53.34 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f7606fcd-7602-4f5d-b31b-5fb97e1ca534")
+	)
+	(junction
+		(at 124.46 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd")
+	)
+	(junction
+		(at 144.78 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8b3b54a-7c03-49e4-8762-b4ef31db5afd")
+	)
+	(junction
+		(at 246.38 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa2795fd-0138-4010-b310-3d5e73c1be1c")
+	)
+	(junction
+		(at 195.58 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fb315348-48a4-4210-8623-991734f6ee66")
+	)
+	(junction
+		(at 73.66 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbda2010-a213-45bb-958d-0c9446d51e42")
+	)
+	(junction
+		(at 73.66 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc393c80-fb90-44e5-ac86-763463fd8acd")
+	)
+	(junction
+		(at 114.3 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc6abd7a-92c0-4b05-85ed-b3bd910676e1")
+	)
+	(junction
+		(at 144.78 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdc0071f-cdad-424a-87db-7bd8a0569159")
+	)
+	(wire
+		(pts
+			(xy 83.82 60.96) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022d84d0-7bcb-4024-8618-6f3a7f7b41aa")
+	)
+	(wire
+		(pts
+			(xy 144.78 25.4) (xy 144.78 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0406a358-3219-4537-99c7-cfb994e5303c")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0429bfe1-2992-4c6f-bb22-b2e8e5724910")
+	)
+	(wire
+		(pts
+			(xy 205.74 182.88) (xy 205.74 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "04f743f4-6844-43ab-a149-4db3a42e61b3")
+	)
+	(wire
+		(pts
+			(xy 185.42 203.2) (xy 185.42 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "054d0701-89e5-4918-a35c-1668152b63f2")
+	)
+	(wire
+		(pts
+			(xy 205.74 203.2) (xy 205.74 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0698b251-ec3b-4a4c-821a-adad423d20ba")
+	)
+	(wire
+		(pts
+			(xy 185.42 162.56) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "070c607f-224b-4963-a847-a5abbe4e2e9d")
+	)
+	(wire
+		(pts
+			(xy 73.66 109.22) (xy 93.98 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07ee4d30-e80a-41ae-829d-e3cecf87d77e")
+	)
+	(wire
+		(pts
+			(xy 226.06 81.28) (xy 226.06 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0805b235-8597-4158-8971-28b691867ce0")
+	)
+	(wire
+		(pts
+			(xy 114.3 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0897e94f-d1e3-47ff-89f6-5de7a1349783")
+	)
+	(wire
+		(pts
+			(xy 226.06 182.88) (xy 226.06 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "08999926-6e91-4cd1-80de-7963ec46f28b")
+	)
+	(wire
+		(pts
+			(xy 175.26 109.22) (xy 195.58 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a962d83-8897-42a2-883b-90f8b3b46e9e")
+	)
+	(wire
+		(pts
+			(xy 246.38 68.58) (xy 246.38 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aee33c0-3781-43dc-99cb-690f399192cd")
+	)
+	(wire
+		(pts
+			(xy 154.94 48.26) (xy 175.26 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b08be29-0149-48a5-b5a3-9614befb1784")
+	)
+	(wire
+		(pts
+			(xy 195.58 203.2) (xy 205.74 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bbfe73f-3f00-4157-8def-4fa012c6902e")
+	)
+	(wire
+		(pts
+			(xy 53.34 231.14) (xy 73.66 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0cfcf878-b8da-4ac7-be72-6319dfc721fd")
+	)
+	(wire
+		(pts
+			(xy 43.18 182.88) (xy 43.18 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e0cdb3f-d11e-41fa-b224-dbdc3dd27130")
+	)
+	(wire
+		(pts
+			(xy 43.18 40.64) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f76c070-bcf8-4924-a8c5-3abe13c36f41")
+	)
+	(wire
+		(pts
+			(xy 63.5 81.28) (xy 63.5 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ef6261-91ba-4d4c-99ef-8991b7c91dc8")
+	)
+	(wire
+		(pts
+			(xy 104.14 101.6) (xy 104.14 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12080e73-a151-4804-ac9b-ac3ac13653e9")
+	)
+	(wire
+		(pts
+			(xy 73.66 48.26) (xy 93.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12a939e2-2ab8-4d74-a5c9-6d61a9528b6e")
+	)
+	(wire
+		(pts
+			(xy 63.5 182.88) (xy 63.5 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13961bb6-28aa-4ee0-a270-8bc7b0339a4b")
+	)
+	(wire
+		(pts
+			(xy 154.94 68.58) (xy 175.26 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14d9635b-ccaf-4f8c-a2a6-101eb19eb42d")
+	)
+	(wire
+		(pts
+			(xy 134.62 210.82) (xy 154.94 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "150130ef-d28d-4782-b4fc-0c67b58e9b8e")
+	)
+	(wire
+		(pts
+			(xy 93.98 190.5) (xy 114.3 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1767f007-bd12-458a-9e69-f01cc8a5ed24")
+	)
+	(wire
+		(pts
+			(xy 205.74 142.24) (xy 205.74 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18ccb399-8ad2-4b42-b317-de1e9939e9e9")
+	)
+	(wire
+		(pts
+			(xy 104.14 25.4) (xy 104.14 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af5b449-9a68-414b-a41f-d6f6cba715a8")
+	)
+	(wire
+		(pts
+			(xy 165.1 203.2) (xy 165.1 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1bc4e1a4-fd5a-4e45-a9b9-9fd07d45de91")
+	)
+	(wire
+		(pts
+			(xy 73.66 81.28) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0140d1-6775-49db-9fd5-7ecf63ae1284")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "211f763f-7ef6-4fb5-98df-2e2ff37faa42")
+	)
+	(wire
+		(pts
+			(xy 215.9 190.5) (xy 238.76 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "21e9b220-b0aa-4b7e-876c-6512dad6a1e2")
+	)
+	(wire
+		(pts
+			(xy 63.5 40.64) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23f46f84-f16d-4b0b-b463-c2c0244adcc0")
+	)
+	(wire
+		(pts
+			(xy 83.82 203.2) (xy 83.82 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24025a56-ae5c-4c1a-a354-e66bbbcc4688")
+	)
+	(wire
+		(pts
+			(xy 33.02 129.54) (xy 53.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24da3fea-844d-4666-b730-f8d7b708f242")
+	)
+	(wire
+		(pts
+			(xy 185.42 40.64) (xy 185.42 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "265c8115-55ea-4d09-95c1-3178314bfa04")
+	)
+	(wire
+		(pts
+			(xy 53.34 129.54) (xy 73.66 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26f78b89-ba4b-4b48-90d1-1245694ead6f")
+	)
+	(wire
+		(pts
+			(xy 83.82 162.56) (xy 83.82 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2703e5ce-9651-45e1-8bd6-144e60387b78")
+	)
+	(wire
+		(pts
+			(xy 33.02 109.22) (xy 53.34 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2832f642-62e7-4a51-b112-f728658e7714")
+	)
+	(wire
+		(pts
+			(xy 195.58 68.58) (xy 215.9 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "28f7b63d-6686-4459-afe8-f6dd162a4f81")
+	)
+	(wire
+		(pts
+			(xy 53.34 68.58) (xy 73.66 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29a0e612-9a4c-422c-a9b8-8a9fe3879b8a")
+	)
+	(wire
+		(pts
+			(xy 215.9 149.86) (xy 238.76 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29b6abf5-e762-402b-a7ef-754a71930101")
+	)
+	(wire
+		(pts
+			(xy 83.82 101.6) (xy 83.82 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a44e441-f6d5-4994-b7ba-34283a1facc7")
+	)
+	(wire
+		(pts
+			(xy 124.46 121.92) (xy 124.46 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0")
+	)
+	(wire
+		(pts
+			(xy 114.3 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a65926a-d988-49f6-92e7-6e4d5936462f")
+	)
+	(wire
+		(pts
+			(xy 195.58 170.18) (xy 215.9 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ada3dc7-0276-4fb5-993b-c6f072f33b85")
+	)
+	(wire
+		(pts
+			(xy 165.1 162.56) (xy 165.1 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2afd7500-0a15-4710-acc0-4f03472785c3")
+	)
+	(wire
+		(pts
+			(xy 165.1 60.96) (xy 165.1 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b8c9def-eaec-4abd-b08a-c3613e6389df")
+	)
+	(wire
+		(pts
+			(xy 53.34 109.22) (xy 73.66 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd")
+	)
+	(wire
+		(pts
+			(xy 124.46 25.4) (xy 124.46 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3115f7a7-e786-49c1-9e4c-25c171cfeb33")
+	)
+	(wire
+		(pts
+			(xy 73.66 68.58) (xy 93.98 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3197b37c-ee5b-406a-ab67-08670d4b8c09")
+	)
+	(wire
+		(pts
+			(xy 215.9 223.52) (xy 226.06 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "331adf6b-edc7-41b1-8701-a50d3af94787")
+	)
+	(wire
+		(pts
+			(xy 165.1 182.88) (xy 165.1 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "335e6f69-208d-4946-a709-07b34240cbfe")
+	)
+	(wire
+		(pts
+			(xy 175.26 231.14) (xy 195.58 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34d9b895-8709-4ae3-8234-e9c042dd7992")
+	)
+	(wire
+		(pts
+			(xy 154.94 88.9) (xy 175.26 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35f5724f-e5dd-4205-b169-9ef9f7b3efa2")
+	)
+	(wire
+		(pts
+			(xy 195.58 149.86) (xy 215.9 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38c60e5d-a6e0-4b17-9178-ac6efdd97384")
+	)
+	(wire
+		(pts
+			(xy 63.5 60.96) (xy 63.5 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "397f8ae6-f8de-4848-93b9-bc08977c0634")
+	)
+	(wire
+		(pts
+			(xy 53.34 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "39a93c24-4e85-400f-b634-4894827c3230")
+	)
+	(wire
+		(pts
+			(xy 246.38 210.82) (xy 246.38 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a9fab7b-7f53-4445-b1a0-755685a5b87b")
+	)
+	(wire
+		(pts
+			(xy 134.62 68.58) (xy 154.94 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b15c81d-3687-4710-9aa6-d57ee4885603")
+	)
+	(wire
+		(pts
+			(xy 63.5 121.92) (xy 63.5 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5")
+	)
+	(wire
+		(pts
+			(xy 114.3 190.5) (xy 134.62 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb")
+	)
+	(wire
+		(pts
+			(xy 195.58 109.22) (xy 215.9 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d4e19e8-2fb5-4e22-930a-612c1a48f37c")
+	)
+	(wire
+		(pts
+			(xy 226.06 25.4) (xy 226.06 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e8a4dda-891b-4819-a0ec-6d09bab41776")
+	)
+	(wire
+		(pts
+			(xy 154.94 231.14) (xy 175.26 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f7461c6-c2c3-4fe0-b1c0-d702c7e88622")
+	)
+	(wire
+		(pts
+			(xy 226.06 60.96) (xy 226.06 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40278c5a-7892-4426-82ce-3b5f75d33db8")
+	)
+	(wire
+		(pts
+			(xy 73.66 170.18) (xy 93.98 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40ad23e4-b284-4d51-a92e-26a2272af251")
+	)
+	(wire
+		(pts
+			(xy 165.1 121.92) (xy 165.1 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "411efa8a-c2b6-469e-b517-3b3f24ffe025")
+	)
+	(wire
+		(pts
+			(xy 73.66 190.5) (xy 93.98 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "432577d5-87d0-4924-a72a-e407dd2ee4b0")
+	)
+	(wire
+		(pts
+			(xy 134.62 170.18) (xy 154.94 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44b0d7a3-542f-48ea-8a2f-25ca02bd7f05")
+	)
+	(wire
+		(pts
+			(xy 53.34 170.18) (xy 73.66 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4554fe48-1b8d-466c-b3f4-c87fb3d79947")
+	)
+	(wire
+		(pts
+			(xy 43.18 60.96) (xy 43.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456f0365-d37d-43a2-afac-d06c44cc48af")
+	)
+	(wire
+		(pts
+			(xy 154.94 129.54) (xy 175.26 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "462b3865-9668-49d6-a9d9-1406a843104e")
+	)
+	(wire
+		(pts
+			(xy 114.3 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "473d672b-6459-459b-93fc-780e5d8f9818")
+	)
+	(wire
+		(pts
+			(xy 226.06 121.92) (xy 226.06 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4905f532-fc39-4175-9bc0-d3b0b2aab86e")
+	)
+	(wire
+		(pts
+			(xy 124.46 81.28) (xy 124.46 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "495f9334-ca7f-4aa5-8d75-09576f1afa2c")
+	)
+	(wire
+		(pts
+			(xy 104.14 182.88) (xy 104.14 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4bc89a8f-f8d9-4d47-a286-fb87f34a3ba1")
+	)
+	(wire
+		(pts
+			(xy 63.5 203.2) (xy 63.5 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d757dc1-e039-4666-8204-33ddd2c3d535")
+	)
+	(wire
+		(pts
+			(xy 165.1 81.28) (xy 165.1 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f7b113-f5f8-43e0-9da7-2a02dc224210")
+	)
+	(wire
+		(pts
+			(xy 246.38 190.5) (xy 246.38 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5194f352-1f61-4ee5-af2e-f0eb341e3d13")
+	)
+	(wire
+		(pts
+			(xy 195.58 48.26) (xy 215.9 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52932ef5-0b57-4b4e-99a0-5bd14e9f6829")
+	)
+	(wire
+		(pts
+			(xy 226.06 162.56) (xy 226.06 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "530fd8d7-df39-43ed-b05c-34496eb7d3a1")
+	)
+	(wire
+		(pts
+			(xy 33.02 190.5) (xy 53.34 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55243e41-6164-4661-b707-a6f503f12968")
+	)
+	(wire
+		(pts
+			(xy 53.34 190.5) (xy 73.66 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "557847f5-42a8-4c4a-a4d9-d21678c28920")
+	)
+	(wire
+		(pts
+			(xy 104.14 60.96) (xy 104.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5837ecd4-cf70-4c14-9c7b-bb5f05f8274a")
+	)
+	(wire
+		(pts
+			(xy 93.98 231.14) (xy 114.3 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "59384b6c-2072-4474-b0f7-71a68de7f080")
+	)
+	(wire
+		(pts
+			(xy 104.14 81.28) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6ae0de-21c8-4433-a4e0-a3b552474fb0")
+	)
+	(wire
+		(pts
+			(xy 154.94 190.5) (xy 175.26 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5baecb37-4d65-4174-bd66-a5145576e2b9")
+	)
+	(wire
+		(pts
+			(xy 154.94 149.86) (xy 175.26 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5bf40b1a-0569-4c54-9cc9-b9bf89658c72")
+	)
+	(wire
+		(pts
+			(xy 134.62 48.26) (xy 154.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d63c1a3-5086-42ca-8afa-60afe2472b23")
+	)
+	(wire
+		(pts
+			(xy 93.98 210.82) (xy 114.3 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f73184b-d2cf-4b7b-afcf-f14e002f7ce1")
+	)
+	(wire
+		(pts
+			(xy 53.34 88.9) (xy 73.66 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b5d548-d07f-40b1-8e16-72d513f499f2")
+	)
+	(wire
+		(pts
+			(xy 124.46 203.2) (xy 124.46 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62806607-b508-4eb1-86e9-30fc018db27c")
+	)
+	(wire
+		(pts
+			(xy 33.02 210.82) (xy 53.34 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6329f5e0-c3e3-42c6-b639-2bebe7a40e8b")
+	)
+	(wire
+		(pts
+			(xy 195.58 210.82) (xy 215.9 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "63344b6a-026f-4395-b562-d9979a7e5b8f")
+	)
+	(wire
+		(pts
+			(xy 93.98 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6414e19f-a27a-435d-a47f-a63cba9086f1")
+	)
+	(wire
+		(pts
+			(xy 134.62 109.22) (xy 154.94 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64344100-c91d-4b5c-a8eb-9406d47360dd")
+	)
+	(wire
+		(pts
+			(xy 154.94 109.22) (xy 175.26 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "650e246e-9637-4cff-aa82-0f918369ac6f")
+	)
+	(wire
+		(pts
+			(xy 33.02 68.58) (xy 53.34 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68161b0c-a285-475d-a645-59648d12bc07")
+	)
+	(wire
+		(pts
+			(xy 134.62 149.86) (xy 154.94 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690a405c-1ac3-4b57-a93b-778dda168d2c")
+	)
+	(wire
+		(pts
+			(xy 134.62 190.5) (xy 154.94 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b21e6c7-ab97-41de-aae4-339e943db88e")
+	)
+	(wire
+		(pts
+			(xy 134.62 231.14) (xy 154.94 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b5263f0-0631-4b01-9161-0e209326bf8d")
+	)
+	(wire
+		(pts
+			(xy 165.1 40.64) (xy 165.1 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc")
+	)
+	(wire
+		(pts
+			(xy 195.58 129.54) (xy 215.9 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6de11233-64b7-40cd-8526-970a6c43cb30")
+	)
+	(wire
+		(pts
+			(xy 205.74 40.64) (xy 205.74 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f1d74d1-18f8-4f5b-8c5d-e1587ab09b83")
+	)
+	(wire
+		(pts
+			(xy 246.38 149.86) (xy 246.38 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f77a68c-1e32-433a-820e-9683e6fd5e12")
+	)
+	(wire
+		(pts
+			(xy 205.74 162.56) (xy 205.74 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7083b47b-e7bb-4169-bf41-06719234452e")
+	)
+	(wire
+		(pts
+			(xy 246.38 88.9) (xy 246.38 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70c6e975-f457-4759-9791-1d1de45afbb3")
+	)
+	(wire
+		(pts
+			(xy 134.62 129.54) (xy 154.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70f3f37d-4259-413e-b59a-babccfdc3a89")
+	)
+	(wire
+		(pts
+			(xy 43.18 121.92) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "727cc522-ef34-45d4-b711-997054ff0b37")
+	)
+	(wire
+		(pts
+			(xy 33.02 48.26) (xy 53.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "737596e8-f579-4b1f-aa71-a489d8ba56da")
+	)
+	(wire
+		(pts
+			(xy 93.98 149.86) (xy 114.3 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "770cc50c-0085-42e2-b068-cd0ae3b59919")
+	)
+	(wire
+		(pts
+			(xy 246.38 25.4) (xy 246.38 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "794205f1-2f7e-4200-b59c-c02481b0416f")
+	)
+	(wire
+		(pts
+			(xy 73.66 88.9) (xy 93.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79a42c80-d7a4-4e03-9070-f9fff835a239")
+	)
+	(wire
+		(pts
+			(xy 33.02 40.64) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a4231d0-fb4b-4c65-9cc1-75d3ed714150")
+	)
+	(wire
+		(pts
+			(xy 195.58 88.9) (xy 215.9 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7c26a162-db98-4260-be20-c438c861d890")
+	)
+	(wire
+		(pts
+			(xy 185.42 142.24) (xy 185.42 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7caa1de0-1c5d-4933-9515-38159a29c856")
+	)
+	(wire
+		(pts
+			(xy 104.14 203.2) (xy 104.14 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8487a4c1-7c32-44ea-a841-69a619e14d61")
+	)
+	(wire
+		(pts
+			(xy 165.1 25.4) (xy 165.1 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8506f273-12d6-426d-910b-0c9eecbe3765")
+	)
+	(wire
+		(pts
+			(xy 134.62 88.9) (xy 154.94 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86d6e974-6898-4932-91cb-e8a4c4c283b7")
+	)
+	(wire
+		(pts
+			(xy 215.9 88.9) (xy 238.76 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8703162e-62ad-4314-bd1a-c51105c1574a")
+	)
+	(wire
+		(pts
+			(xy 104.14 162.56) (xy 104.14 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c3cf446-d0cc-4b1b-9218-75f38db02fb3")
+	)
+	(wire
+		(pts
+			(xy 215.9 129.54) (xy 238.76 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c43e497-1549-4f9e-8686-7a4351f1f35f")
+	)
+	(wire
+		(pts
+			(xy 53.34 210.82) (xy 73.66 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d25f923-67ff-47ea-9485-05bc5282bdab")
+	)
+	(wire
+		(pts
+			(xy 93.98 48.26) (xy 114.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d73bae8-988b-435b-a882-ae9668b41d7e")
+	)
+	(wire
+		(pts
+			(xy 104.14 142.24) (xy 104.14 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dd624a1-3da3-42c1-929d-9366cd043e3d")
+	)
+	(wire
+		(pts
+			(xy 246.38 48.26) (xy 246.38 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f339462-56e0-4361-9d9b-983c75fb21ef")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "909384ab-bc1c-47d8-a34d-c3d137febfc2")
+	)
+	(wire
+		(pts
+			(xy 124.46 101.6) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91eea887-ea8a-4221-ba92-e5ec1caacc4f")
+	)
+	(wire
+		(pts
+			(xy 215.9 48.26) (xy 238.76 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93a432e7-b427-461e-ad5f-cc7bda1f8bc4")
+	)
+	(wire
+		(pts
+			(xy 124.46 142.24) (xy 124.46 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94397688-ce0e-48d4-a59c-7257120bf834")
+	)
+	(wire
+		(pts
+			(xy 185.42 60.96) (xy 185.42 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96776fa9-dbd1-46ef-91bd-e95f23cda112")
+	)
+	(wire
+		(pts
+			(xy 175.26 170.18) (xy 195.58 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "969acf2b-33fe-4e89-abf2-451f22e884f4")
+	)
+	(wire
+		(pts
+			(xy 205.74 101.6) (xy 205.74 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "97a65ef9-5994-4805-9e12-ca2b38a42461")
+	)
+	(wire
+		(pts
+			(xy 215.9 68.58) (xy 238.76 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a462111-1607-4c46-9a00-175a4d0331ab")
+	)
+	(wire
+		(pts
+			(xy 114.3 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c79c76c-a95b-401f-9edb-a06a0cceaa4b")
+	)
+	(wire
+		(pts
+			(xy 185.42 182.88) (xy 185.42 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d4fc90e-2670-42d9-b5a8-2138817fee8a")
+	)
+	(wire
+		(pts
+			(xy 53.34 48.26) (xy 73.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ec847-5716-4125-b40b-fdbd3a1587a7")
+	)
+	(wire
+		(pts
+			(xy 165.1 101.6) (xy 165.1 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f711890-a6d6-4440-8bc1-ed469cb6acc4")
+	)
+	(wire
+		(pts
+			(xy 83.82 182.88) (xy 83.82 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a0b86442-47da-481e-aac6-2c18430e056b")
+	)
+	(wire
+		(pts
+			(xy 93.98 101.6) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a226d887-7662-4dbd-b58b-e683f5d85955")
+	)
+	(wire
+		(pts
+			(xy 114.3 231.14) (xy 134.62 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2aaec3e-8eba-49bd-8096-322f6bbfda7c")
+	)
+	(wire
+		(pts
+			(xy 195.58 190.5) (xy 215.9 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2f7e7c7-60d9-4682-87fe-fb69953ed6aa")
+	)
+	(wire
+		(pts
+			(xy 124.46 40.64) (xy 124.46 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a67c0815-f186-4f70-926f-1b264c84d8d8")
+	)
+	(wire
+		(pts
+			(xy 154.94 162.56) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a803bbba-64cc-448d-a04f-7f03127ebddd")
+	)
+	(wire
+		(pts
+			(xy 226.06 101.6) (xy 226.06 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8d4ba45-df5e-48fe-a1d7-c8d45db9b645")
+	)
+	(wire
+		(pts
+			(xy 53.34 149.86) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aac914ea-c9a3-4a8f-94e1-1f91cdd136a3")
+	)
+	(wire
+		(pts
+			(xy 93.98 129.54) (xy 114.3 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab578e4e-a4bf-4ab4-80fc-d97d4aea6370")
+	)
+	(wire
+		(pts
+			(xy 215.9 170.18) (xy 238.76 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab5a382d-ce16-4f08-a729-c04a9ee1a1bc")
+	)
+	(wire
+		(pts
+			(xy 114.3 210.82) (xy 134.62 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abd1d27d-b9d9-4cf6-b486-65a2a8efef41")
+	)
+	(wire
+		(pts
+			(xy 175.26 88.9) (xy 195.58 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "acc95df4-5464-4718-a58a-e43a56e1893a")
+	)
+	(wire
+		(pts
+			(xy 83.82 121.92) (xy 83.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73")
+	)
+	(wire
+		(pts
+			(xy 175.26 48.26) (xy 195.58 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "adf35dfa-3831-4e3a-9fdd-7a4ac7f5230d")
+	)
+	(wire
+		(pts
+			(xy 93.98 68.58) (xy 114.3 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aea6a633-b213-403d-b447-42d91d3ab4da")
+	)
+	(wire
+		(pts
+			(xy 175.26 68.58) (xy 195.58 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2797b5c-16d1-4c35-814c-4b30f0a6683b")
+	)
+	(wire
+		(pts
+			(xy 114.3 170.18) (xy 134.62 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3e14390-7dc6-416b-bbd5-cdf868192ca4")
+	)
+	(wire
+		(pts
+			(xy 73.66 129.54) (xy 93.98 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f6f053-44f0-4391-9873-b6231b8014db")
+	)
+	(wire
+		(pts
+			(xy 154.94 210.82) (xy 175.26 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b78fdc14-2c27-4eca-a54c-9e333096c8b6")
+	)
+	(wire
+		(pts
+			(xy 144.78 101.6) (xy 144.78 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7b2475f-30dc-4ea2-b799-96c21242154c")
+	)
+	(wire
+		(pts
+			(xy 175.26 210.82) (xy 195.58 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7c3f0e9-4787-4050-9c72-cdbaf3e08cfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 81.28) (xy 83.82 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5")
+	)
+	(wire
+		(pts
+			(xy 246.38 170.18) (xy 246.38 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba045c1c-f33c-4ee8-bfe6-db2af30446e4")
+	)
+	(wire
+		(pts
+			(xy 43.18 101.6) (xy 43.18 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb49a3de-620b-45ad-a54c-29dcceaf0796")
+	)
+	(wire
+		(pts
+			(xy 144.78 121.92) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf12198a-9e62-45c3-b466-f5d86de75219")
+	)
+	(wire
+		(pts
+			(xy 73.66 210.82) (xy 93.98 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c007dc03-0700-44f8-b7e3-69868fe31a12")
+	)
+	(wire
+		(pts
+			(xy 205.74 60.96) (xy 205.74 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0bbd51b-0041-4026-a546-37b4ba305884")
+	)
+	(wire
+		(pts
+			(xy 63.5 25.4) (xy 63.5 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1a940de-fa49-4106-a8b9-697952eec2a2")
+	)
+	(wire
+		(pts
+			(xy 104.14 121.92) (xy 104.14 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c298ba49-6974-4340-859f-5d5a2b4132ff")
+	)
+	(wire
+		(pts
+			(xy 124.46 182.88) (xy 124.46 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3555de4-415f-4041-a3dd-bd91effa102c")
+	)
+	(wire
+		(pts
+			(xy 175.26 182.88) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3f1f747-e966-4c2c-8090-4f190e07864a")
+	)
+	(wire
+		(pts
+			(xy 215.9 210.82) (xy 238.76 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c47e1aaa-477d-4221-9341-1084abdcfc96")
+	)
+	(wire
+		(pts
+			(xy 124.46 162.56) (xy 124.46 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6080a0e-4059-4120-b2e7-12c9aff607b7")
+	)
+	(wire
+		(pts
+			(xy 215.9 231.14) (xy 238.76 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c722c2d7-b406-487d-93db-8a7895592b31")
+	)
+	(wire
+		(pts
+			(xy 124.46 60.96) (xy 124.46 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c950d145-c024-47a8-ba57-97efd7bb658b")
+	)
+	(wire
+		(pts
+			(xy 175.26 149.86) (xy 195.58 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca3290da-38da-422f-ab90-d843d9ab6e32")
+	)
+	(wire
+		(pts
+			(xy 144.78 142.24) (xy 144.78 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca92ed7f-ae97-4c0c-81e4-820de1c001c1")
+	)
+	(wire
+		(pts
+			(xy 246.38 109.22) (xy 246.38 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdde081d-7bdd-42e6-869e-3ff07b8b464b")
+	)
+	(wire
+		(pts
+			(xy 185.42 121.92) (xy 185.42 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cee2f4f4-6cbc-4838-b71a-3189173bbcfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 40.64) (xy 83.82 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cff15ec3-f29c-4d36-8776-64c5d29be534")
+	)
+	(wire
+		(pts
+			(xy 83.82 25.4) (xy 83.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1088709-a9b9-4e05-8ea2-f87942ee2796")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 93.98 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1347903-ae03-46a2-a707-154093060583")
+	)
+	(wire
+		(pts
+			(xy 195.58 231.14) (xy 215.9 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d212462e-72b0-4fc0-81a2-e9aa2cbc9694")
+	)
+	(wire
+		(pts
+			(xy 144.78 40.64) (xy 144.78 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2183fb3-afd3-46ca-955e-993ea31aa5d3")
+	)
+	(wire
+		(pts
+			(xy 185.42 25.4) (xy 185.42 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2951d7e-82c5-4b56-9a90-ca8ae6d71e44")
+	)
+	(wire
+		(pts
+			(xy 205.74 25.4) (xy 205.74 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4107bae-81df-4028-a211-ea4ab3232bfc")
+	)
+	(wire
+		(pts
+			(xy 226.06 142.24) (xy 226.06 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4fda796-f5de-4013-bf1e-6a92a02b00f9")
+	)
+	(wire
+		(pts
+			(xy 43.18 162.56) (xy 43.18 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d56982aa-6580-4d04-83ea-6bf3a85282cc")
+	)
+	(wire
+		(pts
+			(xy 185.42 101.6) (xy 185.42 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d675b927-bdff-4eac-82e7-3f468caedaf2")
+	)
+	(wire
+		(pts
+			(xy 43.18 142.24) (xy 43.18 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d76ad758-0ae0-4ce6-9f67-c689c066c744")
+	)
+	(wire
+		(pts
+			(xy 144.78 182.88) (xy 144.78 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8747c5c-1650-4a8e-b6a0-4fa4acd098ae")
+	)
+	(wire
+		(pts
+			(xy 205.74 81.28) (xy 205.74 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d920ca82-8ad7-4105-a47d-6c01f55c13d9")
+	)
+	(wire
+		(pts
+			(xy 33.02 149.86) (xy 53.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da80b027-904b-4ca2-99c6-5937c80c825c")
+	)
+	(wire
+		(pts
+			(xy 63.5 142.24) (xy 63.5 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db492971-48ff-4667-996c-f5d540a20741")
+	)
+	(wire
+		(pts
+			(xy 205.74 121.92) (xy 205.74 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc91af22-52c4-4234-961f-adc3ed363a9c")
+	)
+	(wire
+		(pts
+			(xy 165.1 142.24) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dccfde3a-ff1d-42ec-97d5-a8f6cccea832")
+	)
+	(wire
+		(pts
+			(xy 33.02 170.18) (xy 53.34 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de8e54c6-84d9-47e5-8f08-dc3e96b8afdb")
+	)
+	(wire
+		(pts
+			(xy 43.18 81.28) (xy 43.18 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df5c3763-e66c-46c4-9070-0f73d8115bc4")
+	)
+	(wire
+		(pts
+			(xy 246.38 129.54) (xy 246.38 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfb5a082-e4d5-46ea-8dc8-c65064cd598b")
+	)
+	(wire
+		(pts
+			(xy 226.06 203.2) (xy 226.06 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e006a777-74b0-4f5f-bb4c-3ab7b31924c0")
+	)
+	(wire
+		(pts
+			(xy 93.98 170.18) (xy 114.3 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb")
+	)
+	(wire
+		(pts
+			(xy 144.78 81.28) (xy 144.78 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e444742a-24b1-4bbf-b7ee-438e6dffc9cc")
+	)
+	(wire
+		(pts
+			(xy 175.26 190.5) (xy 195.58 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5e38d44-8bf0-426b-a99f-727527ca9657")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6d06035-ccb7-4d3e-ae70-d73150e65bbb")
+	)
+	(wire
+		(pts
+			(xy 114.3 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa")
+	)
+	(wire
+		(pts
+			(xy 63.5 101.6) (xy 63.5 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edeeb0d9-51cc-411d-aac4-77f10b619702")
+	)
+	(wire
+		(pts
+			(xy 43.18 203.2) (xy 43.18 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee312ce0-2ae6-4337-8d15-666961b7d179")
+	)
+	(wire
+		(pts
+			(xy 154.94 170.18) (xy 175.26 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee36c21a-970c-453e-93f8-ab4961c20f44")
+	)
+	(wire
+		(pts
+			(xy 104.14 40.64) (xy 104.14 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5c9f05-d71b-4562-9939-852432c066c5")
+	)
+	(wire
+		(pts
+			(xy 144.78 162.56) (xy 144.78 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "efa47227-d3f9-4214-af64-a7e9107c0edb")
+	)
+	(wire
+		(pts
+			(xy 144.78 203.2) (xy 144.78 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f09677ca-cfdb-4119-9431-13dd6580ce71")
+	)
+	(wire
+		(pts
+			(xy 144.78 60.96) (xy 144.78 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0ce7c2b-d80c-49f2-bf63-62b750f7ca47")
+	)
+	(wire
+		(pts
+			(xy 73.66 231.14) (xy 93.98 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f2cc3c58-efff-41fa-a09a-222ad0afe609")
+	)
+	(wire
+		(pts
+			(xy 63.5 162.56) (xy 63.5 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5658dea-a5b6-4ba9-9360-11c3315c15be")
+	)
+	(wire
+		(pts
+			(xy 134.62 142.24) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f781a362-e0d4-48be-9d13-5686e05b406f")
+	)
+	(wire
+		(pts
+			(xy 215.9 109.22) (xy 238.76 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8283c82-a0d8-4f0c-bd6f-e9575336c7df")
+	)
+	(wire
+		(pts
+			(xy 33.02 231.14) (xy 53.34 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8f8e54e-33a9-4d2a-b35e-9b373b3563c7")
+	)
+	(wire
+		(pts
+			(xy 175.26 129.54) (xy 195.58 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f940918e-7aa4-499c-8be1-c536835b2ed6")
+	)
+	(wire
+		(pts
+			(xy 226.06 40.64) (xy 226.06 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa54e42a-1d6a-433e-bb23-df8ec8cd3dca")
+	)
+	(wire
+		(pts
+			(xy 43.18 25.4) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa765e67-a220-4a00-944c-7663298f0ead")
+	)
+	(wire
+		(pts
+			(xy 83.82 142.24) (xy 83.82 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b")
+	)
+	(wire
+		(pts
+			(xy 185.42 81.28) (xy 185.42 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ffe6085a-a7be-4653-b911-c10de4574454")
+	)
+	(global_label "IO 3"
+		(shape bidirectional)
+		(at 104.14 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "24ec698b-5cae-4571-b9c4-c0e35d64a64d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 104.14 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 1"
+		(shape bidirectional)
+		(at 63.5 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d4b15a5-8b6c-4ca3-a7bb-7848c8036590")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 63.5 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 9"
+		(shape bidirectional)
+		(at 226.06 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "388f2ae3-3697-4b0d-bb82-8cc7f8e58abf")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 226.06 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 7"
+		(shape bidirectional)
+		(at 185.42 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "45d4e03e-6cff-41ce-b946-708382da0601")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 185.42 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 0"
+		(shape bidirectional)
+		(at 43.18 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "465a517d-f0e1-4825-8675-1cce54bfa7a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 43.18 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "INTR"
+		(shape bidirectional)
+		(at 246.38 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4e12b932-2346-4e84-b5a4-80468334f3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 254.57 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 2"
+		(shape bidirectional)
+		(at 83.82 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70d42e66-a74c-4de2-af96-d1860851d3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 83.82 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 165.1 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 165.1 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 144.78 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d44cceb0-f409-4e5f-a98a-9feead2e845d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 8"
+		(shape bidirectional)
+		(at 205.74 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e036ec60-274a-4de6-9324-dafd5b920142")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 205.74 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 4"
+		(shape bidirectional)
+		(at 124.46 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f36f49e4-227f-479f-b914-786aa44dd568")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 190.5 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0188dba3-054f-4958-9440-27c9ca673633")
+		(property "Reference" "DI7"
+			(at 242.57 186.69 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 193.04 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "deea1889-824f-4f7a-a6be-9546db353c85")
+		)
+		(pin "2"
+			(uuid "2080be86-a538-40a8-8f30-ead2a96d02d3")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0263b847-a932-4a31-9f35-35bb23f7000d")
+		(property "Reference" "D62"
+			(at 152.4 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc2e60ca-c74f-4e4b-a0a0-9705327e9578")
+		)
+		(pin "2"
+			(uuid "d12efbfe-85ac-442f-8c0f-ddbe5646c7d5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D62")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04430572-8314-4d21-974c-22350cead1a6")
+		(property "Reference" "DS1"
+			(at 55.88 65.405 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 55.88 62.865 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3e433df4-9fec-4cfb-b60f-eebca7c574cf")
+		)
+		(pin "2"
+			(uuid "9bcc1487-0612-4bdb-a2de-a8b2f590b28f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 44.45 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080aaa87-0974-4a77-bf63-185495f411a0")
+		(property "Reference" "DS0"
+			(at 35.56 45.085 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 35.56 42.545 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bfacad1-28fd-4f2e-93dc-68f478b8a6ba")
+		)
+		(pin "2"
+			(uuid "376f73f9-79fa-4153-ae38-31ed5446db52")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09606075-7d6f-4679-9228-3a303ca4f40c")
+		(property "Reference" "RC9-1"
+			(at 220.98 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f5b128f-eb55-44dc-974a-3ac8a1869c2d")
+		)
+		(pin "2"
+			(uuid "9783c397-46c8-4a54-ad23-28d37f071b25")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09d14922-c46a-4bf1-bb2c-1d224060568c")
+		(property "Reference" "D40"
+			(at 111.76 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c2f1a1d2-df3d-4680-9706-2ca411fa6890")
+		)
+		(pin "2"
+			(uuid "f58fd788-6016-46e7-b903-3606dd2ec21d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D40")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 149.86 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d18473f-e37a-4136-b721-5a2e40e4f8ed")
+		(property "Reference" "DI5"
+			(at 242.57 146.05 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 152.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5a885ca-5076-44e6-9a84-d07474947dde")
+		)
+		(pin "2"
+			(uuid "047b5b54-de8b-4afc-abc2-c6d1f2d17bd2")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 170.18 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0ef17723-f7f8-4fdb-8913-5a4ceefbc065")
+		(property "Reference" "DI6"
+			(at 242.57 166.37 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 172.72 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df5a6b10-ba48-4f34-96ce-3832d480a7ee")
+		)
+		(pin "2"
+			(uuid "59f34a55-6ac4-496d-8c40-1b8f1eafbcb5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0f5e4226-91a2-4a41-9aae-518534f05932")
+		(property "Reference" "RC7-9"
+			(at 180.34 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e144b30-8fd2-4ccc-b8e5-b1ca3fb409ba")
+		)
+		(pin "2"
+			(uuid "0e4a0bb0-3e0e-44e1-9c80-03f9a9aa8952")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0fadd319-be81-4c25-8d23-e7495a114aa7")
+		(property "Reference" "RC4-0"
+			(at 119.38 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "efb1c47f-fe25-4bea-8081-43d3c19de5cd")
+		)
+		(pin "2"
+			(uuid "9138c970-6e3d-46df-9354-5174df2a4e52")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ff76361-9578-4f9f-a20c-f042e24a7755")
+		(property "Reference" "D5"
+			(at 30.48 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06")
+		)
+		(pin "2"
+			(uuid "cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "11f01cd8-f751-497f-9599-50fe1fc0a618")
+		(property "Reference" "RC5-4"
+			(at 139.7 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc28293-fab9-4f93-b3d5-ca9ee69110c4")
+		)
+		(pin "2"
+			(uuid "088ac770-af1e-4c4f-ad11-5b44a20594d8")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "13ddd48d-7d2b-415d-b8fa-15c71e245acc")
+		(property "Reference" "D61"
+			(at 152.4 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "745d89b9-e75a-40ae-97bc-d1eadf220f02")
+		)
+		(pin "2"
+			(uuid "7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D61")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "17d027e3-2b58-470b-9fc5-f21e547cdc82")
+		(property "Reference" "RC8-1"
+			(at 200.66 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7f893b29-9b1f-44b8-bac5-e11991e6b604")
+		)
+		(pin "2"
+			(uuid "6b5e04e4-6889-4e49-9600-35d15ee54578")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "19f0de4f-d7ab-4f51-9796-79808aba650f")
+		(property "Reference" "D97"
+			(at 213.36 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad12892f-d26f-4434-82fd-3de2937c1d41")
+		)
+		(pin "2"
+			(uuid "8b061bcb-2b37-4d89-bd19-fcd574e79f03")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D97")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1b13866a-6fbf-441b-9c64-56258379f43a")
+		(property "Reference" "D65"
+			(at 152.4 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c70f4670-9685-4aab-ac4f-4ebaf44d5847")
+		)
+		(pin "2"
+			(uuid "8b9c860d-59e1-424e-a148-1aa2c0db4056")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D65")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a")
+		(property "Reference" "RC6-4"
+			(at 160.02 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3427b432-e194-40af-9dcb-04dccafe2b0f")
+		)
+		(pin "2"
+			(uuid "8af48a1b-2c49-47d9-959c-ee33cdd6f977")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d4decb6-e690-4f06-b8aa-6dd29b7f2622")
+		(property "Reference" "D58"
+			(at 132.08 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0a89d11-f9ed-4dad-a764-70b931421ce9")
+		)
+		(pin "2"
+			(uuid "e072fab0-4e83-437a-8387-943f8bcc1213")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D58")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1e5f084d-4db5-48ad-a2a3-76f186559614")
+		(property "Reference" "RC3-1"
+			(at 99.06 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa")
+		)
+		(pin "2"
+			(uuid "40b7f115-b5d7-4fa0-b12b-c1c7b6866feb")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 210.82 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "210fa303-e6c4-43b3-8ff0-f2f9178c950d")
+		(property "Reference" "DI8"
+			(at 242.57 207.01 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 213.36 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cad82d1c-a62b-40c6-a2ae-61d28ed2d913")
+		)
+		(pin "2"
+			(uuid "ca0c8c70-cbfc-4421-833b-b58ab5f50511")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "213aaf81-8580-4880-9130-4c9d596a7095")
+		(property "Reference" "D90"
+			(at 213.36 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "441dc052-fc8b-4f81-9c35-f08ea1ca4cf5")
+		)
+		(pin "2"
+			(uuid "b7690702-7874-4b26-89ba-a175fce3360b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D90")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "213dd8be-31f7-488d-b5dc-6770d78fccd5")
+		(property "Reference" "RC9-6"
+			(at 220.98 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "593996ed-485e-495f-9d29-6951be77f078")
+		)
+		(pin "2"
+			(uuid "fa5ec1f4-4786-4d7c-9bb1-ab1ce7ad3038")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "22a72d93-d5b5-4a6b-95f6-755ac10ccf50")
+		(property "Reference" "RC4-7"
+			(at 119.38 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "18c97ab1-62df-42bc-9dfa-dba3415ee8e2")
+		)
+		(pin "2"
+			(uuid "ff0eb9a3-538a-4ebf-a42b-97fe870ddfea")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "244b7f9d-3923-4908-be6d-02c49eb4663c")
+		(property "Reference" "RC2-3"
+			(at 78.74 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1d79440a-2f90-4c0b-8d60-528615b0bd65")
+		)
+		(pin "2"
+			(uuid "7f1d0566-f385-4126-b190-2379308ed05b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 166.37 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2518146c-59f4-45b7-a4fa-f618686ab064")
+		(property "Reference" "DS6"
+			(at 157.48 167.005 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 157.48 164.465 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cee2f461-8f62-48d8-ac7b-1698deb984c1")
+		)
+		(pin "2"
+			(uuid "460b9088-619c-4166-a615-45e17ecf1f0d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2519cd5e-8ecf-41a4-a9d0-5b856882cb05")
+		(property "Reference" "D63"
+			(at 152.4 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ea1c9827-ebfa-43f1-b2c6-5a572466713e")
+		)
+		(pin "2"
+			(uuid "0496ba9c-818c-4d39-979a-e8785e06d12a")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D63")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "28137b00-0d76-493b-92b8-23037474163f")
+		(property "Reference" "RC1-3"
+			(at 58.42 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3")
+		)
+		(pin "2"
+			(uuid "41d35b0f-21b5-4da8-92df-229c816b63c5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2a208574-f638-4917-a68f-bc3ff176d324")
+		(property "Reference" "D75"
+			(at 172.72 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "503e8179-7a4a-4075-8fcf-2d7bb00a3908")
+		)
+		(pin "2"
+			(uuid "a744b0f2-49c4-46a7-9ec2-cefb21173879")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D75")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c50947a-4bb9-43c2-b65c-4726e224b6b0")
+		(property "Reference" "RC3-0"
+			(at 99.06 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b")
+		)
+		(pin "2"
+			(uuid "30241adf-a2e7-4976-a53a-5c267616618e")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2cd8f716-5a6b-4cee-ad2e-612d075ffebf")
+		(property "Reference" "RC5-9"
+			(at 139.7 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f37bc637-a5fa-420e-ae7d-11681e40308a")
+		)
+		(pin "2"
+			(uuid "97b6ff47-ae10-45e9-81f0-a4902039b249")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2e38accc-5291-44a5-82e8-9bec928b99c0")
+		(property "Reference" "D18"
+			(at 50.8 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20ca8cf6-b241-4581-b5e1-dadf97a2cf3f")
+		)
+		(pin "2"
+			(uuid "dc0b457e-4296-4b82-a953-b255f1e09c5c")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D18")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2f872c45-59ae-4f02-abee-114e38b97a80")
+		(property "Reference" "D87"
+			(at 193.04 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4139db20-9977-4a84-b30c-e04c47ec888a")
+		)
+		(pin "2"
+			(uuid "bdc078b6-22f8-427e-a1f3-872c3722a746")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D87")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30340eba-9ed0-42ff-b11f-98a864f7223e")
+		(property "Reference" "RC1-4"
+			(at 58.42 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aa956a67-c26e-4a57-9ddb-59688a6476ad")
+		)
+		(pin "2"
+			(uuid "23cd0d93-5050-40ea-9d49-879bbcbb8bcd")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30b60f6a-8d20-44dd-b832-1906a957c513")
+		(property "Reference" "D54"
+			(at 132.08 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2ad1a4-b254-49a0-8435-d3a374353ffc")
+		)
+		(pin "2"
+			(uuid "27a3cb64-baf1-430a-b797-bd52c0e46cbe")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D54")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "310fec10-f10c-41d7-9446-87c12744e146")
+		(property "Reference" "D26"
+			(at 71.12 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e1d524d3-5d24-4c87-b480-74c57a74b567")
+		)
+		(pin "2"
+			(uuid "c0e9aa05-6318-4fdc-abee-cb43875c8e46")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D26")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35827986-7004-4f70-a10a-6ceb42f33d9f")
+		(property "Reference" "RC1-2"
+			(at 58.42 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "879d3b07-b41e-4233-b196-e223f635bdf3")
+		)
+		(pin "2"
+			(uuid "641f8ea7-6306-4550-92c8-e3cc0ed3e5a5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3598234f-e6ed-4eb6-b25a-52bde6e19729")
+		(property "Reference" "D82"
+			(at 193.04 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f8d7980-fcb9-49ec-8704-044fa4175b07")
+		)
+		(pin "2"
+			(uuid "e2992df7-1f75-4c2b-bd16-ce868f4adf82")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D82")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "369ff51e-db51-4132-aa26-7b5d981cba74")
+		(property "Reference" "D17"
+			(at 50.8 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b5adb2f-c180-494e-86cd-ef0a68591be2")
+		)
+		(pin "2"
+			(uuid "24774a87-3207-4ab9-a94d-2b9e1b568e65")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D17")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "37da2014-affc-4731-b642-c4245ff411f2")
+		(property "Reference" "RC5-7"
+			(at 139.7 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ac410347-ba8b-493b-832e-a3f9e3359951")
+		)
+		(pin "2"
+			(uuid "4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976")
+		(property "Reference" "D43"
+			(at 111.76 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6fb6c4-b36c-4ff1-879b-43826c273a72")
+		)
+		(pin "2"
+			(uuid "198c65f6-b3df-4780-9f6d-1c910e870a1b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D43")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3a9b19be-43ef-409c-9489-c069efbfa3ee")
+		(property "Reference" "RC0-7"
+			(at 38.1 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "898cdd62-8ad6-4d58-b6f7-f4db79a4cca2")
+		)
+		(pin "2"
+			(uuid "277b2226-c100-403c-a519-ef9cdc3923fe")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ac53e86-aa26-4394-9e99-e33f3c863b14")
+		(property "Reference" "RC7-1"
+			(at 180.34 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e6efb38c-f391-43d6-9511-8c7da50b3d51")
+		)
+		(pin "2"
+			(uuid "03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ad37b9b-353e-40fc-ac40-f5195f3dc605")
+		(property "Reference" "RC1-8"
+			(at 58.42 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3efa7b0a-a125-48e1-96a0-b756f7dea902")
+		)
+		(pin "2"
+			(uuid "e99d0060-9d73-4fee-8521-d18593d0656b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef0222e-2eac-4930-ac36-0f395f4593b6")
+		(property "Reference" "RC1-0"
+			(at 58.42 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20f0b9b8-9322-4d89-a423-dd3d807d99ff")
+		)
+		(pin "2"
+			(uuid "ce54609e-9d1d-4a3b-81a2-5a384dbe41c8")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef86e49-a152-4515-afb0-4098f497c742")
+		(property "Reference" "D31"
+			(at 91.44 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a")
+		)
+		(pin "2"
+			(uuid "b917ad78-96a8-428f-ad4f-d49149b5b97b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "402f0f46-5eb8-421b-9b9f-01a54b5cfa87")
+		(property "Reference" "RC4-1"
+			(at 119.38 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cb206c0-1fab-4ac5-b301-f9678369525b")
+		)
+		(pin "2"
+			(uuid "b99c2ecc-04a5-4c54-a491-d99fe2562dcc")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40d8058d-714e-4f99-a508-f64f9c8b575b")
+		(property "Reference" "D60"
+			(at 152.4 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66710233-d2ab-4921-aa86-488ee87fbb3a")
+		)
+		(pin "2"
+			(uuid "a9636da9-222c-478f-bc5b-71d3f0473300")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D60")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "411a5386-edd0-4032-883d-ba445f257b99")
+		(property "Reference" "D93"
+			(at 213.36 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "21f0660e-6a0c-4492-a9e5-01821c71a5fe")
+		)
+		(pin "2"
+			(uuid "096c2860-22cd-4d22-bbb5-2c4452c158a3")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D93")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "430b936d-b8ad-4c28-b93d-4046aec980c7")
+		(property "Reference" "D67"
+			(at 152.4 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9255475-7a77-44cc-9bd9-589d63ced82b")
+		)
+		(pin "2"
+			(uuid "9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D67")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "433f3f09-0867-41a3-8ac6-5f00bd3314fc")
+		(property "Reference" "D32"
+			(at 91.44 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11a29637-fd50-4473-bb70-d4116312a4f5")
+		)
+		(pin "2"
+			(uuid "53f6307d-8380-45e9-b3fa-4d05a2bd575d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44499808-710f-44ae-bed2-0632db78b8c8")
+		(property "Reference" "D71"
+			(at 172.72 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8805b31-9770-4092-b10a-101cf112fd76")
+		)
+		(pin "2"
+			(uuid "9f3056b1-b197-421f-9d54-08cf5cc88970")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D71")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4461a601-2e4b-4cf8-8094-5e4d8e990676")
+		(property "Reference" "RC5-8"
+			(at 139.7 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f54d1c0f-d68b-4769-9ef7-ac6475687d30")
+		)
+		(pin "2"
+			(uuid "49768dd5-fbea-4db4-9154-60b22afd8a29")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44de9323-bd5d-49cd-bf0a-70392801309d")
+		(property "Reference" "D45"
+			(at 111.76 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb2b185b-5d98-46b8-8516-9e5c980291cf")
+		)
+		(pin "2"
+			(uuid "f730da3b-5ef9-4abc-8c8d-0794fe3feb87")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D45")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "454ad926-1c6a-4aa4-b6f8-25297463de18")
+		(property "Reference" "RC3-2"
+			(at 99.06 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0aebfce-7e76-40f1-83ef-5914b8ebbcc7")
+		)
+		(pin "2"
+			(uuid "744fce2b-a15c-45a6-92b0-e880efafb5f6")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 48.26 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46348ccc-126c-461a-8e39-f93f389ddaa7")
+		(property "Reference" "DI0"
+			(at 242.57 44.45 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 50.8 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c86bf5fa-c113-44c1-b93d-7a5d4ac11904")
+		)
+		(pin "2"
+			(uuid "dbd8322f-50c7-4271-821c-b0005fd066b2")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a7f7b3d-918b-431a-b79d-c66494b3ec50")
+		(property "Reference" "D52"
+			(at 132.08 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd114d76-87b2-4089-b211-b7b541ac42b3")
+		)
+		(pin "2"
+			(uuid "a360aa38-116c-4dd0-a569-f6a7a5a88a05")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D52")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4d978207-10b9-4a43-a474-2e66421925a0")
+		(property "Reference" "D64"
+			(at 152.4 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "27529674-e97c-460d-9de8-89cd61c8a6eb")
+		)
+		(pin "2"
+			(uuid "57e77ee6-e62d-402e-a614-a833da3fbafb")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D64")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4e9036c3-3848-485b-8b45-7e377c05efba")
+		(property "Reference" "D86"
+			(at 193.04 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cebd91c6-213c-407e-8871-b40d23e32e3c")
+		)
+		(pin "2"
+			(uuid "209631a2-8c98-4e88-8a48-286a9aadd110")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D86")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "50dfbd73-3671-493b-8466-ba295a53891e")
+		(property "Reference" "D69"
+			(at 152.4 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12473813-984c-45f7-a1ec-6b60de9f4230")
+		)
+		(pin "2"
+			(uuid "ef3a08d5-f80f-45b3-9407-fe76d147d1fb")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D69")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "50e4b379-7602-45c8-aa05-dfc9b3f70f58")
+		(property "Reference" "RC9-2"
+			(at 220.98 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6d506f53-ffcf-4d12-ae8f-d5b7539fbeba")
+		)
+		(pin "2"
+			(uuid "3324ce76-0743-47e2-af09-b4daae2fb475")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5466fd2d-f22f-409b-b7da-f8d297aeb7a2")
+		(property "Reference" "RC6-5"
+			(at 160.02 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffdd8419-9afa-4f38-bfbf-7dc4e869b438")
+		)
+		(pin "2"
+			(uuid "0db27643-51f5-4634-a791-2c4813885195")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5518d7f7-6de1-409b-a6d0-90efa78c0b82")
+		(property "Reference" "D7"
+			(at 30.48 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9bdf2265-17dd-4712-9f75-996577068823")
+		)
+		(pin "2"
+			(uuid "cd2654f9-f2c1-4ff7-bbce-8fe664862762")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "553a576d-44a1-4bad-9211-394526206f63")
+		(property "Reference" "D41"
+			(at 111.76 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4a035e61-91c9-41ba-9328-bc9b284e86c2")
+		)
+		(pin "2"
+			(uuid "8628539f-d3cd-4957-a6bb-5c605649e715")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55c4f5cb-c530-414c-92f5-fbf9e58a8885")
+		(property "Reference" "D37"
+			(at 91.44 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "64d90630-a755-4eae-b416-80d8ff93fde4")
+		)
+		(pin "2"
+			(uuid "77e4ef56-5ac3-4295-aacb-04ae680de9b7")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D37")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55dc1959-7c17-496b-b079-56725e7400ff")
+		(property "Reference" "RC7-6"
+			(at 180.34 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d91f51f-9558-44e7-9b69-c9ba25dbac1f")
+		)
+		(pin "2"
+			(uuid "f7ee2403-2740-4116-96fa-c5f3c0c9f293")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "563bf078-cf50-4f0f-84d6-a83a0feddd45")
+		(property "Reference" "D70"
+			(at 172.72 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "91318668-36ae-48a7-a13c-18d4c2f08036")
+		)
+		(pin "2"
+			(uuid "29b99e4d-eeeb-4f18-b49f-b44a360c9eac")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D70")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 207.01 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5642ac65-20dd-447b-a5a3-1b21218d5bac")
+		(property "Reference" "DS8"
+			(at 198.12 207.645 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 198.12 205.105 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6d406bb4-8771-4842-b48d-4d5e1f3de0cf")
+		)
+		(pin "2"
+			(uuid "bcdb56a4-4458-438f-b33a-abdcc29a1ebf")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "568f737d-6752-4b16-be92-273eb7ac8c9d")
+		(property "Reference" "D98"
+			(at 213.36 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "96fa163e-1e2c-4d82-ada6-6b53530a015e")
+		)
+		(pin "2"
+			(uuid "eef2dd73-ade2-4fd8-a1e4-1b0837b59db5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D98")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 68.58 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5692cd7d-67c7-4fe7-8b4d-c8bc86968b31")
+		(property "Reference" "DI1"
+			(at 242.57 64.77 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9abe1fc5-b3c1-424f-8519-d12916c57a11")
+		)
+		(pin "2"
+			(uuid "168b1203-c5fc-4b69-b8e5-94d0bdc27e41")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "57e7516d-643d-4cd1-9646-d8696e387a16")
+		(property "Reference" "D38"
+			(at 91.44 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c0d30413-2127-456f-a30c-24a92d981ac9")
+		)
+		(pin "2"
+			(uuid "a92161f1-81a1-4199-93bf-ab8287ab6d27")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D38")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5924da97-d274-4fb5-b277-06f309e62438")
+		(property "Reference" "D79"
+			(at 172.72 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb3328cf-70d1-402a-9b12-5297b037e47d")
+		)
+		(pin "2"
+			(uuid "44a70a68-2fd3-413e-8aa0-d6527cb0cab5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D79")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59263e5e-1eeb-458b-9b02-ca162d4a65d7")
+		(property "Reference" "D21"
+			(at 71.12 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2372f523-257f-414c-92f4-8d433cfbee15")
+		)
+		(pin "2"
+			(uuid "21891727-1d09-4cab-bd90-75c57b141f7c")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59fdee43-9b65-471d-9ea8-5dc40dc65f6e")
+		(property "Reference" "D35"
+			(at 91.44 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5834d436-0e26-481b-a20d-40fa6346502e")
+		)
+		(pin "2"
+			(uuid "59af1ddc-701f-49c0-b6cd-778072695c5c")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D35")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5aeb247f-6f79-4df2-b767-9ca89069182c")
+		(property "Reference" "D56"
+			(at 132.08 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d46c0cdd-d9c1-44c1-ba6c-034fc547ff01")
+		)
+		(pin "2"
+			(uuid "53f3e198-3ef2-40c4-a8f7-298435eddd0b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D56")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5c60f960-fb0a-46f6-9aff-5d8144586231")
+		(property "Reference" "RC4-6"
+			(at 119.38 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "990f1ee1-d6da-4ae8-809a-1911d8099a4c")
+		)
+		(pin "2"
+			(uuid "a8276c00-b61f-4db4-8f4f-e51e512de654")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f21a75c-b9ee-47bf-adcf-39a03e42660f")
+		(property "Reference" "D15"
+			(at 50.8 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1")
+		)
+		(pin "2"
+			(uuid "7a8a84c2-38d2-473b-955d-81dd816a398e")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fa8cce4-fbbf-4784-a459-71364b77e1a7")
+		(property "Reference" "RC0-2"
+			(at 38.1 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cb7750fa-a378-43a3-a1c6-638c32a1c79e")
+		)
+		(pin "2"
+			(uuid "67dfe958-6bd5-4618-98a3-d513db4ad5c0")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5ff7733c-a36f-4b29-a8e7-bdf79fabdf72")
+		(property "Reference" "D4"
+			(at 30.48 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed6062e9-f00a-474a-840f-39685bd66d70")
+		)
+		(pin "2"
+			(uuid "c0e85db4-b88d-4383-8de6-9f7370be62a6")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61b2e3fc-583b-407b-beff-dd8441f2f403")
+		(property "Reference" "RC2-6"
+			(at 78.74 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "752f308d-4723-4468-9745-81de18307ba3")
+		)
+		(pin "2"
+			(uuid "3267c09c-2818-42d7-96a9-6aaa2d6c4a92")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6368f5d6-df20-4a23-a72c-e29e990ea131")
+		(property "Reference" "D36"
+			(at 91.44 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cd72461-15a2-466d-828d-9560639fb78b")
+		)
+		(pin "2"
+			(uuid "e26d27e6-f81a-4557-bc98-f3f953d25d26")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D36")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "64616073-76e8-465f-9707-663a78749bf1")
+		(property "Reference" "RC7-3"
+			(at 180.34 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0925180b-4c04-468a-84a3-7e0c543a243b")
+		)
+		(pin "2"
+			(uuid "000c5508-f583-4022-ad6d-ee3a9a754164")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6692c134-d619-4b90-b4c4-ab21aa3df3a5")
+		(property "Reference" "RC8-7"
+			(at 200.66 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "453a02c7-7770-40fc-8f21-06b63fd625f1")
+		)
+		(pin "2"
+			(uuid "3ebf9656-8129-4c66-8b10-67f0c0e2bb28")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 227.33 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "678223ff-e0fe-486b-b260-417e9028494d")
+		(property "Reference" "DS9"
+			(at 218.44 227.965 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 218.44 225.425 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6cfbc946-abd5-4358-933d-727d4186f547")
+		)
+		(pin "2"
+			(uuid "b5044718-d927-48a8-a198-355f14c09004")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "67aba0e0-2c92-4816-99a5-9091230a7899")
+		(property "Reference" "RC3-6"
+			(at 99.06 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c252319-dc79-4365-afaa-77dcde3e6c4e")
+		)
+		(pin "2"
+			(uuid "a5f35312-d094-4f22-9eb9-0edc1f8fb9c4")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "68966b55-0a95-4b34-bc89-5c7298da3231")
+		(property "Reference" "D95"
+			(at 213.36 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2fe5baba-e2be-4676-a63d-cc166ce0c4ba")
+		)
+		(pin "2"
+			(uuid "72f97c9f-1d3c-4a38-bcaa-aad4f2a66c32")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D95")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6aa79de9-555a-4ed1-93d3-b801685ebd28")
+		(property "Reference" "D53"
+			(at 132.08 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b2031fe-ef72-48a9-afa6-c06144a31b2c")
+		)
+		(pin "2"
+			(uuid "7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D53")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6b349af3-e96d-42ed-a60b-1fcc6b2649ce")
+		(property "Reference" "D92"
+			(at 213.36 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bb4396c1-91b0-45de-ba96-3d4f74f6cf48")
+		)
+		(pin "2"
+			(uuid "b8385798-a88a-45df-851b-dcd7d4329aec")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D92")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6bdaf872-00b8-4813-a1b1-3be3a6e9f042")
+		(property "Reference" "RC2-9"
+			(at 78.74 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b47928c2-316d-4b2a-9b65-93bc5a6a16f7")
+		)
+		(pin "2"
+			(uuid "4fe94ff2-bac5-49bb-b97c-9a9ebef4c923")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6ef4f980-15ce-420f-b02f-d66ae810e188")
+		(property "Reference" "D78"
+			(at 172.72 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "680d9493-5437-446a-836f-9ed5bb999bdf")
+		)
+		(pin "2"
+			(uuid "d64a76a9-3b5d-48b1-9a48-ee12b0cd1ab7")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D78")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "70d661b8-51f1-49b8-ad84-9ce8d120c0fc")
+		(property "Reference" "RC6-2"
+			(at 160.02 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e2175ea2-22e6-4720-ab54-24959d43a616")
+		)
+		(pin "2"
+			(uuid "63a1bf12-3f2f-4dc8-8a86-7932361b8306")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "712ade27-46b2-4d0c-b658-ec3775a1c528")
+		(property "Reference" "RC3-8"
+			(at 99.06 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4811e298-73bc-4ac1-af58-3ae7f508d1d7")
+		)
+		(pin "2"
+			(uuid "ac21b718-c133-4ed3-a2f4-c437b7879cce")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "72047ccc-8813-4e13-ae4a-04618a9ab771")
+		(property "Reference" "D23"
+			(at 71.12 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84")
+		)
+		(pin "2"
+			(uuid "6dee3493-b1eb-401e-abb4-cbdef0ef3867")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7295efa3-e253-4b6b-ad8d-641bcea1e272")
+		(property "Reference" "D68"
+			(at 152.4 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0450f5cb-94f5-4de3-b50e-da553aca1ff3")
+		)
+		(pin "2"
+			(uuid "47f460cc-5812-4c14-b97e-030930a4c1aa")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D68")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7322809e-8332-47c6-af41-fcf3bbcec7d0")
+		(property "Reference" "D34"
+			(at 91.44 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e3b096d1-dbd9-4fb8-8775-725a7aed0bc4")
+		)
+		(pin "2"
+			(uuid "63756bb0-b693-4bbc-82da-e89a6b927e71")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D34")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "75e13388-d7c5-4583-8a3d-9b2d5836631d")
+		(property "Reference" "RC9-0"
+			(at 220.98 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df3fb1ca-e1d7-4dba-9f10-debc4bd28da0")
+		)
+		(pin "2"
+			(uuid "8e4b1d03-6eb1-4014-a87e-35bcdd8c8002")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "76054860-648b-474e-9b4d-cc9d83653495")
+		(property "Reference" "D10"
+			(at 50.8 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d7e8bc-1ac3-4327-ab17-369de6ee755c")
+		)
+		(pin "2"
+			(uuid "c8283bba-c907-48e0-9745-e0818ca7ab04")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "77aa25a5-82c7-42c3-9d55-8606dd65ffa8")
+		(property "Reference" "RC5-1"
+			(at 139.7 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51db5d58-5004-4c9c-b8d1-c184bfb493da")
+		)
+		(pin "2"
+			(uuid "16d6f605-4627-49bd-9180-8203902febfd")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7876e2e4-9d5a-416f-b97a-e958a989e5b8")
+		(property "Reference" "D16"
+			(at 50.8 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8bd5710-8f18-4748-9b3c-a975f78342a1")
+		)
+		(pin "2"
+			(uuid "da0aa924-203b-4985-9bff-4185f3555d43")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D16")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7b85c895-ed2f-4daf-bbd5-9b0e9148eed9")
+		(property "Reference" "RC7-8"
+			(at 180.34 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c6604866-4e4a-4cb4-bf09-ea0fa22fde38")
+		)
+		(pin "2"
+			(uuid "0729bbae-70ee-4c7e-8da7-29c0812b5be7")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8010e136-1dd3-496f-b7ef-81fb0c8b419e")
+		(property "Reference" "D20"
+			(at 71.12 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5aa5bf69-e040-48d4-81fc-332aff45c2f9")
+		)
+		(pin "2"
+			(uuid "f5458189-75e2-45c3-bf32-0320ebe63391")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80c46ab4-724f-418d-bb6f-e89792097e1a")
+		(property "Reference" "RC2-4"
+			(at 78.74 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc0fd3d-897b-4e06-ac65-16066b68709e")
+		)
+		(pin "2"
+			(uuid "b7b98128-d37a-4ac7-b049-5cf9bdd5aadb")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "814545b5-c5a6-4c45-83b2-5c1b5ef43a22")
+		(property "Reference" "D57"
+			(at 132.08 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "adc35f03-9c02-4ca4-bbc5-866d317a7469")
+		)
+		(pin "2"
+			(uuid "f05a395b-0185-4ab8-bf1d-fa0561316ad4")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D57")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "81912d5a-1def-44e9-a6ef-abaf3ecd517d")
+		(property "Reference" "RC6-1"
+			(at 160.02 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fa9aca31-bd8b-4e2e-8b86-05d191575df9")
+		)
+		(pin "2"
+			(uuid "fce38bd6-fb8f-42a6-8d68-ecda7f1a588f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "820f9c2f-0705-41a0-aa6a-3a211d61773f")
+		(property "Reference" "RC6-7"
+			(at 160.02 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb135129-1d78-4d36-9389-941aee94da0a")
+		)
+		(pin "2"
+			(uuid "2a32e7b7-f134-4c47-a153-d8fce8404094")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83cc3bf3-09a0-4d14-be9d-180ca479485f")
+		(property "Reference" "D73"
+			(at 172.72 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22a68b69-e4e9-436e-b154-616fe8bb66c2")
+		)
+		(pin "2"
+			(uuid "b8e81b5d-9257-4482-8c33-cdfcb13c22e7")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D73")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83fb734e-dbcd-4939-9bb9-d97efd05ec97")
+		(property "Reference" "RC5-6"
+			(at 139.7 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7315a9fc-fd63-46c2-90db-bee656dc7568")
+		)
+		(pin "2"
+			(uuid "f2997912-9551-49e9-aab8-387875819f56")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8408f1ce-a660-4217-a7dd-6677d6fa5c0c")
+		(property "Reference" "D96"
+			(at 213.36 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eaa398b7-f50e-4597-99f7-b1dcab75a526")
+		)
+		(pin "2"
+			(uuid "5719d7b4-74f2-42c4-b1c6-34b59ae5b787")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D96")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "84146f81-04f3-4efb-b753-bdc596c8e7a9")
+		(property "Reference" "RC4-3"
+			(at 119.38 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "774ced50-3b17-48fe-b2d7-22681b1dd1f7")
+		)
+		(pin "2"
+			(uuid "bad310c0-ca25-47d0-b27e-42438b959c7b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8475a219-4e20-438a-84d8-4847d5d45c64")
+		(property "Reference" "RC9-5"
+			(at 220.98 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8668fb6-f91a-4502-9f57-a2869aa9f6f1")
+		)
+		(pin "2"
+			(uuid "8e2e3508-e150-49c5-a82e-0ccd478af757")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86602dfb-ea19-4060-ad39-496c613a47cb")
+		(property "Reference" "D30"
+			(at 91.44 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "02958e5d-18b7-48f3-9883-661ceaa75da5")
+		)
+		(pin "2"
+			(uuid "abed4b13-9431-40c7-848f-b30c05e39dfd")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D30")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8af20987-c3c2-465e-8640-61ab0bd7d8fa")
+		(property "Reference" "D81"
+			(at 193.04 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f42cdbf-02ba-4b39-8586-bbff1b6ed80b")
+		)
+		(pin "2"
+			(uuid "7d939371-3ab1-4f18-b55f-07048dcfe21f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D81")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8b2b0803-8190-43b4-9c0d-a9a9edc27829")
+		(property "Reference" "RC2-7"
+			(at 78.74 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8e9f64d-5849-4a62-8bf4-dafc65fcdd75")
+		)
+		(pin "2"
+			(uuid "e45fa11d-c755-4d62-baa5-974f973ba20f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c168cda-0a39-478d-9d71-1073400c7ed7")
+		(property "Reference" "RC1-5"
+			(at 58.42 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d2851af-db15-44cf-8e07-da339bdc18b2")
+		)
+		(pin "2"
+			(uuid "94b381a2-7c19-4916-9f9a-ee00221d04d3")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 129.54 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7")
+		(property "Reference" "DI4"
+			(at 242.57 125.73 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c02807d6-1705-4325-bcb0-203f4e9a5baa")
+		)
+		(pin "2"
+			(uuid "d6c46059-bf9c-4959-836e-e4d33dcc5edd")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8eb7a7fa-054b-460a-a80c-73a56219fecd")
+		(property "Reference" "RC7-0"
+			(at 180.34 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be9c1065-912d-49b5-8f2f-271b4a0c1db2")
+		)
+		(pin "2"
+			(uuid "626f5614-e69d-4277-acf6-7ff35b08ddb4")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "90049005-7b99-4d2f-9282-dbf53b76b55d")
+		(property "Reference" "RC3-7"
+			(at 99.06 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "62acb361-e48a-40de-9689-6c103c4c7663")
+		)
+		(pin "2"
+			(uuid "f3ee11cf-4f81-4591-ab5d-f41aece910dc")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 186.69 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "91a5d9b4-63df-4567-88f7-1d2f7ac8c33d")
+		(property "Reference" "DS7"
+			(at 177.8 187.325 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 177.8 184.785 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2ec7f316-054f-444d-9c0b-c2c6e1d51faf")
+		)
+		(pin "2"
+			(uuid "e22dc61a-a86f-42a7-9c26-623bb8233a05")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "92030355-9e31-45db-a9ef-a705772288a6")
+		(property "Reference" "RC6-9"
+			(at 160.02 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "83a62e7f-2925-4bbe-9dad-6089ad98ff2d")
+		)
+		(pin "2"
+			(uuid "c1b87b81-e623-49b5-bacd-1c525772e150")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "933178a7-83a9-4f29-88ef-1e369645dcaa")
+		(property "Reference" "RC2-8"
+			(at 78.74 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4d133f2b-f4f1-4994-a89d-7141989cf18e")
+		)
+		(pin "2"
+			(uuid "9ed70267-ef82-4b49-85af-67297365ea60")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "93921179-259f-4393-a6ae-bfcb2df690b6")
+		(property "Reference" "D80"
+			(at 193.04 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d32d457e-c0ce-46dc-ac4a-08e965633eab")
+		)
+		(pin "2"
+			(uuid "0645b564-d7c5-4845-82b9-8702f3f470a4")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D80")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "93dd9936-9573-4973-8fb2-a71d5e19f115")
+		(property "Reference" "D94"
+			(at 213.36 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7beb185a-6309-4671-8dd9-da0c3ef9bc52")
+		)
+		(pin "2"
+			(uuid "baeb1083-702e-43e8-9a5d-760812497130")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D94")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9578a4b6-1a56-40b7-be8d-56404ef59fdf")
+		(property "Reference" "RC1-6"
+			(at 58.42 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0b899b44-3ae3-40be-a452-1f16eaa5f4af")
+		)
+		(pin "2"
+			(uuid "11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 109.22 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "957e7a82-ca9c-46a8-bca9-099b05fe7e8f")
+		(property "Reference" "DI3"
+			(at 242.57 105.41 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc53fac9-006c-4101-8113-949ab8e05afb")
+		)
+		(pin "2"
+			(uuid "f6122429-5885-4b7a-b72a-162ca49c70c2")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9789c79d-d74e-4c16-a474-31201e3b4997")
+		(property "Reference" "RC0-9"
+			(at 38.1 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b4d335e-fe84-4869-8670-3368a7ef15e9")
+		)
+		(pin "2"
+			(uuid "3a372e91-311a-4276-8504-54c40aee2304")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "98a45ae1-6346-4607-b0c8-1479c51b1f75")
+		(property "Reference" "D49"
+			(at 111.76 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "245fa70b-724d-4379-9c74-b8f5c8d9569d")
+		)
+		(pin "2"
+			(uuid "964a681d-53eb-46ee-b5d9-73ca4400bb74")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D49")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9af5b930-d274-4b05-b0bf-e2c27b7e71dd")
+		(property "Reference" "D6"
+			(at 30.48 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bdad3d4-58ec-438c-beb8-3eea36a29d95")
+		)
+		(pin "2"
+			(uuid "5ff4e8af-dd18-4010-b183-21b8178cd684")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 88.9 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd")
+		(property "Reference" "DI2"
+			(at 242.57 85.09 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a")
+		)
+		(pin "2"
+			(uuid "81e4b9c6-9b09-4e38-94e9-cebdeae457ee")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e96ab02-44ee-4ac7-8251-0d309b7409ad")
+		(property "Reference" "RC5-3"
+			(at 139.7 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd85b120-1be2-4f17-a3d7-505a734afc72")
+		)
+		(pin "2"
+			(uuid "666e03ce-bf1c-4b58-ac4e-f01557ca11fd")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a026138b-aabb-432d-b516-5341ad9fe06b")
+		(property "Reference" "D39"
+			(at 91.44 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6257e834-355d-4e0b-a5bb-744bef7d141f")
+		)
+		(pin "2"
+			(uuid "8be7ee86-36bb-4b87-9942-9d15d9003e1c")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D39")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a3969e5a-abe0-44e9-adf1-6255946e3f4c")
+		(property "Reference" "RC6-0"
+			(at 160.02 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc4d6aea-ec1e-45c7-842c-68cd7e21336f")
+		)
+		(pin "2"
+			(uuid "f785fa77-0ac2-41ff-9704-1acbb4a72c84")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a400377f-e146-4099-97e7-db21e16d5759")
+		(property "Reference" "D3"
+			(at 30.48 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bfc71c1-6349-4b3f-bf89-22c83277904e")
+		)
+		(pin "2"
+			(uuid "dafd4b6c-6c2f-41e0-95ab-05ead276d86d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a4f847ba-a334-4631-aef3-ca47db1a1700")
+		(property "Reference" "D29"
+			(at 71.12 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc5b522c-bddd-4a8d-8ded-7fc36acfc178")
+		)
+		(pin "2"
+			(uuid "8e96df26-db08-4a3c-92ce-ba5029c624ac")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D29")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a576c983-0812-4f76-8327-d260ce9c2826")
+		(property "Reference" "D27"
+			(at 71.12 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c11deb1a-dbe0-4d39-8303-331b09dd3cc0")
+		)
+		(pin "2"
+			(uuid "9251c46a-97e6-41c1-9326-a6a8b52abc12")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D27")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a71b771b-4e14-4d95-98e7-86a6250f569e")
+		(property "Reference" "RC0-4"
+			(at 38.1 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "95049e61-b78e-490f-86e1-aba711db5c19")
+		)
+		(pin "2"
+			(uuid "6e474ba8-5b88-41c8-9259-b0ebfb6012f0")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "aac180ff-c5e7-4a0e-9a07-44c1b3bcc7fe")
+		(property "Reference" "D59"
+			(at 132.08 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c6b5d04d-906d-4f18-b7a3-382b3a768815")
+		)
+		(pin "2"
+			(uuid "d74367e2-5126-4fe7-ac31-7039cd9552e5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D59")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "abf3c9d9-a279-4546-abcf-5e4f6862bc48")
+		(property "Reference" "D2"
+			(at 30.48 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a3499f31-3593-4cd9-977b-3b6479091d7b")
+		)
+		(pin "2"
+			(uuid "17f09d49-1093-4838-8e5c-8fc4c42e5d05")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac10b530-144b-4dfc-ab37-ad7a8ced8612")
+		(property "Reference" "RC4-5"
+			(at 119.38 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d6c95156-54b9-4f54-a278-f808b4871687")
+		)
+		(pin "2"
+			(uuid "c3dc8d92-1759-4195-a3c9-81260bc6d8b1")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac95bba7-885e-446e-b059-0ba3c38e43f7")
+		(property "Reference" "D19"
+			(at 50.8 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "63ad0fd9-4009-4287-bfa1-9dc63b978ef3")
+		)
+		(pin "2"
+			(uuid "d7eafe2c-7576-4ddd-821f-8f8bca43ff92")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D19")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 85.09 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "accba515-4e8d-4804-afea-f36f436141c3")
+		(property "Reference" "DS2"
+			(at 76.2 85.725 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 76.2 83.185 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "034e4344-7cda-43bc-a12a-f56b6e8f68f5")
+		)
+		(pin "2"
+			(uuid "6f0bef00-c613-46da-9667-752b92174ad1")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ad352cc7-0ffd-4a04-82ac-bc693299cd86")
+		(property "Reference" "D83"
+			(at 193.04 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9662d2b8-61ec-4840-a8f1-af48833c11eb")
+		)
+		(pin "2"
+			(uuid "4d0c4f9f-b435-4d30-95d7-23d9f87d5f48")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D83")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ae019221-3fd0-468c-9cf0-dac8d7470e8e")
+		(property "Reference" "RC9-3"
+			(at 220.98 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be20235f-2999-4595-bedf-c52cf23b7bd1")
+		)
+		(pin "2"
+			(uuid "f57afa4c-8044-4217-b32d-12bed3437591")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "afcc8d67-6ed8-4a82-aef7-417b4229ad61")
+		(property "Reference" "RC7-4"
+			(at 180.34 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "982715f0-55ee-4146-b98e-756e5b630dca")
+		)
+		(pin "2"
+			(uuid "7f384a84-9632-4ac9-a8b6-05778cf49f62")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b05bbd1d-9d65-4ef7-a639-885ae69d8b01")
+		(property "Reference" "RC8-0"
+			(at 200.66 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "16c6866c-1d06-4257-9cde-9d9c6f4c3642")
+		)
+		(pin "2"
+			(uuid "70b152f6-7e7d-4a93-9ef0-b6ec51ff9b25")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b2cc8c06-500a-41ac-a412-7baf61e0f24c")
+		(property "Reference" "RC6-3"
+			(at 160.02 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a77d5cb-df53-4102-99ed-4829fa686656")
+		)
+		(pin "2"
+			(uuid "22df81c2-2a06-44e2-bed1-a6d6c14df76a")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 146.05 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3573dc3-ef18-4f4c-817b-c984ae7cfae9")
+		(property "Reference" "DS5"
+			(at 137.16 146.685 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 137.16 144.145 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "813e7cf6-f821-4e03-95cc-308010bed54e")
+		)
+		(pin "2"
+			(uuid "9669a028-42d7-436f-8ec5-bc3423db62d6")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b39d56f9-3079-43e4-bb1b-80277fdae425")
+		(property "Reference" "RC4-2"
+			(at 119.38 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b205d044-9ffa-4dce-82fd-f51ba622a818")
+		)
+		(pin "2"
+			(uuid "29ce7588-4a17-4be4-9207-ea3ed2669aa1")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c497a9-b81f-4161-88cf-2e58ddb4cdd8")
+		(property "Reference" "RC3-4"
+			(at 99.06 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae78f0d3-f75a-49c8-ab9b-8a9831e434d7")
+		)
+		(pin "2"
+			(uuid "a59e897c-0784-437d-9243-baf91d40a453")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b92624bc-936a-4bc6-ac7c-dbc9faa7208a")
+		(property "Reference" "D8"
+			(at 30.48 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0ef02d0f-103e-468b-b30c-fac4e90fb218")
+		)
+		(pin "2"
+			(uuid "aa510cff-115d-4ad1-9c78-bf1246172261")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba3c5bf2-9824-404a-befe-7584c286e012")
+		(property "Reference" "D48"
+			(at 111.76 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "38e4de38-525a-4e2c-8e51-9d4770973903")
+		)
+		(pin "2"
+			(uuid "e71e068d-4f7e-493a-960b-e49aa171ca56")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D48")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba927934-b2e1-4953-b21b-54ef02be8935")
+		(property "Reference" "RC0-5"
+			(at 38.1 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cadba0a-3bb3-40cd-acea-644da4b3e05f")
+		)
+		(pin "2"
+			(uuid "1368ebac-096c-415f-acaf-9afb071e729f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bb2c72f0-a908-44e7-b7d5-67df52eed516")
+		(property "Reference" "DS4"
+			(at 116.84 126.365 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 116.84 123.825 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5ab0b348-3e2a-4517-90b3-fad111de6205")
+		)
+		(pin "2"
+			(uuid "6e7351bb-5d09-464f-9e8d-535ba0f5c6f3")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bbc3ae57-e1db-475c-9bc3-18c822e7531a")
+		(property "Reference" "D28"
+			(at 71.12 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90783402-edc5-4638-ae16-d31c3aaf5e2b")
+		)
+		(pin "2"
+			(uuid "f9e9c399-273d-43fc-9007-1e5ca67fea38")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D28")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be02506a-2bb1-4713-b046-f0327dae72de")
+		(property "Reference" "RC0-1"
+			(at 38.1 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97a92abd-708c-465e-baf7-79fa35370a7c")
+		)
+		(pin "2"
+			(uuid "c9056b1e-419e-478d-9fc4-be1e95902d28")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be554787-60ed-4b8f-b7bc-2220fcd28430")
+		(property "Reference" "RC8-3"
+			(at 200.66 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "76eac86e-4d5a-4833-a702-c89fc5eb96e0")
+		)
+		(pin "2"
+			(uuid "6e41d262-c7fe-4c54-b525-59ae026a918d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d")
+		(property "Reference" "RC5-2"
+			(at 139.7 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f22c39d-012a-4297-b61c-1ff841801333")
+		)
+		(pin "2"
+			(uuid "adbe8c88-ad34-405b-866a-efb64899002f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bf639842-72e9-4bdd-be11-7972d8d5c3c4")
+		(property "Reference" "RC3-9"
+			(at 99.06 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8015b627-c562-4073-8a9c-3d88306d5597")
+		)
+		(pin "2"
+			(uuid "b34e9dd8-5aad-496e-81b0-f2f5cb3bdb66")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c11b6807-83e7-46af-9d7e-9d56aab4109c")
+		(property "Reference" "D46"
+			(at 111.76 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46")
+		)
+		(pin "2"
+			(uuid "6764bae9-067c-4178-897e-2c25048ade8b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D46")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c164cb58-7d29-400c-b219-f07036f5e8c9")
+		(property "Reference" "RC0-3"
+			(at 38.1 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92164ea1-76d0-4223-80cc-32c093c14fcd")
+		)
+		(pin "2"
+			(uuid "e615b2e5-6986-47ac-8f35-da60c20b811c")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c43b92c2-4283-44f7-8cb3-665623564383")
+		(property "Reference" "D42"
+			(at 111.76 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0929e13-ab77-4737-9d55-142bd9901b1c")
+		)
+		(pin "2"
+			(uuid "0f45988c-1752-479c-97d5-fbada14f9a42")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D42")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c64cc71e-aae1-49fa-83d0-4d8a51355bc6")
+		(property "Reference" "D9"
+			(at 30.48 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "328932ea-b1f6-431f-8c23-8a2d8eae8bba")
+		)
+		(pin "2"
+			(uuid "10eab654-b7fb-42dd-bf39-41b39e8328d6")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c72dd108-be98-47d5-b809-561778aa3212")
+		(property "Reference" "RC2-5"
+			(at 78.74 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d2f0fd-ce69-4d4e-a4ab-163c1691ef24")
+		)
+		(pin "2"
+			(uuid "03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c7f185b3-c785-4ddb-9c6f-f854c93057c1")
+		(property "Reference" "D85"
+			(at 193.04 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b8f08018-67e0-4945-91d2-9a40292e0a1a")
+		)
+		(pin "2"
+			(uuid "096b6293-e540-4273-b6aa-9e314016c840")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D85")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe")
+		(property "Reference" "D50"
+			(at 132.08 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a606860e-126b-4f3e-bcfe-a2dfa8adc9c8")
+		)
+		(pin "2"
+			(uuid "59120505-a333-4c63-8904-aa379cfb043b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D50")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c996541a-3b07-4fed-9687-afa9b7ffb878")
+		(property "Reference" "RC7-5"
+			(at 180.34 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "560b334e-ed5f-40a2-b100-5974e92ce94c")
+		)
+		(pin "2"
+			(uuid "55bbe733-1ff6-4a73-b892-49d49c6c0fc9")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce521a1c-e123-4f49-866e-f4f51848f864")
+		(property "Reference" "RC7-2"
+			(at 180.34 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2a9b15ea-df9e-4ef0-a128-13d2e129d7f7")
+		)
+		(pin "2"
+			(uuid "e9530707-f705-4741-a308-e08f558f67a1")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e")
+		(property "Reference" "D51"
+			(at 132.08 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48596e1c-4629-46bb-98c1-de11cd41e539")
+		)
+		(pin "2"
+			(uuid "f7decfb7-c4ef-4861-ba8a-043f44f3b09e")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D51")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf81ef85-b58f-422a-b88a-7b7914aa3581")
+		(property "Reference" "D12"
+			(at 50.8 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e34c154b-a3cb-467d-891b-2f2891056190")
+		)
+		(pin "2"
+			(uuid "dc926c49-c915-470d-b2b5-00749f3505bb")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d2e0ab87-3807-4a88-be47-f5c2586bfeb9")
+		(property "Reference" "RC1-9"
+			(at 58.42 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "905c7978-373b-43c6-894f-f9da59358409")
+		)
+		(pin "2"
+			(uuid "9dabc73f-860c-4bde-9950-7e2511b1e9b3")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d352da38-bdf9-428f-a8d9-8df6c9a36ec3")
+		(property "Reference" "D89"
+			(at 193.04 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4c3fc4a6-4570-4b34-b7cc-c9d681cef14a")
+		)
+		(pin "2"
+			(uuid "7d95533d-af2b-4a4c-b205-9385c93624cd")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D89")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d40b4fbb-e58c-433e-b2c5-236bb8aa92c5")
+		(property "Reference" "D1"
+			(at 30.48 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90049b07-ff34-407c-ad1c-bcb8b89b241c")
+		)
+		(pin "2"
+			(uuid "7bd5d68f-4902-47f7-bc35-be0973d0d904")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578")
+		(property "Reference" "RC5-0"
+			(at 139.7 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e5729530-792d-44f2-80ff-f6315aae335e")
+		)
+		(pin "2"
+			(uuid "01f42ec4-9037-47c0-8fc0-8f7345fd0a2b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d69b760e-d231-449e-ae78-5289569bfcf8")
+		(property "Reference" "RC4-8"
+			(at 119.38 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b2174dcf-3936-44c4-b9c9-8a8c2ffd5559")
+		)
+		(pin "2"
+			(uuid "553bf002-fd89-4554-b1c2-ed094fd5fe57")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d7b98385-4339-43e1-a83a-6daba8def1f8")
+		(property "Reference" "RC0-8"
+			(at 38.1 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c3a8852b-59c8-4849-9f9f-edc39c43f8e6")
+		)
+		(pin "2"
+			(uuid "f4bfef10-0157-4077-9c8b-8858eccf5c1a")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69")
+		(property "Reference" "RC2-1"
+			(at 78.74 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba2015a3-c3ad-44cf-b530-b2a60bac2c12")
+		)
+		(pin "2"
+			(uuid "12bdf482-8bd0-4b7d-a511-fcaadc8ab54d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "daefbaa6-3e17-4eca-837b-024ccac5fc10")
+		(property "Reference" "D14"
+			(at 50.8 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12e5236e-b23d-4e38-9768-e28d1693b6eb")
+		)
+		(pin "2"
+			(uuid "1be4fe23-ac83-4b50-b43f-2e4b33c335d7")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "de9b7bb1-afa1-4e19-b963-4516a18a17bf")
+		(property "Reference" "D91"
+			(at 213.36 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6167a490-f64e-4925-8d8a-b4543a48c019")
+		)
+		(pin "2"
+			(uuid "b78fba3b-33a1-4c3a-941e-dc9814c91e24")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D91")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "df14ac0c-5b64-41d1-ac61-954e84a88f4b")
+		(property "Reference" "D47"
+			(at 111.76 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7284aa2f-4456-4e07-9251-a86b7acd95b1")
+		)
+		(pin "2"
+			(uuid "c06243a0-5a23-4af5-88df-f2a88bfb1da0")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D47")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e214b496-153e-40f8-93df-30f96574576d")
+		(property "Reference" "RC6-8"
+			(at 160.02 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "762c516c-df17-4ae0-8f7f-03315e74925e")
+		)
+		(pin "2"
+			(uuid "874fed4d-cc1d-47bf-b14e-533fedfc9875")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e255666b-19cd-45a4-b5c1-8997235eb1ad")
+		(property "Reference" "D72"
+			(at 172.72 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92803ca1-7814-4c2f-986c-c7a2afaea4b2")
+		)
+		(pin "2"
+			(uuid "f1e544c9-5e94-460f-960c-d30fdb857f44")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D72")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e345b77c-4943-4943-8fff-9d2c0a863651")
+		(property "Reference" "RC9-8"
+			(at 220.98 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3c5bbf7f-11d9-45e3-9492-3b3f4802883c")
+		)
+		(pin "2"
+			(uuid "8e4fc19e-5f68-43e8-b4a4-baf188b4cd3a")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e433e872-70f0-4e5b-b473-1ebd1af79f33")
+		(property "Reference" "D84"
+			(at 193.04 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2c838395-b13b-44f3-9cda-ae0061827054")
+		)
+		(pin "2"
+			(uuid "b7abe52a-50b6-4b31-8da0-3b0e1433e922")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D84")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e4362acf-dcaf-47ae-b824-45cc81be26fd")
+		(property "Reference" "RC9-4"
+			(at 220.98 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "59031059-0660-4b8b-bc7c-d25dfdf99292")
+		)
+		(pin "2"
+			(uuid "8d191698-0ba8-4bfd-9183-392ad5be38af")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e490f25a-1360-4f95-aa79-5f1d93892bb3")
+		(property "Reference" "RC3-5"
+			(at 99.06 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "056973a8-92e3-49be-9b21-fe961241d12f")
+		)
+		(pin "2"
+			(uuid "01c4c06b-d45d-4ffb-ad72-57ca7686fd55")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e6262d19-9b35-41b6-845a-39c20b831416")
+		(property "Reference" "D76"
+			(at 172.72 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8324bd70-bd5e-4513-bc52-cc4e838003e8")
+		)
+		(pin "2"
+			(uuid "64285f25-2c5b-4231-8d94-7ba284d5a2d2")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D76")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e97aeea5-7475-4b9f-a312-6f51452496a5")
+		(property "Reference" "RC8-4"
+			(at 200.66 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b5d442a-c78e-4d0d-8f8c-3cc6c91bf307")
+		)
+		(pin "2"
+			(uuid "4b2eebd0-ccb3-482c-8c43-2690e285e66f")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 105.41 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b")
+		(property "Reference" "DS3"
+			(at 96.52 106.045 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 96.52 103.505 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "738869bf-f410-43b7-b7e7-4e927d69911a")
+		)
+		(pin "2"
+			(uuid "71649a24-87f4-49fb-9896-e50c64c03a31")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb153eb2-74b0-4cb9-b105-af356654d60d")
+		(property "Reference" "D24"
+			(at 71.12 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "77c4fd5e-5c79-4799-aab6-2f07a57c7df3")
+		)
+		(pin "2"
+			(uuid "a062346b-452b-46dc-a106-fab01848555d")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D24")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 242.57 231.14 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ec0ebda2-e0b5-4648-83ee-afd68a4093ad")
+		(property "Reference" "DI9"
+			(at 242.57 227.33 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 244.475 233.68 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 242.57 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 242.57 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 242.57 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 242.57 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 242.57 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "941790dd-6c84-4d17-8c86-cd053db9749e")
+		)
+		(pin "2"
+			(uuid "1cfb4960-1c24-46af-9168-505412fc1763")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ee3742e9-8e22-4413-88a6-b893a7cb3439")
+		(property "Reference" "RC8-6"
+			(at 200.66 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12157fba-1ac0-4b59-9ef4-f0b7f556fda2")
+		)
+		(pin "2"
+			(uuid "a6fa6d7f-615c-410e-9188-d1867808891a")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eeca0e5b-e9f9-4790-9c32-e398887f1254")
+		(property "Reference" "RC8-9"
+			(at 200.66 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ee863615-0428-4134-aa77-1d7c4e3647ad")
+		)
+		(pin "2"
+			(uuid "7b155375-a70f-42ef-9309-987f1f53d011")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ef64a689-efe5-479a-a53a-19c9f4177765")
+		(property "Reference" "D74"
+			(at 172.72 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fc4be4a8-3bcc-4a9b-8dca-654b73020c91")
+		)
+		(pin "2"
+			(uuid "982449b6-25db-4afc-abf2-592e07b23449")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D74")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1920e34-64a4-41c9-8680-7fa42f5dfb9d")
+		(property "Reference" "RC2-0"
+			(at 78.74 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9242378-4df5-4b90-afbf-1098ccb8067f")
+		)
+		(pin "2"
+			(uuid "a135b9b9-316d-4cb2-a5a5-8d618a00a752")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1a5bcca-72b0-4fb1-9570-8abc0f731fb7")
+		(property "Reference" "RC1-7"
+			(at 58.42 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "058cb33f-3013-4884-ba52-2b175c6e6f25")
+		)
+		(pin "2"
+			(uuid "cb54004f-a1b9-489e-9cdf-00b812c2d5fa")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f31d54be-89a7-479b-90a6-e9bcd6257412")
+		(property "Reference" "RC9-7"
+			(at 220.98 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f83ff9f6-7715-4e86-b4bf-0de9179fec70")
+		)
+		(pin "2"
+			(uuid "2a257b84-25fd-4cd2-9e3d-5ac106f662f8")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f735328c-2a24-4fb3-983d-b3e512d5a5cf")
+		(property "Reference" "RC8-5"
+			(at 200.66 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "af0d403b-f1be-40d9-bf46-12c29a8b07f1")
+		)
+		(pin "2"
+			(uuid "cf12207d-8835-4b4d-855b-207eb48891b5")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f93938b2-5ce6-4ad4-aef1-bcec2b0c3413")
+		(property "Reference" "RC4-9"
+			(at 119.38 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb557f65-fb80-44d7-9e25-f09389e948a7")
+		)
+		(pin "2"
+			(uuid "ef20bae4-a01f-4ba7-8d51-cad542d569ba")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f9c61822-7d54-487f-93d1-920e041f55a6")
+		(property "Reference" "RC8-2"
+			(at 200.66 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffd61ace-0250-4fd9-8d0c-c2c917d0d4b5")
+		)
+		(pin "2"
+			(uuid "d354ba15-00ca-4efb-954b-871f951259db")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc941f43-b642-4fef-8515-f8f851adced2")
+		(property "Reference" "D13"
+			(at 50.8 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c")
+		)
+		(pin "2"
+			(uuid "ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fcc35b13-8da5-4271-981a-5470b3add3e5")
+		(property "Reference" "D25"
+			(at 71.12 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0f0d662a-16b3-4c76-b4ee-49de18b57b47")
+		)
+		(pin "2"
+			(uuid "ba9a1f4c-173e-4b32-907f-fe9b31df718b")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fd13d6af-afdf-4367-a43b-1889348eabd8")
+		(property "Reference" "RC0-6"
+			(at 38.1 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "854af50a-a007-4ba3-a405-76f0f99e9817")
+		)
+		(pin "2"
+			(uuid "bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142")
+		)
+		(instances
+			(project "round-robin-11-90"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/round-robin-12-110.kicad_sch
+++ b/round-robin-12-110.kicad_sch
@@ -4509,7 +4509,7 @@
 			)
 		)
 	)
-	(global_label "IO 5"
+	(global_label "IO 6"
 		(shape bidirectional)
 		(at 165.1 25.4 90)
 		(fields_autoplaced yes)
@@ -4521,12 +4521,12 @@
 		)
 		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 165.1 17.2705 90)
+			(at 165.1 17.1911 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 				(hide yes)
 			)
 		)

--- a/round-robin-12-110.kicad_sch
+++ b/round-robin-12-110.kicad_sch
@@ -1,9051 +1,24405 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid cbac505e-77a6-4a00-a758-435de33cca16)
-
-  (paper "A3" portrait)
-
-  (lib_symbols
-    (symbol "Diode:1N4148" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "1N4148" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Device" "D" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Pins" "1=K 2=A" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "100V 0.15A standard switching diode, DO-35" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "D*DO?35*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "1N4148_0_1"
-        (polyline
-          (pts
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "1N4148_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 1.27 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "SW_Push" (at 0 -1.524 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "switch normally-open pushbutton push-button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Push button switch, generic, two pins" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SW_Push_0_1"
-        (circle (center -2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 3.048)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 0 180) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 165.1 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 00d75863-bb9f-4d4c-ae8f-f64498ed1533)
-  )
-  (junction (at 266.7 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 04d157fc-c063-40ca-ad05-26c77c1c313c)
-  )
-  (junction (at 215.9 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 057080d9-d7cd-490d-ab5f-b591aaae58fa)
-  )
-  (junction (at 185.42 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 05e510f3-8ca9-490a-bdc5-77faace67735)
-  )
-  (junction (at 104.14 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 06a6d1a8-0f12-4174-b63e-d35d8ca618bf)
-  )
-  (junction (at 43.18 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 06e66b38-0070-40a1-8fc5-70306b17897f)
-  )
-  (junction (at 246.38 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 088d9831-391b-4393-b317-222e60d64881)
-  )
-  (junction (at 165.1 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 09e82fd3-a43f-4071-83d2-fb0a65931c0e)
-  )
-  (junction (at 195.58 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0a12de08-1706-4b9c-a033-35ba5807ef7b)
-  )
-  (junction (at 63.5 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0a9113d4-8a8c-4abc-b886-f22c92ad18dc)
-  )
-  (junction (at 165.1 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 0a95c2d4-251b-4df1-a8c0-c0fc6241e43d)
-  )
-  (junction (at 124.46 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29)
-  )
-  (junction (at 73.66 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0c7244ee-ddfb-470b-a70b-1cfc53f83773)
-  )
-  (junction (at 134.62 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 0c73479c-4e07-428a-85f3-93341c42ca57)
-  )
-  (junction (at 93.98 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5f3a7a-dc5d-4973-8743-eafaa1c1a462)
-  )
-  (junction (at 43.18 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid 0fa898f1-7f7f-49aa-98b2-974fb5bba30b)
-  )
-  (junction (at 43.18 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 10cae212-bc64-40b9-b44f-13fd4a0406a6)
-  )
-  (junction (at 53.34 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 122dbfee-176c-4f21-802f-09581864dffb)
-  )
-  (junction (at 83.82 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1278b5e3-5eff-46d6-a162-44fde2066970)
-  )
-  (junction (at 53.34 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 14bb4fc2-d7df-49aa-b10e-882abdd2aa5f)
-  )
-  (junction (at 215.9 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 15ad1e9e-3a46-4b63-85e5-8965649033ac)
-  )
-  (junction (at 185.42 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 15daf298-357b-4f73-8767-34988eed6eb8)
-  )
-  (junction (at 104.14 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 17f3773a-2c02-426d-bcd6-7a35c59a710a)
-  )
-  (junction (at 205.74 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1943e8ad-b21d-4f7c-9e48-baf07472bdf8)
-  )
-  (junction (at 114.3 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 1a11ada5-19c8-45ac-810c-daedbb80ad5b)
-  )
-  (junction (at 195.58 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 1a6176d3-a6a6-4f72-9be0-2812f8861a46)
-  )
-  (junction (at 73.66 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1c386ee6-5b9d-4eae-92b5-9440e81067f6)
-  )
-  (junction (at 266.7 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 216bc563-0bc0-4447-af79-7933fdef7d63)
-  )
-  (junction (at 93.98 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 21e320b6-a0c4-4d5d-babf-ee5274120507)
-  )
-  (junction (at 205.74 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid 22da1369-0217-4ceb-b653-345b9ee68839)
-  )
-  (junction (at 185.42 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 23554013-cd0d-4767-9f22-8c19a7d8c5ca)
-  )
-  (junction (at 154.94 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 23916c3a-0d37-416a-91d3-82a34b3ade4a)
-  )
-  (junction (at 165.1 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 2501dc30-a271-4271-9ca6-b085328a23ec)
-  )
-  (junction (at 73.66 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 2654ce54-6e59-4c49-bfbf-12326c83c638)
-  )
-  (junction (at 226.06 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 28c72d93-951d-432a-abf9-c3f05af6b90f)
-  )
-  (junction (at 154.94 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 2af4d5cf-36e8-471b-be0a-21fb2d03facc)
-  )
-  (junction (at 124.46 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 2b2b66bc-905d-4b48-89f5-1c62f6c27dbb)
-  )
-  (junction (at 134.62 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 2c5878fe-fb0a-42a4-a883-ea4209708ea5)
-  )
-  (junction (at 104.14 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid 2c97cd17-57cb-4fbf-859b-370fde839231)
-  )
-  (junction (at 175.26 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 2cae1312-83d6-4b55-a6a7-5303ad6d6c6c)
-  )
-  (junction (at 154.94 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 2cf168f3-fe97-43f2-b72e-223dd4e6b386)
-  )
-  (junction (at 73.66 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 2f562ace-9050-4ec1-bf70-b5691b93259e)
-  )
-  (junction (at 73.66 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 30c9eca3-7c32-4704-8819-3599d7b84f53)
-  )
-  (junction (at 93.98 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 31a1b16e-8174-4fea-bc42-9c75ed9182a0)
-  )
-  (junction (at 83.82 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3)
-  )
-  (junction (at 114.3 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 347306fc-87ef-43e1-a98f-ca29ac9473e6)
-  )
-  (junction (at 124.46 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 352af8be-9d08-4866-961e-b8632013179f)
-  )
-  (junction (at 104.14 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 356b49b0-20ac-4c33-8df8-9b27dee0b312)
-  )
-  (junction (at 175.26 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 357aa667-d746-4e3e-ab2a-484493e6765a)
-  )
-  (junction (at 266.7 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c)
-  )
-  (junction (at 175.26 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 39869536-29f6-4e84-a33a-473fa8fb0f36)
-  )
-  (junction (at 185.42 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 3abcfbc6-0288-48d7-a0e0-144f99e6dd30)
-  )
-  (junction (at 144.78 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 3d987483-3b5e-44fb-b675-40705bf855c1)
-  )
-  (junction (at 73.66 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 3ddc125c-fcd9-4032-ab01-48905fc95e1f)
-  )
-  (junction (at 134.62 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 3ddd9e62-5556-463c-9539-c0d582cc40e9)
-  )
-  (junction (at 215.9 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 3e3c4ece-47a6-47a0-92bc-290b69884d25)
-  )
-  (junction (at 43.18 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 4420dc63-3aee-4086-92ad-39d849507e61)
-  )
-  (junction (at 175.26 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 461b5e1e-26c0-464b-90de-d503b74d31b2)
-  )
-  (junction (at 236.22 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 46349b1a-d4af-45cd-a544-99bbfc4dc176)
-  )
-  (junction (at 246.38 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 47663216-b5b6-46c0-86b4-2eecf37e4714)
-  )
-  (junction (at 205.74 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 4788fde7-f606-4229-8a7b-9fa04f56d3d4)
-  )
-  (junction (at 114.3 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 490a89d7-a161-4f1a-9b45-a55729d9d59b)
-  )
-  (junction (at 114.3 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 49621764-c8ec-44d3-917e-f33f018f3c73)
-  )
-  (junction (at 124.46 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4c74baef-72cb-4cdf-b4eb-a3d28782257d)
-  )
-  (junction (at 53.34 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 4c7a50e9-7650-493b-b0a7-057b900a13a7)
-  )
-  (junction (at 63.5 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9)
-  )
-  (junction (at 144.78 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid 4ca8463c-17c1-4081-98f7-058f3e24afa5)
-  )
-  (junction (at 165.1 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 4df4e0a7-6e46-4c32-959d-094f3457d75b)
-  )
-  (junction (at 43.18 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 4e641ba8-cbcf-42cf-89f0-ac977902bf98)
-  )
-  (junction (at 73.66 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 4fc826ad-ef7b-406a-9b89-76eb2c211523)
-  )
-  (junction (at 53.34 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 4fce0301-62b3-4ef1-9bae-8d55ea745d66)
-  )
-  (junction (at 185.42 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 508ddd33-e065-44a5-a999-5944a523ef76)
-  )
-  (junction (at 175.26 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 50f2ad43-aa07-4fd1-8d58-f22d767da31f)
-  )
-  (junction (at 215.9 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 5139e9d8-9859-4a06-8a53-2bb6b6b13b50)
-  )
-  (junction (at 185.42 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 51c7f5d6-d0e7-40a3-b648-cddc977cf840)
-  )
-  (junction (at 195.58 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 51dbbda9-bf1e-445e-9a43-5f378a7d2f7f)
-  )
-  (junction (at 215.9 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 520e65e5-7987-406d-915b-7bab05f2eec5)
-  )
-  (junction (at 53.34 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 53bb27f5-9b54-4704-b90e-33b3053be6c4)
-  )
-  (junction (at 246.38 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 568866d4-b9be-4a7c-a92b-303ebf890e4c)
-  )
-  (junction (at 236.22 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 59d94e1a-df14-41a9-ac17-b3e09684cb2e)
-  )
-  (junction (at 114.3 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 5b35d564-88c3-4b41-864f-a4f82bc4c871)
-  )
-  (junction (at 43.18 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 5bfc49c0-36f2-431c-81ea-cf78c71d7681)
-  )
-  (junction (at 266.7 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 5e5c2547-fedb-4174-9d5d-8b097a3c440f)
-  )
-  (junction (at 124.46 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid 5fc4155a-3665-4a3a-bfc7-8b7bed175ee0)
-  )
-  (junction (at 215.9 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 622ffcf7-d6fa-402d-9dd5-75baba79ad71)
-  )
-  (junction (at 246.38 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 64b2f9ba-796d-4b73-a2bf-61e94b67dfc1)
-  )
-  (junction (at 83.82 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 6540c8f5-821c-412a-807a-c3ef62138fbb)
-  )
-  (junction (at 63.5 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 65600a9a-e392-4668-8020-aa25d35ebf98)
-  )
-  (junction (at 104.14 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 65f27e9a-164b-490a-b847-29af22012c0c)
-  )
-  (junction (at 63.5 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 670a793c-4c48-41d1-9f07-66b1d7d84b06)
-  )
-  (junction (at 83.82 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 672e2ce9-8f2c-43ff-9498-0e342bc1c65e)
-  )
-  (junction (at 246.38 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid 67489099-7e87-45d2-97ff-6d98a41edce4)
-  )
-  (junction (at 175.26 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 69e63d66-faab-411c-9093-a81235a7547c)
-  )
-  (junction (at 134.62 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 6a52e2bd-c4f2-4694-96d3-9fbd895ea66f)
-  )
-  (junction (at 63.5 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 6b0b87a9-8a81-4bd1-ac24-ffcd6512236b)
-  )
-  (junction (at 43.18 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6bfc7531-8adc-4c87-bf8a-788404262765)
-  )
-  (junction (at 134.62 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1)
-  )
-  (junction (at 154.94 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 6ff7fc69-ca50-4b66-851e-eb36da3cadd8)
-  )
-  (junction (at 63.5 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 712da204-b8e1-4637-b967-521ccf7b108c)
-  )
-  (junction (at 246.38 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 71a71501-1b26-4915-93b4-96a7dee3a44f)
-  )
-  (junction (at 73.66 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 71e77471-d824-448e-a6de-31cce05e17c2)
-  )
-  (junction (at 205.74 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 72e4e912-d3a6-49dd-a5cd-3717c5b10d71)
-  )
-  (junction (at 73.66 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 742ecb41-f257-40d3-a6f3-d155d6036628)
-  )
-  (junction (at 154.94 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 74eb0a18-3ddb-4ea4-a352-4c8a041470e2)
-  )
-  (junction (at 53.34 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 7710d08c-fec8-48ed-9536-82f00f1cfc8b)
-  )
-  (junction (at 226.06 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 77bb30a6-a1de-4dd1-a9f1-aff61d4e98ac)
-  )
-  (junction (at 93.98 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 782ee96d-a257-4c78-ac0f-a3b5279bef37)
-  )
-  (junction (at 53.34 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 7943e9ed-5e22-49d3-a238-47d875f3e823)
-  )
-  (junction (at 236.22 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 79f1a6f6-1219-460c-9c15-e032107323da)
-  )
-  (junction (at 43.18 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 7dbcae2f-e000-4aff-92b3-5518ea113182)
-  )
-  (junction (at 246.38 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 7e1e558a-0687-4da1-890d-e5b08d32906f)
-  )
-  (junction (at 236.22 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid 802959db-8c82-47e0-a5cd-84de44b3e860)
-  )
-  (junction (at 236.22 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 81204729-3be0-4723-b09e-5baeace0ae6e)
-  )
-  (junction (at 104.14 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 822096c9-a5b4-460b-8639-9bbf1bb1a2fa)
-  )
-  (junction (at 93.98 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 84442e81-a253-49f6-ab0f-8ece0b39f637)
-  )
-  (junction (at 53.34 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 86d88f2b-6e5b-493a-b3a4-5436a8374fae)
-  )
-  (junction (at 246.38 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 882f2a13-7075-40af-8a18-844f6b92a1f3)
-  )
-  (junction (at 104.14 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 88441b0d-9a40-4e18-8fc9-814cc1cb4d3e)
-  )
-  (junction (at 185.42 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 8a6c81db-4db5-4eb7-a06a-31575c90f62f)
-  )
-  (junction (at 83.82 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 8bf191a4-2dcd-4018-b67a-91aef9fad846)
-  )
-  (junction (at 93.98 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 8d0975e0-03e3-4038-81bb-699f429e5e7b)
-  )
-  (junction (at 144.78 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 8d88bb99-f0e4-4a81-b464-31814877675a)
-  )
-  (junction (at 195.58 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 8de5a888-7283-4e9f-99ef-73d74bb27108)
-  )
-  (junction (at 246.38 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 8eb3e5bb-f2c3-42a2-a6bc-5eddd7433f5d)
-  )
-  (junction (at 205.74 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid 90d2cc8f-50ae-48a5-81ff-9df8ee53f514)
-  )
-  (junction (at 215.9 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 90dd44b9-9dd3-4690-8a0a-64e100872339)
-  )
-  (junction (at 205.74 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid 91635678-4449-4ed4-88c1-10b19deef1b0)
-  )
-  (junction (at 266.7 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 95b0c111-7d27-49ee-a08f-b6f35d9d5b54)
-  )
-  (junction (at 236.22 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 96160b01-68f8-4d57-83d8-bf1fa6b0ffdd)
-  )
-  (junction (at 93.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 96a12dd2-d02f-4a86-aa6d-3a7015c06462)
-  )
-  (junction (at 195.58 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 98319cb9-c3ce-4829-b82f-df8af9cb7381)
-  )
-  (junction (at 134.62 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 99c67f58-7bde-4417-a08c-823e6af847f2)
-  )
-  (junction (at 93.98 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid 9a57387e-9b4d-41d6-99cb-8b5046a4210a)
-  )
-  (junction (at 63.5 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9c5d2aae-598c-438e-b7da-ebb8546ddaff)
-  )
-  (junction (at 195.58 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid 9cbabbae-21a8-4838-be56-56e992e4b864)
-  )
-  (junction (at 124.46 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9d2b0f02-b19d-4907-8835-9e7f8a8b9c34)
-  )
-  (junction (at 226.06 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 9e2bd5cb-7b23-4384-a3c5-2d4acf752984)
-  )
-  (junction (at 215.9 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid a2c3f4db-e97d-4584-bc55-22a1f47c7221)
-  )
-  (junction (at 93.98 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid a2db7df7-b835-49df-98be-3c291238016c)
-  )
-  (junction (at 185.42 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid a3593416-7fea-415d-a48b-ed5f49c771b2)
-  )
-  (junction (at 114.3 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid a47737c8-d0f1-4d7f-a269-cdad9b41d18b)
-  )
-  (junction (at 246.38 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid a52ed26a-ac7f-4cb2-a1c7-12172b24c4ab)
-  )
-  (junction (at 185.42 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid a63b450e-8bb6-4430-a1a8-c471d275241a)
-  )
-  (junction (at 63.5 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid a6cd881c-1146-4d92-9184-bf83a80c20c4)
-  )
-  (junction (at 165.1 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid a7400bf6-86c3-4d41-886e-57235a457a4c)
-  )
-  (junction (at 165.1 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid a9baaad2-c62c-4b79-a10b-261651ef4961)
-  )
-  (junction (at 266.7 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid a9ece8f4-f868-428b-b7ff-a3dc07b47d6c)
-  )
-  (junction (at 144.78 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid aa4f9edb-d8b6-45e2-8d16-270f3c9fc990)
-  )
-  (junction (at 104.14 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid ab0811a2-347a-4a90-b4d0-f1b1ba038333)
-  )
-  (junction (at 195.58 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid ac27d187-5d39-4e20-a98d-006d06095529)
-  )
-  (junction (at 226.06 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid ac7cf2c1-f0eb-4f3a-bdfc-60426aa052ac)
-  )
-  (junction (at 63.5 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid ace95043-3b32-415f-8735-1487cbd49332)
-  )
-  (junction (at 124.46 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid b1e2ebf4-6a50-4b42-af1b-0294cfee2751)
-  )
-  (junction (at 83.82 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b23bc3a0-3ebe-44a5-9126-8b5c4d648e08)
-  )
-  (junction (at 205.74 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid b3d0ee10-bd96-4305-9675-c2f1f7a7662b)
-  )
-  (junction (at 114.3 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid b5ce3eda-e357-44e1-9c69-f84009fc7a87)
-  )
-  (junction (at 154.94 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid b7093823-b63a-4a1a-b279-5afe0127ec9d)
-  )
-  (junction (at 266.7 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b98759bc-77be-4dce-9aa2-cc5ce3889034)
-  )
-  (junction (at 154.94 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b995f4ca-5e8d-4350-aff6-b7bea568d7f5)
-  )
-  (junction (at 53.34 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3)
-  )
-  (junction (at 205.74 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bb9843d1-ea35-45a8-bd3d-5b381b0dc875)
-  )
-  (junction (at 175.26 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid bbd2fe65-aac5-437c-9177-9832921486d5)
-  )
-  (junction (at 175.26 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid bcf6a98c-2d79-4afb-9a5e-6558bb743cec)
-  )
-  (junction (at 226.06 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid bdaa210f-5df4-43b3-b2cb-9563b1c2f196)
-  )
-  (junction (at 154.94 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid be75ea2d-b3b9-4fd0-812b-104329fac661)
-  )
-  (junction (at 144.78 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid befc6138-873b-4406-bc9e-e5a72f7f36fe)
-  )
-  (junction (at 175.26 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid bf44b855-bf79-4ceb-a9a9-021d72c7f67c)
-  )
-  (junction (at 83.82 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0)
-  )
-  (junction (at 83.82 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid c179a6f6-d6cf-4784-b7f0-70633ed08609)
-  )
-  (junction (at 134.62 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid c29c26fc-c285-45ba-9e88-4c2a02375307)
-  )
-  (junction (at 165.1 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid c331d35d-23c9-43ea-b243-b660cb5f4bdb)
-  )
-  (junction (at 134.62 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid c3f1775c-0d63-41d3-b7d8-a4c96d241ce3)
-  )
-  (junction (at 93.98 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c41e97f8-87c8-4e82-92ed-e4644d6f526e)
-  )
-  (junction (at 236.22 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c4319a07-1f8f-4ae0-928a-04e03c76b2be)
-  )
-  (junction (at 124.46 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid c51de65b-dd06-4a71-8763-eab77eba6638)
-  )
-  (junction (at 266.7 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c56d20e0-377b-42bf-89fc-25b698ca10b4)
-  )
-  (junction (at 114.3 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c5afc93c-0846-4cf9-8f93-4c8f2232c9fa)
-  )
-  (junction (at 83.82 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid c7d88142-1b7e-4dd1-b026-f2267e06dab1)
-  )
-  (junction (at 43.18 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid c8f222f6-943e-4d7d-919b-3278ca0ede33)
-  )
-  (junction (at 195.58 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c9e3ffd4-a7b6-4729-8189-cdaba274ef13)
-  )
-  (junction (at 144.78 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cc2d9922-84c9-42ce-883b-c028a251c101)
-  )
-  (junction (at 266.7 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid cc477f6c-44d3-44d1-b104-0f5c17b8e6fa)
-  )
-  (junction (at 124.46 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid cd054c4e-f9d4-4701-a538-16740432e58d)
-  )
-  (junction (at 226.06 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cd48bbd4-ca90-4b55-bc6b-cf9da8cf6333)
-  )
-  (junction (at 195.58 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid cf841124-1985-4dfd-858c-868589098888)
-  )
-  (junction (at 63.5 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid cfd86ddc-0810-4057-8a79-4468ec7b2424)
-  )
-  (junction (at 205.74 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d07b66d1-3d51-4607-8fd1-974bbf8f9371)
-  )
-  (junction (at 53.34 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid d328f077-6d93-4470-a2b2-f4c9287daff0)
-  )
-  (junction (at 205.74 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid d3f7612d-781e-42f5-a5f0-fe2744aa5d60)
-  )
-  (junction (at 144.78 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid d4ac21a4-2c41-454b-9f76-4f3d030f7ac8)
-  )
-  (junction (at 83.82 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid d5a179bd-82b1-4661-aebc-4c4d4801bdff)
-  )
-  (junction (at 144.78 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d5b7ef4f-419a-421c-a02d-fd71016e6c97)
-  )
-  (junction (at 154.94 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid d774ae68-7d44-45a8-babf-4a5136fe82a1)
-  )
-  (junction (at 236.22 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid d82f4811-d69b-4b67-86ec-58dc2b09efce)
-  )
-  (junction (at 185.42 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d8d69513-50ec-441c-a953-5a6c226b729f)
-  )
-  (junction (at 236.22 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid d9d8d322-c1a6-4620-97f8-79c4d7399c0b)
-  )
-  (junction (at 226.06 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid dc26fb26-3b4c-4f5f-8838-a826029b5e11)
-  )
-  (junction (at 195.58 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid dc8b09d2-1c55-4758-be69-6f8072d6abe0)
-  )
-  (junction (at 114.3 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid dcab5abe-0f5a-44d8-b554-722164ca6a23)
-  )
-  (junction (at 154.94 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid dded6bb5-453a-4491-9278-65d2368e4bc0)
-  )
-  (junction (at 93.98 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid dece07f3-2868-47c6-b119-0ca286e7cc50)
-  )
-  (junction (at 215.9 251.46) (diameter 0) (color 0 0 0 0)
-    (uuid e1ae70a8-71e4-4b07-b504-14219374e1fa)
-  )
-  (junction (at 236.22 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid e3118c0a-3d75-4cb1-a7c3-cdeb1c9e52bc)
-  )
-  (junction (at 165.1 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid e3259dd4-fd6c-4d03-8afb-b6f306558bb6)
-  )
-  (junction (at 175.26 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid e3827bb6-d8e8-410a-8c19-3e64c8191b94)
-  )
-  (junction (at 215.9 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid e4337269-24a1-47d0-90ce-0190655362a9)
-  )
-  (junction (at 154.94 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid e46432a2-96f1-448e-8928-bfcbbf445ca9)
-  )
-  (junction (at 175.26 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid e66342f0-16d5-4367-b00a-d7cf257720d9)
-  )
-  (junction (at 226.06 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid e7e968af-bf0e-4847-a623-74d007921b9f)
-  )
-  (junction (at 165.1 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid ed20875e-b9a5-4926-97e0-c3921a5eb1cd)
-  )
-  (junction (at 215.9 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid ed60b040-01a3-47a4-9e4e-0093442edfae)
-  )
-  (junction (at 114.3 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid ee17efa1-5df9-47d0-aec2-a440d8b33e4c)
-  )
-  (junction (at 104.14 182.88) (diameter 0) (color 0 0 0 0)
-    (uuid f0d84c95-52f0-41cd-8742-4de83021f783)
-  )
-  (junction (at 134.62 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid f1379b2f-59c4-4b61-a98f-3645b6e5fe6b)
-  )
-  (junction (at 104.14 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid f24e6016-cf0c-4fe9-b584-ca06dfdbe767)
-  )
-  (junction (at 134.62 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid f299a1cc-612f-4d6b-9276-fe837e4e91d9)
-  )
-  (junction (at 134.62 210.82) (diameter 0) (color 0 0 0 0)
-    (uuid f368e14e-0af5-4e13-a581-f1a139c24e5c)
-  )
-  (junction (at 226.06 223.52) (diameter 0) (color 0 0 0 0)
-    (uuid f46f02fc-54c8-4580-bd05-1da63b3c8bbc)
-  )
-  (junction (at 43.18 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid f6f817c6-438a-4497-93b1-8dc1f36a395c)
-  )
-  (junction (at 226.06 203.2) (diameter 0) (color 0 0 0 0)
-    (uuid f70d9535-4e8c-4a08-92e9-2c160ff79eff)
-  )
-  (junction (at 53.34 231.14) (diameter 0) (color 0 0 0 0)
-    (uuid f7606fcd-7602-4f5d-b31b-5fb97e1ca534)
-  )
-  (junction (at 124.46 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd)
-  )
-  (junction (at 144.78 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid f8b3b54a-7c03-49e4-8762-b4ef31db5afd)
-  )
-  (junction (at 266.7 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fa2795fd-0138-4010-b310-3d5e73c1be1c)
-  )
-  (junction (at 195.58 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid fb315348-48a4-4210-8623-991734f6ee66)
-  )
-  (junction (at 73.66 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fbda2010-a213-45bb-958d-0c9446d51e42)
-  )
-  (junction (at 73.66 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid fc393c80-fb90-44e5-ac86-763463fd8acd)
-  )
-  (junction (at 114.3 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid fc6abd7a-92c0-4b05-85ed-b3bd910676e1)
-  )
-  (junction (at 144.78 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid fdc0071f-cdad-424a-87db-7bd8a0569159)
-  )
-  (junction (at 236.22 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid fe54d4f8-4808-4257-a695-1a4bbd144566)
-  )
-
-  (wire (pts (xy 83.82 60.96) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 022d84d0-7bcb-4024-8618-6f3a7f7b41aa)
-  )
-  (wire (pts (xy 144.78 25.4) (xy 144.78 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0406a358-3219-4537-99c7-cfb994e5303c)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0429bfe1-2992-4c6f-bb22-b2e8e5724910)
-  )
-  (wire (pts (xy 215.9 129.54) (xy 236.22 129.54))
-    (stroke (width 0) (type default))
-    (uuid 04b771e3-dd4b-454d-b08d-2ba0a456c1cb)
-  )
-  (wire (pts (xy 205.74 182.88) (xy 205.74 203.2))
-    (stroke (width 0) (type default))
-    (uuid 04f743f4-6844-43ab-a149-4db3a42e61b3)
-  )
-  (wire (pts (xy 185.42 203.2) (xy 185.42 223.52))
-    (stroke (width 0) (type default))
-    (uuid 054d0701-89e5-4918-a35c-1668152b63f2)
-  )
-  (wire (pts (xy 236.22 129.54) (xy 259.08 129.54))
-    (stroke (width 0) (type default))
-    (uuid 065b1c3f-f9a5-4c91-b47a-16d2b0f4b78c)
-  )
-  (wire (pts (xy 205.74 203.2) (xy 205.74 223.52))
-    (stroke (width 0) (type default))
-    (uuid 0698b251-ec3b-4a4c-821a-adad423d20ba)
-  )
-  (wire (pts (xy 63.5 60.96) (xy 63.5 81.28))
-    (stroke (width 0) (type default))
-    (uuid 06b94062-ab90-4776-acd7-64603720a270)
-  )
-  (wire (pts (xy 185.42 162.56) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid 070c607f-224b-4963-a847-a5abbe4e2e9d)
-  )
-  (wire (pts (xy 73.66 109.22) (xy 93.98 109.22))
-    (stroke (width 0) (type default))
-    (uuid 07ee4d30-e80a-41ae-829d-e3cecf87d77e)
-  )
-  (wire (pts (xy 226.06 81.28) (xy 226.06 101.6))
-    (stroke (width 0) (type default))
-    (uuid 0805b235-8597-4158-8971-28b691867ce0)
-  )
-  (wire (pts (xy 114.3 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0897e94f-d1e3-47ff-89f6-5de7a1349783)
-  )
-  (wire (pts (xy 226.06 182.88) (xy 226.06 203.2))
-    (stroke (width 0) (type default))
-    (uuid 08999926-6e91-4cd1-80de-7963ec46f28b)
-  )
-  (wire (pts (xy 246.38 121.92) (xy 246.38 142.24))
-    (stroke (width 0) (type default))
-    (uuid 0909471f-383c-4975-9a61-5008689e9193)
-  )
-  (wire (pts (xy 175.26 109.22) (xy 195.58 109.22))
-    (stroke (width 0) (type default))
-    (uuid 0a962d83-8897-42a2-883b-90f8b3b46e9e)
-  )
-  (wire (pts (xy 266.7 68.58) (xy 266.7 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0aee33c0-3781-43dc-99cb-690f399192cd)
-  )
-  (wire (pts (xy 154.94 48.26) (xy 175.26 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0b08be29-0149-48a5-b5a3-9614befb1784)
-  )
-  (wire (pts (xy 266.7 231.14) (xy 266.7 251.46))
-    (stroke (width 0) (type default))
-    (uuid 0b495840-7c14-4d0f-aea8-1a6a34972054)
-  )
-  (wire (pts (xy 195.58 203.2) (xy 205.74 203.2))
-    (stroke (width 0) (type default))
-    (uuid 0bbfe73f-3f00-4157-8def-4fa012c6902e)
-  )
-  (wire (pts (xy 53.34 231.14) (xy 73.66 231.14))
-    (stroke (width 0) (type default))
-    (uuid 0cfcf878-b8da-4ac7-be72-6319dfc721fd)
-  )
-  (wire (pts (xy 43.18 182.88) (xy 43.18 203.2))
-    (stroke (width 0) (type default))
-    (uuid 0e0cdb3f-d11e-41fa-b224-dbdc3dd27130)
-  )
-  (wire (pts (xy 43.18 40.64) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0f76c070-bcf8-4924-a8c5-3abe13c36f41)
-  )
-  (wire (pts (xy 63.5 81.28) (xy 63.5 101.6))
-    (stroke (width 0) (type default))
-    (uuid 11ef6261-91ba-4d4c-99ef-8991b7c91dc8)
-  )
-  (wire (pts (xy 104.14 101.6) (xy 104.14 121.92))
-    (stroke (width 0) (type default))
-    (uuid 12080e73-a151-4804-ac9b-ac3ac13653e9)
-  )
-  (wire (pts (xy 73.66 48.26) (xy 93.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 12a939e2-2ab8-4d74-a5c9-6d61a9528b6e)
-  )
-  (wire (pts (xy 63.5 182.88) (xy 63.5 203.2))
-    (stroke (width 0) (type default))
-    (uuid 13961bb6-28aa-4ee0-a270-8bc7b0339a4b)
-  )
-  (wire (pts (xy 154.94 68.58) (xy 175.26 68.58))
-    (stroke (width 0) (type default))
-    (uuid 14d9635b-ccaf-4f8c-a2a6-101eb19eb42d)
-  )
-  (wire (pts (xy 134.62 210.82) (xy 154.94 210.82))
-    (stroke (width 0) (type default))
-    (uuid 150130ef-d28d-4782-b4fc-0c67b58e9b8e)
-  )
-  (wire (pts (xy 93.98 190.5) (xy 114.3 190.5))
-    (stroke (width 0) (type default))
-    (uuid 1767f007-bd12-458a-9e69-f01cc8a5ed24)
-  )
-  (wire (pts (xy 246.38 203.2) (xy 246.38 223.52))
-    (stroke (width 0) (type default))
-    (uuid 1822529b-8f09-4adb-aaae-0504083bb89e)
-  )
-  (wire (pts (xy 205.74 142.24) (xy 205.74 162.56))
-    (stroke (width 0) (type default))
-    (uuid 18ccb399-8ad2-4b42-b317-de1e9939e9e9)
-  )
-  (wire (pts (xy 104.14 25.4) (xy 104.14 40.64))
-    (stroke (width 0) (type default))
-    (uuid 1af5b449-9a68-414b-a41f-d6f6cba715a8)
-  )
-  (wire (pts (xy 165.1 203.2) (xy 165.1 223.52))
-    (stroke (width 0) (type default))
-    (uuid 1bc4e1a4-fd5a-4e45-a9b9-9fd07d45de91)
-  )
-  (wire (pts (xy 73.66 81.28) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 1c0140d1-6775-49db-9fd5-7ecf63ae1284)
-  )
-  (wire (pts (xy 205.74 223.52) (xy 205.74 243.84))
-    (stroke (width 0) (type default))
-    (uuid 1f10ac4d-394d-4f34-a8e8-91d9d3ca5fd5)
-  )
-  (wire (pts (xy 114.3 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid 211f763f-7ef6-4fb5-98df-2e2ff37faa42)
-  )
-  (wire (pts (xy 236.22 68.58) (xy 259.08 68.58))
-    (stroke (width 0) (type default))
-    (uuid 23d9c8d8-62ef-48ef-a21d-8c042f11ec2f)
-  )
-  (wire (pts (xy 63.5 40.64) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 23f46f84-f16d-4b0b-b463-c2c0244adcc0)
-  )
-  (wire (pts (xy 83.82 203.2) (xy 83.82 223.52))
-    (stroke (width 0) (type default))
-    (uuid 24025a56-ae5c-4c1a-a354-e66bbbcc4688)
-  )
-  (wire (pts (xy 33.02 129.54) (xy 53.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid 24da3fea-844d-4666-b730-f8d7b708f242)
-  )
-  (wire (pts (xy 185.42 40.64) (xy 185.42 60.96))
-    (stroke (width 0) (type default))
-    (uuid 265c8115-55ea-4d09-95c1-3178314bfa04)
-  )
-  (wire (pts (xy 53.34 129.54) (xy 73.66 129.54))
-    (stroke (width 0) (type default))
-    (uuid 26f78b89-ba4b-4b48-90d1-1245694ead6f)
-  )
-  (wire (pts (xy 83.82 162.56) (xy 83.82 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2703e5ce-9651-45e1-8bd6-144e60387b78)
-  )
-  (wire (pts (xy 215.9 88.9) (xy 236.22 88.9))
-    (stroke (width 0) (type default))
-    (uuid 271ac63e-22d2-4815-976d-7e67fdaefe83)
-  )
-  (wire (pts (xy 33.02 109.22) (xy 53.34 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2832f642-62e7-4a51-b112-f728658e7714)
-  )
-  (wire (pts (xy 195.58 68.58) (xy 215.9 68.58))
-    (stroke (width 0) (type default))
-    (uuid 28f7b63d-6686-4459-afe8-f6dd162a4f81)
-  )
-  (wire (pts (xy 53.34 68.58) (xy 73.66 68.58))
-    (stroke (width 0) (type default))
-    (uuid 29a0e612-9a4c-422c-a9b8-8a9fe3879b8a)
-  )
-  (wire (pts (xy 83.82 101.6) (xy 83.82 121.92))
-    (stroke (width 0) (type default))
-    (uuid 2a44e441-f6d5-4994-b7ba-34283a1facc7)
-  )
-  (wire (pts (xy 124.46 121.92) (xy 124.46 142.24))
-    (stroke (width 0) (type default))
-    (uuid 2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0)
-  )
-  (wire (pts (xy 53.34 60.96) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 2a62b555-17b9-46f9-8a2e-f1db0d1e286c)
-  )
-  (wire (pts (xy 114.3 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 2a65926a-d988-49f6-92e7-6e4d5936462f)
-  )
-  (wire (pts (xy 195.58 170.18) (xy 215.9 170.18))
-    (stroke (width 0) (type default))
-    (uuid 2ada3dc7-0276-4fb5-993b-c6f072f33b85)
-  )
-  (wire (pts (xy 165.1 162.56) (xy 165.1 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2afd7500-0a15-4710-acc0-4f03472785c3)
-  )
-  (wire (pts (xy 165.1 60.96) (xy 165.1 81.28))
-    (stroke (width 0) (type default))
-    (uuid 2b8c9def-eaec-4abd-b08a-c3613e6389df)
-  )
-  (wire (pts (xy 53.34 109.22) (xy 73.66 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd)
-  )
-  (wire (pts (xy 195.58 48.26) (xy 215.9 48.26))
-    (stroke (width 0) (type default))
-    (uuid 2eb5b021-cd36-4ec2-99b5-3504f408e676)
-  )
-  (wire (pts (xy 124.46 25.4) (xy 124.46 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3115f7a7-e786-49c1-9e4c-25c171cfeb33)
-  )
-  (wire (pts (xy 73.66 68.58) (xy 93.98 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3197b37c-ee5b-406a-ab67-08670d4b8c09)
-  )
-  (wire (pts (xy 215.9 223.52) (xy 226.06 223.52))
-    (stroke (width 0) (type default))
-    (uuid 331adf6b-edc7-41b1-8701-a50d3af94787)
-  )
-  (wire (pts (xy 165.1 182.88) (xy 165.1 203.2))
-    (stroke (width 0) (type default))
-    (uuid 335e6f69-208d-4946-a709-07b34240cbfe)
-  )
-  (wire (pts (xy 63.5 223.52) (xy 63.5 243.84))
-    (stroke (width 0) (type default))
-    (uuid 34351d11-022e-4b57-b2c7-81036e999059)
-  )
-  (wire (pts (xy 185.42 223.52) (xy 185.42 243.84))
-    (stroke (width 0) (type default))
-    (uuid 34a6214b-f3a2-4b07-8c59-5326fa1f0444)
-  )
-  (wire (pts (xy 175.26 231.14) (xy 195.58 231.14))
-    (stroke (width 0) (type default))
-    (uuid 34d9b895-8709-4ae3-8234-e9c042dd7992)
-  )
-  (wire (pts (xy 154.94 88.9) (xy 175.26 88.9))
-    (stroke (width 0) (type default))
-    (uuid 35f5724f-e5dd-4205-b169-9ef9f7b3efa2)
-  )
-  (wire (pts (xy 236.22 48.26) (xy 259.08 48.26))
-    (stroke (width 0) (type default))
-    (uuid 379018e3-d7a0-42c0-abbf-14d4c107728d)
-  )
-  (wire (pts (xy 266.7 210.82) (xy 266.7 231.14))
-    (stroke (width 0) (type default))
-    (uuid 3a9fab7b-7f53-4445-b1a0-755685a5b87b)
-  )
-  (wire (pts (xy 134.62 68.58) (xy 154.94 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3b15c81d-3687-4710-9aa6-d57ee4885603)
-  )
-  (wire (pts (xy 63.5 121.92) (xy 63.5 142.24))
-    (stroke (width 0) (type default))
-    (uuid 3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5)
-  )
-  (wire (pts (xy 134.62 251.46) (xy 154.94 251.46))
-    (stroke (width 0) (type default))
-    (uuid 3bdb9bc8-9458-4811-8b47-c38bf9331962)
-  )
-  (wire (pts (xy 114.3 190.5) (xy 134.62 190.5))
-    (stroke (width 0) (type default))
-    (uuid 3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb)
-  )
-  (wire (pts (xy 195.58 109.22) (xy 215.9 109.22))
-    (stroke (width 0) (type default))
-    (uuid 3d4e19e8-2fb5-4e22-930a-612c1a48f37c)
-  )
-  (wire (pts (xy 226.06 25.4) (xy 226.06 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3e8a4dda-891b-4819-a0ec-6d09bab41776)
-  )
-  (wire (pts (xy 43.18 223.52) (xy 43.18 243.84))
-    (stroke (width 0) (type default))
-    (uuid 3f02d1c4-e975-4454-aaaf-b01003921ce8)
-  )
-  (wire (pts (xy 154.94 231.14) (xy 175.26 231.14))
-    (stroke (width 0) (type default))
-    (uuid 3f7461c6-c2c3-4fe0-b1c0-d702c7e88622)
-  )
-  (wire (pts (xy 226.06 60.96) (xy 226.06 81.28))
-    (stroke (width 0) (type default))
-    (uuid 40278c5a-7892-4426-82ce-3b5f75d33db8)
-  )
-  (wire (pts (xy 73.66 170.18) (xy 93.98 170.18))
-    (stroke (width 0) (type default))
-    (uuid 40ad23e4-b284-4d51-a92e-26a2272af251)
-  )
-  (wire (pts (xy 165.1 121.92) (xy 165.1 142.24))
-    (stroke (width 0) (type default))
-    (uuid 411efa8a-c2b6-469e-b517-3b3f24ffe025)
-  )
-  (wire (pts (xy 73.66 190.5) (xy 93.98 190.5))
-    (stroke (width 0) (type default))
-    (uuid 432577d5-87d0-4924-a72a-e407dd2ee4b0)
-  )
-  (wire (pts (xy 134.62 170.18) (xy 154.94 170.18))
-    (stroke (width 0) (type default))
-    (uuid 44b0d7a3-542f-48ea-8a2f-25ca02bd7f05)
-  )
-  (wire (pts (xy 53.34 170.18) (xy 73.66 170.18))
-    (stroke (width 0) (type default))
-    (uuid 4554fe48-1b8d-466c-b3f4-c87fb3d79947)
-  )
-  (wire (pts (xy 43.18 60.96) (xy 43.18 81.28))
-    (stroke (width 0) (type default))
-    (uuid 456f0365-d37d-43a2-afac-d06c44cc48af)
-  )
-  (wire (pts (xy 154.94 129.54) (xy 175.26 129.54))
-    (stroke (width 0) (type default))
-    (uuid 462b3865-9668-49d6-a9d9-1406a843104e)
-  )
-  (wire (pts (xy 215.9 48.26) (xy 236.22 48.26))
-    (stroke (width 0) (type default))
-    (uuid 4666d04a-04e6-40ed-be2c-4247995ce902)
-  )
-  (wire (pts (xy 114.3 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid 473d672b-6459-459b-93fc-780e5d8f9818)
-  )
-  (wire (pts (xy 226.06 121.92) (xy 226.06 142.24))
-    (stroke (width 0) (type default))
-    (uuid 4905f532-fc39-4175-9bc0-d3b0b2aab86e)
-  )
-  (wire (pts (xy 124.46 81.28) (xy 124.46 101.6))
-    (stroke (width 0) (type default))
-    (uuid 495f9334-ca7f-4aa5-8d75-09576f1afa2c)
-  )
-  (wire (pts (xy 104.14 182.88) (xy 104.14 203.2))
-    (stroke (width 0) (type default))
-    (uuid 4bc89a8f-f8d9-4d47-a286-fb87f34a3ba1)
-  )
-  (wire (pts (xy 215.9 149.86) (xy 236.22 149.86))
-    (stroke (width 0) (type default))
-    (uuid 4c0ce08b-4ec4-4aec-a724-210098f01260)
-  )
-  (wire (pts (xy 63.5 203.2) (xy 63.5 223.52))
-    (stroke (width 0) (type default))
-    (uuid 4d757dc1-e039-4666-8204-33ddd2c3d535)
-  )
-  (wire (pts (xy 73.66 251.46) (xy 93.98 251.46))
-    (stroke (width 0) (type default))
-    (uuid 50546e55-dd78-410b-802d-e2e542a3aeb8)
-  )
-  (wire (pts (xy 165.1 81.28) (xy 165.1 101.6))
-    (stroke (width 0) (type default))
-    (uuid 50f7b113-f5f8-43e0-9da7-2a02dc224210)
-  )
-  (wire (pts (xy 266.7 190.5) (xy 266.7 210.82))
-    (stroke (width 0) (type default))
-    (uuid 5194f352-1f61-4ee5-af2e-f0eb341e3d13)
-  )
-  (wire (pts (xy 226.06 162.56) (xy 226.06 182.88))
-    (stroke (width 0) (type default))
-    (uuid 530fd8d7-df39-43ed-b05c-34496eb7d3a1)
-  )
-  (wire (pts (xy 215.9 190.5) (xy 236.22 190.5))
-    (stroke (width 0) (type default))
-    (uuid 54aeade9-047f-465a-b676-344776802b0f)
-  )
-  (wire (pts (xy 33.02 190.5) (xy 53.34 190.5))
-    (stroke (width 0) (type default))
-    (uuid 55243e41-6164-4661-b707-a6f503f12968)
-  )
-  (wire (pts (xy 53.34 190.5) (xy 73.66 190.5))
-    (stroke (width 0) (type default))
-    (uuid 557847f5-42a8-4c4a-a4d9-d21678c28920)
-  )
-  (wire (pts (xy 236.22 210.82) (xy 259.08 210.82))
-    (stroke (width 0) (type default))
-    (uuid 55c45ac0-23c6-495d-9bfd-1e1f6c945956)
-  )
-  (wire (pts (xy 104.14 60.96) (xy 104.14 81.28))
-    (stroke (width 0) (type default))
-    (uuid 5837ecd4-cf70-4c14-9c7b-bb5f05f8274a)
-  )
-  (wire (pts (xy 93.98 231.14) (xy 114.3 231.14))
-    (stroke (width 0) (type default))
-    (uuid 59384b6c-2072-4474-b0f7-71a68de7f080)
-  )
-  (wire (pts (xy 104.14 81.28) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid 5b6ae0de-21c8-4433-a4e0-a3b552474fb0)
-  )
-  (wire (pts (xy 154.94 190.5) (xy 175.26 190.5))
-    (stroke (width 0) (type default))
-    (uuid 5baecb37-4d65-4174-bd66-a5145576e2b9)
-  )
-  (wire (pts (xy 154.94 149.86) (xy 175.26 149.86))
-    (stroke (width 0) (type default))
-    (uuid 5bf40b1a-0569-4c54-9cc9-b9bf89658c72)
-  )
-  (wire (pts (xy 215.9 170.18) (xy 236.22 170.18))
-    (stroke (width 0) (type default))
-    (uuid 5d453d03-4d0f-4be1-b096-6496e136bcf8)
-  )
-  (wire (pts (xy 134.62 48.26) (xy 154.94 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5d63c1a3-5086-42ca-8afa-60afe2472b23)
-  )
-  (wire (pts (xy 246.38 142.24) (xy 246.38 162.56))
-    (stroke (width 0) (type default))
-    (uuid 5ead2e45-47c8-46fa-90d4-a4246ed8dc04)
-  )
-  (wire (pts (xy 93.98 210.82) (xy 114.3 210.82))
-    (stroke (width 0) (type default))
-    (uuid 5f73184b-d2cf-4b7b-afcf-f14e002f7ce1)
-  )
-  (wire (pts (xy 236.22 231.14) (xy 259.08 231.14))
-    (stroke (width 0) (type default))
-    (uuid 5ffd8e81-92ad-4f1f-939a-305b07eaf56b)
-  )
-  (wire (pts (xy 53.34 88.9) (xy 73.66 88.9))
-    (stroke (width 0) (type default))
-    (uuid 60b5d548-d07f-40b1-8e16-72d513f499f2)
-  )
-  (wire (pts (xy 124.46 203.2) (xy 124.46 223.52))
-    (stroke (width 0) (type default))
-    (uuid 62806607-b508-4eb1-86e9-30fc018db27c)
-  )
-  (wire (pts (xy 33.02 210.82) (xy 53.34 210.82))
-    (stroke (width 0) (type default))
-    (uuid 6329f5e0-c3e3-42c6-b639-2bebe7a40e8b)
-  )
-  (wire (pts (xy 195.58 210.82) (xy 215.9 210.82))
-    (stroke (width 0) (type default))
-    (uuid 63344b6a-026f-4395-b562-d9979a7e5b8f)
-  )
-  (wire (pts (xy 93.98 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6414e19f-a27a-435d-a47f-a63cba9086f1)
-  )
-  (wire (pts (xy 134.62 109.22) (xy 154.94 109.22))
-    (stroke (width 0) (type default))
-    (uuid 64344100-c91d-4b5c-a8eb-9406d47360dd)
-  )
-  (wire (pts (xy 154.94 109.22) (xy 175.26 109.22))
-    (stroke (width 0) (type default))
-    (uuid 650e246e-9637-4cff-aa82-0f918369ac6f)
-  )
-  (wire (pts (xy 165.1 223.52) (xy 165.1 243.84))
-    (stroke (width 0) (type default))
-    (uuid 661899e2-86b7-446b-a2a9-e69172119b47)
-  )
-  (wire (pts (xy 144.78 223.52) (xy 144.78 243.84))
-    (stroke (width 0) (type default))
-    (uuid 66fa373c-afc7-4261-a808-153f4c2367ba)
-  )
-  (wire (pts (xy 33.02 68.58) (xy 53.34 68.58))
-    (stroke (width 0) (type default))
-    (uuid 68161b0c-a285-475d-a645-59648d12bc07)
-  )
-  (wire (pts (xy 134.62 149.86) (xy 154.94 149.86))
-    (stroke (width 0) (type default))
-    (uuid 690a405c-1ac3-4b57-a93b-778dda168d2c)
-  )
-  (wire (pts (xy 134.62 190.5) (xy 154.94 190.5))
-    (stroke (width 0) (type default))
-    (uuid 6b21e6c7-ab97-41de-aae4-339e943db88e)
-  )
-  (wire (pts (xy 134.62 231.14) (xy 154.94 231.14))
-    (stroke (width 0) (type default))
-    (uuid 6b5263f0-0631-4b01-9161-0e209326bf8d)
-  )
-  (wire (pts (xy 165.1 40.64) (xy 165.1 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc)
-  )
-  (wire (pts (xy 114.3 251.46) (xy 134.62 251.46))
-    (stroke (width 0) (type default))
-    (uuid 6dd9cb59-fa4c-43ef-b035-62559ec6a185)
-  )
-  (wire (pts (xy 195.58 129.54) (xy 215.9 129.54))
-    (stroke (width 0) (type default))
-    (uuid 6de11233-64b7-40cd-8526-970a6c43cb30)
-  )
-  (wire (pts (xy 246.38 60.96) (xy 246.38 81.28))
-    (stroke (width 0) (type default))
-    (uuid 6e16ce81-dfc9-4083-ad2c-ab9c4532be39)
-  )
-  (wire (pts (xy 205.74 40.64) (xy 205.74 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6f1d74d1-18f8-4f5b-8c5d-e1587ab09b83)
-  )
-  (wire (pts (xy 266.7 149.86) (xy 266.7 170.18))
-    (stroke (width 0) (type default))
-    (uuid 6f77a68c-1e32-433a-820e-9683e6fd5e12)
-  )
-  (wire (pts (xy 205.74 162.56) (xy 205.74 182.88))
-    (stroke (width 0) (type default))
-    (uuid 7083b47b-e7bb-4169-bf41-06719234452e)
-  )
-  (wire (pts (xy 266.7 88.9) (xy 266.7 109.22))
-    (stroke (width 0) (type default))
-    (uuid 70c6e975-f457-4759-9791-1d1de45afbb3)
-  )
-  (wire (pts (xy 134.62 129.54) (xy 154.94 129.54))
-    (stroke (width 0) (type default))
-    (uuid 70f3f37d-4259-413e-b59a-babccfdc3a89)
-  )
-  (wire (pts (xy 43.18 121.92) (xy 43.18 142.24))
-    (stroke (width 0) (type default))
-    (uuid 727cc522-ef34-45d4-b711-997054ff0b37)
-  )
-  (wire (pts (xy 33.02 48.26) (xy 53.34 48.26))
-    (stroke (width 0) (type default))
-    (uuid 737596e8-f579-4b1f-aa71-a489d8ba56da)
-  )
-  (wire (pts (xy 93.98 149.86) (xy 114.3 149.86))
-    (stroke (width 0) (type default))
-    (uuid 770cc50c-0085-42e2-b068-cd0ae3b59919)
-  )
-  (wire (pts (xy 266.7 25.4) (xy 266.7 48.26))
-    (stroke (width 0) (type default))
-    (uuid 794205f1-2f7e-4200-b59c-c02481b0416f)
-  )
-  (wire (pts (xy 73.66 88.9) (xy 93.98 88.9))
-    (stroke (width 0) (type default))
-    (uuid 79a42c80-d7a4-4e03-9070-f9fff835a239)
-  )
-  (wire (pts (xy 33.02 40.64) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid 7a4231d0-fb4b-4c65-9cc1-75d3ed714150)
-  )
-  (wire (pts (xy 195.58 88.9) (xy 215.9 88.9))
-    (stroke (width 0) (type default))
-    (uuid 7c26a162-db98-4260-be20-c438c861d890)
-  )
-  (wire (pts (xy 185.42 142.24) (xy 185.42 162.56))
-    (stroke (width 0) (type default))
-    (uuid 7caa1de0-1c5d-4933-9515-38159a29c856)
-  )
-  (wire (pts (xy 236.22 251.46) (xy 259.08 251.46))
-    (stroke (width 0) (type default))
-    (uuid 8296ef34-62aa-49fd-9583-d43eff4a9c61)
-  )
-  (wire (pts (xy 236.22 88.9) (xy 259.08 88.9))
-    (stroke (width 0) (type default))
-    (uuid 841d8f67-3e67-46e5-8955-042c5899dc70)
-  )
-  (wire (pts (xy 104.14 203.2) (xy 104.14 223.52))
-    (stroke (width 0) (type default))
-    (uuid 8487a4c1-7c32-44ea-a841-69a619e14d61)
-  )
-  (wire (pts (xy 165.1 25.4) (xy 165.1 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8506f273-12d6-426d-910b-0c9eecbe3765)
-  )
-  (wire (pts (xy 134.62 88.9) (xy 154.94 88.9))
-    (stroke (width 0) (type default))
-    (uuid 86d6e974-6898-4932-91cb-e8a4c4c283b7)
-  )
-  (wire (pts (xy 93.98 251.46) (xy 114.3 251.46))
-    (stroke (width 0) (type default))
-    (uuid 8a13c872-e78a-41c8-b365-f6f2f0595fb7)
-  )
-  (wire (pts (xy 215.9 210.82) (xy 236.22 210.82))
-    (stroke (width 0) (type default))
-    (uuid 8ab98883-52fd-4210-a5b1-42a74e144026)
-  )
-  (wire (pts (xy 104.14 162.56) (xy 104.14 182.88))
-    (stroke (width 0) (type default))
-    (uuid 8c3cf446-d0cc-4b1b-9218-75f38db02fb3)
-  )
-  (wire (pts (xy 53.34 210.82) (xy 73.66 210.82))
-    (stroke (width 0) (type default))
-    (uuid 8d25f923-67ff-47ea-9485-05bc5282bdab)
-  )
-  (wire (pts (xy 93.98 48.26) (xy 114.3 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8d73bae8-988b-435b-a882-ae9668b41d7e)
-  )
-  (wire (pts (xy 104.14 142.24) (xy 104.14 162.56))
-    (stroke (width 0) (type default))
-    (uuid 8dd624a1-3da3-42c1-929d-9366cd043e3d)
-  )
-  (wire (pts (xy 266.7 48.26) (xy 266.7 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8f339462-56e0-4361-9d9b-983c75fb21ef)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 53.34 88.9))
-    (stroke (width 0) (type default))
-    (uuid 909384ab-bc1c-47d8-a34d-c3d137febfc2)
-  )
-  (wire (pts (xy 124.46 101.6) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91eea887-ea8a-4221-ba92-e5ec1caacc4f)
-  )
-  (wire (pts (xy 124.46 142.24) (xy 124.46 162.56))
-    (stroke (width 0) (type default))
-    (uuid 94397688-ce0e-48d4-a59c-7257120bf834)
-  )
-  (wire (pts (xy 185.42 60.96) (xy 185.42 81.28))
-    (stroke (width 0) (type default))
-    (uuid 96776fa9-dbd1-46ef-91bd-e95f23cda112)
-  )
-  (wire (pts (xy 175.26 170.18) (xy 195.58 170.18))
-    (stroke (width 0) (type default))
-    (uuid 969acf2b-33fe-4e89-abf2-451f22e884f4)
-  )
-  (wire (pts (xy 205.74 101.6) (xy 205.74 121.92))
-    (stroke (width 0) (type default))
-    (uuid 97a65ef9-5994-4805-9e12-ca2b38a42461)
-  )
-  (wire (pts (xy 33.02 251.46) (xy 53.34 251.46))
-    (stroke (width 0) (type default))
-    (uuid 9a3c8ad8-1ef2-4bd9-9b4e-28f46f2d15bb)
-  )
-  (wire (pts (xy 195.58 190.5) (xy 215.9 190.5))
-    (stroke (width 0) (type default))
-    (uuid 9be28702-7d58-41e0-b741-6f1abaea8222)
-  )
-  (wire (pts (xy 114.3 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 9c79c76c-a95b-401f-9edb-a06a0cceaa4b)
-  )
-  (wire (pts (xy 185.42 182.88) (xy 185.42 203.2))
-    (stroke (width 0) (type default))
-    (uuid 9d4fc90e-2670-42d9-b5a8-2138817fee8a)
-  )
-  (wire (pts (xy 53.34 48.26) (xy 73.66 48.26))
-    (stroke (width 0) (type default))
-    (uuid 9d5ec847-5716-4125-b40b-fdbd3a1587a7)
-  )
-  (wire (pts (xy 165.1 101.6) (xy 165.1 121.92))
-    (stroke (width 0) (type default))
-    (uuid 9f711890-a6d6-4440-8bc1-ed469cb6acc4)
-  )
-  (wire (pts (xy 83.82 182.88) (xy 83.82 203.2))
-    (stroke (width 0) (type default))
-    (uuid a0b86442-47da-481e-aac6-2c18430e056b)
-  )
-  (wire (pts (xy 93.98 101.6) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid a226d887-7662-4dbd-b58b-e683f5d85955)
-  )
-  (wire (pts (xy 114.3 231.14) (xy 134.62 231.14))
-    (stroke (width 0) (type default))
-    (uuid a2aaec3e-8eba-49bd-8096-322f6bbfda7c)
-  )
-  (wire (pts (xy 215.9 251.46) (xy 236.22 251.46))
-    (stroke (width 0) (type default))
-    (uuid a357144a-4c42-404f-a2bc-b2fa39b75cb6)
-  )
-  (wire (pts (xy 246.38 25.4) (xy 246.38 40.64))
-    (stroke (width 0) (type default))
-    (uuid a56378d0-e1be-4b80-bccf-56cd522e32fd)
-  )
-  (wire (pts (xy 124.46 40.64) (xy 124.46 60.96))
-    (stroke (width 0) (type default))
-    (uuid a67c0815-f186-4f70-926f-1b264c84d8d8)
-  )
-  (wire (pts (xy 215.9 109.22) (xy 236.22 109.22))
-    (stroke (width 0) (type default))
-    (uuid a68793c4-3c89-4b82-b021-9e6aae767eeb)
-  )
-  (wire (pts (xy 154.94 162.56) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid a803bbba-64cc-448d-a04f-7f03127ebddd)
-  )
-  (wire (pts (xy 226.06 101.6) (xy 226.06 121.92))
-    (stroke (width 0) (type default))
-    (uuid a8d4ba45-df5e-48fe-a1d7-c8d45db9b645)
-  )
-  (wire (pts (xy 175.26 251.46) (xy 195.58 251.46))
-    (stroke (width 0) (type default))
-    (uuid a9724538-37b8-4ff1-b631-6f0ee30d3df6)
-  )
-  (wire (pts (xy 53.34 149.86) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid aac914ea-c9a3-4a8f-94e1-1f91cdd136a3)
-  )
-  (wire (pts (xy 93.98 129.54) (xy 114.3 129.54))
-    (stroke (width 0) (type default))
-    (uuid ab578e4e-a4bf-4ab4-80fc-d97d4aea6370)
-  )
-  (wire (pts (xy 114.3 210.82) (xy 134.62 210.82))
-    (stroke (width 0) (type default))
-    (uuid abd1d27d-b9d9-4cf6-b486-65a2a8efef41)
-  )
-  (wire (pts (xy 175.26 88.9) (xy 195.58 88.9))
-    (stroke (width 0) (type default))
-    (uuid acc95df4-5464-4718-a58a-e43a56e1893a)
-  )
-  (wire (pts (xy 83.82 121.92) (xy 83.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73)
-  )
-  (wire (pts (xy 104.14 223.52) (xy 104.14 243.84))
-    (stroke (width 0) (type default))
-    (uuid add1312b-e7f6-4d87-b931-7c2a8ddeb1dd)
-  )
-  (wire (pts (xy 175.26 48.26) (xy 195.58 48.26))
-    (stroke (width 0) (type default))
-    (uuid adf35dfa-3831-4e3a-9fdd-7a4ac7f5230d)
-  )
-  (wire (pts (xy 93.98 68.58) (xy 114.3 68.58))
-    (stroke (width 0) (type default))
-    (uuid aea6a633-b213-403d-b447-42d91d3ab4da)
-  )
-  (wire (pts (xy 246.38 162.56) (xy 246.38 182.88))
-    (stroke (width 0) (type default))
-    (uuid b042fde0-5041-4313-8349-0fa8c4f38c49)
-  )
-  (wire (pts (xy 175.26 68.58) (xy 195.58 68.58))
-    (stroke (width 0) (type default))
-    (uuid b2797b5c-16d1-4c35-814c-4b30f0a6683b)
-  )
-  (wire (pts (xy 236.22 170.18) (xy 259.08 170.18))
-    (stroke (width 0) (type default))
-    (uuid b319eab6-824b-4699-8ec0-ab7034aad5e2)
-  )
-  (wire (pts (xy 114.3 170.18) (xy 134.62 170.18))
-    (stroke (width 0) (type default))
-    (uuid b3e14390-7dc6-416b-bbd5-cdf868192ca4)
-  )
-  (wire (pts (xy 73.66 129.54) (xy 93.98 129.54))
-    (stroke (width 0) (type default))
-    (uuid b3f6f053-44f0-4391-9873-b6231b8014db)
-  )
-  (wire (pts (xy 124.46 223.52) (xy 124.46 243.84))
-    (stroke (width 0) (type default))
-    (uuid b5f86959-3a69-4c8e-bb87-f427afde7482)
-  )
-  (wire (pts (xy 154.94 210.82) (xy 175.26 210.82))
-    (stroke (width 0) (type default))
-    (uuid b78fdc14-2c27-4eca-a54c-9e333096c8b6)
-  )
-  (wire (pts (xy 144.78 101.6) (xy 144.78 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7b2475f-30dc-4ea2-b799-96c21242154c)
-  )
-  (wire (pts (xy 175.26 210.82) (xy 195.58 210.82))
-    (stroke (width 0) (type default))
-    (uuid b7c3f0e9-4787-4050-9c72-cdbaf3e08cfe)
-  )
-  (wire (pts (xy 83.82 81.28) (xy 83.82 101.6))
-    (stroke (width 0) (type default))
-    (uuid b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5)
-  )
-  (wire (pts (xy 226.06 223.52) (xy 226.06 243.84))
-    (stroke (width 0) (type default))
-    (uuid b92dec59-82b2-4a2b-8ab2-ee9822afe59d)
-  )
-  (wire (pts (xy 266.7 170.18) (xy 266.7 190.5))
-    (stroke (width 0) (type default))
-    (uuid ba045c1c-f33c-4ee8-bfe6-db2af30446e4)
-  )
-  (wire (pts (xy 43.18 101.6) (xy 43.18 121.92))
-    (stroke (width 0) (type default))
-    (uuid bb49a3de-620b-45ad-a54c-29dcceaf0796)
-  )
-  (wire (pts (xy 195.58 251.46) (xy 215.9 251.46))
-    (stroke (width 0) (type default))
-    (uuid bd4b76ea-10fa-4f47-a569-ae3d4d93ab96)
-  )
-  (wire (pts (xy 144.78 121.92) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid bf12198a-9e62-45c3-b466-f5d86de75219)
-  )
-  (wire (pts (xy 73.66 210.82) (xy 93.98 210.82))
-    (stroke (width 0) (type default))
-    (uuid c007dc03-0700-44f8-b7e3-69868fe31a12)
-  )
-  (wire (pts (xy 205.74 60.96) (xy 205.74 81.28))
-    (stroke (width 0) (type default))
-    (uuid c0bbd51b-0041-4026-a546-37b4ba305884)
-  )
-  (wire (pts (xy 63.5 25.4) (xy 63.5 40.64))
-    (stroke (width 0) (type default))
-    (uuid c1a940de-fa49-4106-a8b9-697952eec2a2)
-  )
-  (wire (pts (xy 246.38 182.88) (xy 246.38 203.2))
-    (stroke (width 0) (type default))
-    (uuid c28b063a-d950-494b-9533-b480d5393152)
-  )
-  (wire (pts (xy 104.14 121.92) (xy 104.14 142.24))
-    (stroke (width 0) (type default))
-    (uuid c298ba49-6974-4340-859f-5d5a2b4132ff)
-  )
-  (wire (pts (xy 124.46 182.88) (xy 124.46 203.2))
-    (stroke (width 0) (type default))
-    (uuid c3555de4-415f-4041-a3dd-bd91effa102c)
-  )
-  (wire (pts (xy 236.22 243.84) (xy 246.38 243.84))
-    (stroke (width 0) (type default))
-    (uuid c3f0abaa-920a-49c5-8ee8-d7e02ba230ca)
-  )
-  (wire (pts (xy 175.26 182.88) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid c3f1f747-e966-4c2c-8090-4f190e07864a)
-  )
-  (wire (pts (xy 124.46 162.56) (xy 124.46 182.88))
-    (stroke (width 0) (type default))
-    (uuid c6080a0e-4059-4120-b2e7-12c9aff607b7)
-  )
-  (wire (pts (xy 246.38 101.6) (xy 246.38 121.92))
-    (stroke (width 0) (type default))
-    (uuid c8a7fdb7-185d-4eaf-81e7-2129f2a8c65a)
-  )
-  (wire (pts (xy 124.46 60.96) (xy 124.46 81.28))
-    (stroke (width 0) (type default))
-    (uuid c950d145-c024-47a8-ba57-97efd7bb658b)
-  )
-  (wire (pts (xy 175.26 149.86) (xy 195.58 149.86))
-    (stroke (width 0) (type default))
-    (uuid ca3290da-38da-422f-ab90-d843d9ab6e32)
-  )
-  (wire (pts (xy 144.78 142.24) (xy 144.78 162.56))
-    (stroke (width 0) (type default))
-    (uuid ca92ed7f-ae97-4c0c-81e4-820de1c001c1)
-  )
-  (wire (pts (xy 154.94 251.46) (xy 175.26 251.46))
-    (stroke (width 0) (type default))
-    (uuid cca7e5a2-d6cf-4d12-bd12-5ddc06a47c9e)
-  )
-  (wire (pts (xy 246.38 40.64) (xy 246.38 60.96))
-    (stroke (width 0) (type default))
-    (uuid cd4bb4a7-b480-4eff-a68f-b9e74cef84d3)
-  )
-  (wire (pts (xy 236.22 149.86) (xy 259.08 149.86))
-    (stroke (width 0) (type default))
-    (uuid cd7336a6-7179-450e-82ce-ab60fef82201)
-  )
-  (wire (pts (xy 266.7 109.22) (xy 266.7 129.54))
-    (stroke (width 0) (type default))
-    (uuid cdde081d-7bdd-42e6-869e-3ff07b8b464b)
-  )
-  (wire (pts (xy 185.42 121.92) (xy 185.42 142.24))
-    (stroke (width 0) (type default))
-    (uuid cee2f4f4-6cbc-4838-b71a-3189173bbcfe)
-  )
-  (wire (pts (xy 83.82 40.64) (xy 83.82 60.96))
-    (stroke (width 0) (type default))
-    (uuid cff15ec3-f29c-4d36-8776-64c5d29be534)
-  )
-  (wire (pts (xy 83.82 25.4) (xy 83.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid d1088709-a9b9-4e05-8ea2-f87942ee2796)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 93.98 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1347903-ae03-46a2-a707-154093060583)
-  )
-  (wire (pts (xy 195.58 231.14) (xy 215.9 231.14))
-    (stroke (width 0) (type default))
-    (uuid d212462e-72b0-4fc0-81a2-e9aa2cbc9694)
-  )
-  (wire (pts (xy 144.78 40.64) (xy 144.78 60.96))
-    (stroke (width 0) (type default))
-    (uuid d2183fb3-afd3-46ca-955e-993ea31aa5d3)
-  )
-  (wire (pts (xy 185.42 25.4) (xy 185.42 40.64))
-    (stroke (width 0) (type default))
-    (uuid d2951d7e-82c5-4b56-9a90-ca8ae6d71e44)
-  )
-  (wire (pts (xy 205.74 25.4) (xy 205.74 40.64))
-    (stroke (width 0) (type default))
-    (uuid d4107bae-81df-4028-a211-ea4ab3232bfc)
-  )
-  (wire (pts (xy 226.06 142.24) (xy 226.06 162.56))
-    (stroke (width 0) (type default))
-    (uuid d4fda796-f5de-4013-bf1e-6a92a02b00f9)
-  )
-  (wire (pts (xy 43.18 162.56) (xy 43.18 182.88))
-    (stroke (width 0) (type default))
-    (uuid d56982aa-6580-4d04-83ea-6bf3a85282cc)
-  )
-  (wire (pts (xy 185.42 101.6) (xy 185.42 121.92))
-    (stroke (width 0) (type default))
-    (uuid d675b927-bdff-4eac-82e7-3f468caedaf2)
-  )
-  (wire (pts (xy 43.18 142.24) (xy 43.18 162.56))
-    (stroke (width 0) (type default))
-    (uuid d76ad758-0ae0-4ce6-9f67-c689c066c744)
-  )
-  (wire (pts (xy 144.78 182.88) (xy 144.78 203.2))
-    (stroke (width 0) (type default))
-    (uuid d8747c5c-1650-4a8e-b6a0-4fa4acd098ae)
-  )
-  (wire (pts (xy 205.74 81.28) (xy 205.74 101.6))
-    (stroke (width 0) (type default))
-    (uuid d920ca82-8ad7-4105-a47d-6c01f55c13d9)
-  )
-  (wire (pts (xy 83.82 223.52) (xy 83.82 243.84))
-    (stroke (width 0) (type default))
-    (uuid d952f794-a9ef-400a-b190-92d1381a7bd5)
-  )
-  (wire (pts (xy 33.02 149.86) (xy 53.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid da80b027-904b-4ca2-99c6-5937c80c825c)
-  )
-  (wire (pts (xy 63.5 142.24) (xy 63.5 162.56))
-    (stroke (width 0) (type default))
-    (uuid db492971-48ff-4667-996c-f5d540a20741)
-  )
-  (wire (pts (xy 205.74 121.92) (xy 205.74 142.24))
-    (stroke (width 0) (type default))
-    (uuid dc91af22-52c4-4234-961f-adc3ed363a9c)
-  )
-  (wire (pts (xy 165.1 142.24) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid dccfde3a-ff1d-42ec-97d5-a8f6cccea832)
-  )
-  (wire (pts (xy 33.02 170.18) (xy 53.34 170.18))
-    (stroke (width 0) (type default))
-    (uuid de8e54c6-84d9-47e5-8f08-dc3e96b8afdb)
-  )
-  (wire (pts (xy 43.18 81.28) (xy 43.18 101.6))
-    (stroke (width 0) (type default))
-    (uuid df5c3763-e66c-46c4-9070-0f73d8115bc4)
-  )
-  (wire (pts (xy 266.7 129.54) (xy 266.7 149.86))
-    (stroke (width 0) (type default))
-    (uuid dfb5a082-e4d5-46ea-8dc8-c65064cd598b)
-  )
-  (wire (pts (xy 226.06 203.2) (xy 226.06 223.52))
-    (stroke (width 0) (type default))
-    (uuid e006a777-74b0-4f5f-bb4c-3ab7b31924c0)
-  )
-  (wire (pts (xy 93.98 170.18) (xy 114.3 170.18))
-    (stroke (width 0) (type default))
-    (uuid e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb)
-  )
-  (wire (pts (xy 144.78 81.28) (xy 144.78 101.6))
-    (stroke (width 0) (type default))
-    (uuid e444742a-24b1-4bbf-b7ee-438e6dffc9cc)
-  )
-  (wire (pts (xy 175.26 190.5) (xy 195.58 190.5))
-    (stroke (width 0) (type default))
-    (uuid e5e38d44-8bf0-426b-a99f-727527ca9657)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid e6d06035-ccb7-4d3e-ae70-d73150e65bbb)
-  )
-  (wire (pts (xy 215.9 231.14) (xy 236.22 231.14))
-    (stroke (width 0) (type default))
-    (uuid e75ebd5e-5f93-4d1a-a8cb-e4f158ba626b)
-  )
-  (wire (pts (xy 236.22 190.5) (xy 259.08 190.5))
-    (stroke (width 0) (type default))
-    (uuid e7dd0479-d978-4c9d-ac31-40cf0582e439)
-  )
-  (wire (pts (xy 53.34 251.46) (xy 73.66 251.46))
-    (stroke (width 0) (type default))
-    (uuid e91e3b45-5a4a-4cad-8f6d-8da054a1776d)
-  )
-  (wire (pts (xy 114.3 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa)
-  )
-  (wire (pts (xy 246.38 243.84) (xy 246.38 223.52))
-    (stroke (width 0) (type default))
-    (uuid ea05e2af-fd29-4a7e-aa30-c8e742f8574e)
-  )
-  (wire (pts (xy 195.58 149.86) (xy 215.9 149.86))
-    (stroke (width 0) (type default))
-    (uuid ea36985b-5a45-46a7-be39-a5ceee9dc964)
-  )
-  (wire (pts (xy 63.5 101.6) (xy 63.5 121.92))
-    (stroke (width 0) (type default))
-    (uuid edeeb0d9-51cc-411d-aac4-77f10b619702)
-  )
-  (wire (pts (xy 43.18 203.2) (xy 43.18 223.52))
-    (stroke (width 0) (type default))
-    (uuid ee312ce0-2ae6-4337-8d15-666961b7d179)
-  )
-  (wire (pts (xy 154.94 170.18) (xy 175.26 170.18))
-    (stroke (width 0) (type default))
-    (uuid ee36c21a-970c-453e-93f8-ab4961c20f44)
-  )
-  (wire (pts (xy 104.14 40.64) (xy 104.14 60.96))
-    (stroke (width 0) (type default))
-    (uuid ef5c9f05-d71b-4562-9939-852432c066c5)
-  )
-  (wire (pts (xy 144.78 162.56) (xy 144.78 182.88))
-    (stroke (width 0) (type default))
-    (uuid efa47227-d3f9-4214-af64-a7e9107c0edb)
-  )
-  (wire (pts (xy 144.78 203.2) (xy 144.78 223.52))
-    (stroke (width 0) (type default))
-    (uuid f09677ca-cfdb-4119-9431-13dd6580ce71)
-  )
-  (wire (pts (xy 144.78 60.96) (xy 144.78 81.28))
-    (stroke (width 0) (type default))
-    (uuid f0ce7c2b-d80c-49f2-bf63-62b750f7ca47)
-  )
-  (wire (pts (xy 236.22 109.22) (xy 259.08 109.22))
-    (stroke (width 0) (type default))
-    (uuid f275e971-a5b1-41ee-ac80-764aa694f4e1)
-  )
-  (wire (pts (xy 73.66 231.14) (xy 93.98 231.14))
-    (stroke (width 0) (type default))
-    (uuid f2cc3c58-efff-41fa-a09a-222ad0afe609)
-  )
-  (wire (pts (xy 63.5 162.56) (xy 63.5 182.88))
-    (stroke (width 0) (type default))
-    (uuid f5658dea-a5b6-4ba9-9360-11c3315c15be)
-  )
-  (wire (pts (xy 134.62 142.24) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid f781a362-e0d4-48be-9d13-5686e05b406f)
-  )
-  (wire (pts (xy 246.38 81.28) (xy 246.38 101.6))
-    (stroke (width 0) (type default))
-    (uuid f88e1e07-ac9e-4cbd-a0af-8963c31f296c)
-  )
-  (wire (pts (xy 33.02 231.14) (xy 53.34 231.14))
-    (stroke (width 0) (type default))
-    (uuid f8f8e54e-33a9-4d2a-b35e-9b373b3563c7)
-  )
-  (wire (pts (xy 175.26 129.54) (xy 195.58 129.54))
-    (stroke (width 0) (type default))
-    (uuid f940918e-7aa4-499c-8be1-c536835b2ed6)
-  )
-  (wire (pts (xy 215.9 68.58) (xy 236.22 68.58))
-    (stroke (width 0) (type default))
-    (uuid f9bf6b2c-c726-44fd-afa9-844550de8af2)
-  )
-  (wire (pts (xy 226.06 40.64) (xy 226.06 60.96))
-    (stroke (width 0) (type default))
-    (uuid fa54e42a-1d6a-433e-bb23-df8ec8cd3dca)
-  )
-  (wire (pts (xy 43.18 25.4) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid fa765e67-a220-4a00-944c-7663298f0ead)
-  )
-  (wire (pts (xy 83.82 142.24) (xy 83.82 162.56))
-    (stroke (width 0) (type default))
-    (uuid fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b)
-  )
-  (wire (pts (xy 185.42 81.28) (xy 185.42 101.6))
-    (stroke (width 0) (type default))
-    (uuid ffe6085a-a7be-4653-b911-c10de4574454)
-  )
-
-  (global_label "IO 3" (shape bidirectional) (at 104.14 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 24ec698b-5cae-4571-b9c4-c0e35d64a64d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 104.14 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 1" (shape bidirectional) (at 63.5 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2d4b15a5-8b6c-4ca3-a7bb-7848c8036590)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 63.5 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 9" (shape bidirectional) (at 226.06 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 388f2ae3-3697-4b0d-bb82-8cc7f8e58abf)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 226.06 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 7" (shape bidirectional) (at 185.42 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 45d4e03e-6cff-41ce-b946-708382da0601)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 185.42 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 0" (shape bidirectional) (at 43.18 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 465a517d-f0e1-4825-8675-1cce54bfa7a5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 43.18 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "INTR" (shape bidirectional) (at 266.7 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4e12b932-2346-4e84-b5a4-80468334f3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 274.89 25.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "IO 10" (shape bidirectional) (at 246.38 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 5fc8da19-2489-4964-a31f-4b81b27f0926)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 246.38 16.061 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 2" (shape bidirectional) (at 83.82 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 70d42e66-a74c-4de2-af96-d1860851d3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 83.82 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 165.1 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 89461221-a936-49a3-bf5d-18ec120f3e0c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 165.1 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 144.78 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d44cceb0-f409-4e5f-a98a-9feead2e845d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 8" (shape bidirectional) (at 205.74 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid e036ec60-274a-4de6-9324-dafd5b920142)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 205.74 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 4" (shape bidirectional) (at 124.46 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f36f49e4-227f-479f-b914-786aa44dd568)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 124.46 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 251.46 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 00fc2774-1e85-42dc-993a-cdcdc9df2e68)
-    (property "Reference" "DI10" (at 262.89 247.65 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 254 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 251.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 251.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 251.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 251.46 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ad12a4a2-a558-4a9d-83b2-f1e4f7bf7638))
-    (pin "2" (uuid ab764813-e248-4da7-9ff1-1f698a422085))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 190.5 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0188dba3-054f-4958-9440-27c9ca673633)
-    (property "Reference" "DI7" (at 262.89 186.69 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 193.04 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid deea1889-824f-4f7a-a6be-9546db353c85))
-    (pin "2" (uuid 2080be86-a538-40a8-8f30-ead2a96d02d3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0263b847-a932-4a31-9f35-35bb23f7000d)
-    (property "Reference" "D62" (at 152.4 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc2e60ca-c74f-4e4b-a0a0-9705327e9578))
-    (pin "2" (uuid d12efbfe-85ac-442f-8c0f-ddbe5646c7d5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D62") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 64.77 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 04430572-8314-4d21-974c-22350cead1a6)
-    (property "Reference" "DS1" (at 55.88 65.405 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 55.88 62.865 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e433df4-9fec-4cfb-b60f-eebca7c574cf))
-    (pin "2" (uuid 9bcc1487-0612-4bdb-a2de-a8b2f590b28f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080a5952-914c-46a1-ba80-7cc09f9efbdf)
-    (property "Reference" "D114" (at 111.76 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cd20c400-0339-492e-b713-e3ef1c01763f))
-    (pin "2" (uuid 19944e75-22c9-4237-a2b2-cdf3ae3d739b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D114") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 44.45 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080aaa87-0974-4a77-bf63-185495f411a0)
-    (property "Reference" "DS0" (at 35.56 45.085 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 35.56 42.545 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bfacad1-28fd-4f2e-93dc-68f478b8a6ba))
-    (pin "2" (uuid 376f73f9-79fa-4153-ae38-31ed5446db52))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09606075-7d6f-4679-9228-3a303ca4f40c)
-    (property "Reference" "RC9-1" (at 220.98 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f5b128f-eb55-44dc-974a-3ac8a1869c2d))
-    (pin "2" (uuid 9783c397-46c8-4a54-ad23-28d37f071b25))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09d14922-c46a-4bf1-bb2c-1d224060568c)
-    (property "Reference" "D40" (at 111.76 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2f1a1d2-df3d-4680-9706-2ca411fa6890))
-    (pin "2" (uuid f58fd788-6016-46e7-b903-3606dd2ec21d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D40") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 149.86 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0d18473f-e37a-4136-b721-5a2e40e4f8ed)
-    (property "Reference" "DI5" (at 262.89 146.05 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 152.4 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d5a885ca-5076-44e6-9a84-d07474947dde))
-    (pin "2" (uuid 047b5b54-de8b-4afc-abc2-c6d1f2d17bd2))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 170.18 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0ef17723-f7f8-4fdb-8913-5a4ceefbc065)
-    (property "Reference" "DI6" (at 262.89 166.37 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 172.72 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df5a6b10-ba48-4f34-96ce-3832d480a7ee))
-    (pin "2" (uuid 59f34a55-6ac4-496d-8c40-1b8f1eafbcb5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0f5e4226-91a2-4a41-9aae-518534f05932)
-    (property "Reference" "RC7-9" (at 180.34 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e144b30-8fd2-4ccc-b8e5-b1ca3fb409ba))
-    (pin "2" (uuid 0e4a0bb0-3e0e-44e1-9c80-03f9a9aa8952))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0fadd319-be81-4c25-8d23-e7495a114aa7)
-    (property "Reference" "RC4-0" (at 119.38 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid efb1c47f-fe25-4bea-8081-43d3c19de5cd))
-    (pin "2" (uuid 9138c970-6e3d-46df-9354-5174df2a4e52))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ff76361-9578-4f9f-a20c-f042e24a7755)
-    (property "Reference" "D5" (at 30.48 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06))
-    (pin "2" (uuid cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 11f01cd8-f751-497f-9599-50fe1fc0a618)
-    (property "Reference" "RC5-4" (at 139.7 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc28293-fab9-4f93-b3d5-ca9ee69110c4))
-    (pin "2" (uuid 088ac770-af1e-4c4f-ad11-5b44a20594d8))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 13ddd48d-7d2b-415d-b8fa-15c71e245acc)
-    (property "Reference" "D61" (at 152.4 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 745d89b9-e75a-40ae-97bc-d1eadf220f02))
-    (pin "2" (uuid 7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D61") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1597bfb0-dabd-48b6-a2ca-f9171da312d5)
-    (property "Reference" "RC10-3" (at 241.3 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 22a87d66-e5d9-4630-bb65-e557654257a9))
-    (pin "2" (uuid 586aafd1-f8f9-4fea-8263-558415220f6f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 17d027e3-2b58-470b-9fc5-f21e547cdc82)
-    (property "Reference" "RC8-1" (at 200.66 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7f893b29-9b1f-44b8-bac5-e11991e6b604))
-    (pin "2" (uuid 6b5e04e4-6889-4e49-9600-35d15ee54578))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 19f0de4f-d7ab-4f51-9796-79808aba650f)
-    (property "Reference" "D97" (at 213.36 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ad12892f-d26f-4434-82fd-3de2937c1d41))
-    (pin "2" (uuid 8b061bcb-2b37-4d89-bd19-fcd574e79f03))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D97") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1a21ce9e-a70d-4048-80c2-b67a7c165b7f)
-    (property "Reference" "D117" (at 172.72 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1f6173a6-5b9d-47d1-8fc5-4539bbfab6f3))
-    (pin "2" (uuid c72e39dc-ef93-42be-afff-91188bea0ab7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D117") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1b13866a-6fbf-441b-9c64-56258379f43a)
-    (property "Reference" "D65" (at 152.4 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c70f4670-9685-4aab-ac4f-4ebaf44d5847))
-    (pin "2" (uuid 8b9c860d-59e1-424e-a148-1aa2c0db4056))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D65") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a)
-    (property "Reference" "RC6-4" (at 160.02 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3427b432-e194-40af-9dcb-04dccafe2b0f))
-    (pin "2" (uuid 8af48a1b-2c49-47d9-959c-ee33cdd6f977))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d4decb6-e690-4f06-b8aa-6dd29b7f2622)
-    (property "Reference" "D58" (at 132.08 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0a89d11-f9ed-4dad-a764-70b931421ce9))
-    (pin "2" (uuid e072fab0-4e83-437a-8387-943f8bcc1213))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D58") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1e5f084d-4db5-48ad-a2a3-76f186559614)
-    (property "Reference" "RC3-1" (at 99.06 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa))
-    (pin "2" (uuid 40b7f115-b5d7-4fa0-b12b-c1c7b6866feb))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 210.82 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 210fa303-e6c4-43b3-8ff0-f2f9178c950d)
-    (property "Reference" "DI8" (at 262.89 207.01 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 213.36 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 210.82 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cad82d1c-a62b-40c6-a2ae-61d28ed2d913))
-    (pin "2" (uuid ca0c8c70-cbfc-4421-833b-b58ab5f50511))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 213aaf81-8580-4880-9130-4c9d596a7095)
-    (property "Reference" "D90" (at 213.36 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 441dc052-fc8b-4f81-9c35-f08ea1ca4cf5))
-    (pin "2" (uuid b7690702-7874-4b26-89ba-a175fce3360b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D90") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 213dd8be-31f7-488d-b5dc-6770d78fccd5)
-    (property "Reference" "RC9-6" (at 220.98 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 593996ed-485e-495f-9d29-6951be77f078))
-    (pin "2" (uuid fa5ec1f4-4786-4d7c-9bb1-ab1ce7ad3038))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 22a72d93-d5b5-4a6b-95f6-755ac10ccf50)
-    (property "Reference" "RC4-7" (at 119.38 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 18c97ab1-62df-42bc-9dfa-dba3415ee8e2))
-    (pin "2" (uuid ff0eb9a3-538a-4ebf-a42b-97fe870ddfea))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 244b7f9d-3923-4908-be6d-02c49eb4663c)
-    (property "Reference" "RC2-3" (at 78.74 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d79440a-2f90-4c0b-8d60-528615b0bd65))
-    (pin "2" (uuid 7f1d0566-f385-4126-b190-2379308ed05b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 166.37 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2518146c-59f4-45b7-a4fa-f618686ab064)
-    (property "Reference" "DS6" (at 157.48 167.005 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 157.48 164.465 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cee2f461-8f62-48d8-ac7b-1698deb984c1))
-    (pin "2" (uuid 460b9088-619c-4166-a615-45e17ecf1f0d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2519cd5e-8ecf-41a4-a9d0-5b856882cb05)
-    (property "Reference" "D63" (at 152.4 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ea1c9827-ebfa-43f1-b2c6-5a572466713e))
-    (pin "2" (uuid 0496ba9c-818c-4d39-979a-e8785e06d12a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D63") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 270e65d5-141a-497e-af55-d32d80c01617)
-    (property "Reference" "D118" (at 193.04 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fce64b77-c994-40f7-be6f-e1d7fe43ea57))
-    (pin "2" (uuid 9567d8aa-8f12-417f-8460-1af89c257716))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D118") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 28137b00-0d76-493b-92b8-23037474163f)
-    (property "Reference" "RC1-3" (at 58.42 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3))
-    (pin "2" (uuid 41d35b0f-21b5-4da8-92df-229c816b63c5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2a208574-f638-4917-a68f-bc3ff176d324)
-    (property "Reference" "D75" (at 172.72 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 503e8179-7a4a-4075-8fcf-2d7bb00a3908))
-    (pin "2" (uuid a744b0f2-49c4-46a7-9ec2-cefb21173879))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D75") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c50947a-4bb9-43c2-b65c-4726e224b6b0)
-    (property "Reference" "RC3-0" (at 99.06 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b))
-    (pin "2" (uuid 30241adf-a2e7-4976-a53a-5c267616618e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c9d0815-f6d3-49dd-89d8-cea98629f461)
-    (property "Reference" "D104" (at 233.68 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d4aa1a8c-5efd-48af-8e22-4c35fa0cdce0))
-    (pin "2" (uuid 64108911-fd65-4f0f-b0f7-cf192f04f6e7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D104") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2cd8f716-5a6b-4cee-ad2e-612d075ffebf)
-    (property "Reference" "RC5-9" (at 139.7 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f37bc637-a5fa-420e-ae7d-11681e40308a))
-    (pin "2" (uuid 97b6ff47-ae10-45e9-81f0-a4902039b249))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2e38accc-5291-44a5-82e8-9bec928b99c0)
-    (property "Reference" "D18" (at 50.8 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20ca8cf6-b241-4581-b5e1-dadf97a2cf3f))
-    (pin "2" (uuid dc0b457e-4296-4b82-a953-b255f1e09c5c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D18") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2f872c45-59ae-4f02-abee-114e38b97a80)
-    (property "Reference" "D87" (at 193.04 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4139db20-9977-4a84-b30c-e04c47ec888a))
-    (pin "2" (uuid bdc078b6-22f8-427e-a1f3-872c3722a746))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D87") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30340eba-9ed0-42ff-b11f-98a864f7223e)
-    (property "Reference" "RC1-4" (at 58.42 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aa956a67-c26e-4a57-9ddb-59688a6476ad))
-    (pin "2" (uuid 23cd0d93-5050-40ea-9d49-879bbcbb8bcd))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30b60f6a-8d20-44dd-b832-1906a957c513)
-    (property "Reference" "D54" (at 132.08 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c2ad1a4-b254-49a0-8435-d3a374353ffc))
-    (pin "2" (uuid 27a3cb64-baf1-430a-b797-bd52c0e46cbe))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D54") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30f8682e-9109-46d6-80ea-6dedfc8c0eee)
-    (property "Reference" "RC10-7" (at 241.3 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f5e4ae69-f050-4591-8a39-3444621f4976))
-    (pin "2" (uuid 78cf5cbb-b4aa-487d-9661-5dfbf52cb0b3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 310fec10-f10c-41d7-9446-87c12744e146)
-    (property "Reference" "D26" (at 71.12 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e1d524d3-5d24-4c87-b480-74c57a74b567))
-    (pin "2" (uuid c0e9aa05-6318-4fdc-abee-cb43875c8e46))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D26") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 32c1c5fd-b6bc-4aba-a718-d9540ec4db69)
-    (property "Reference" "RC10-2" (at 241.3 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 69777a23-120f-4e97-b9ca-87ed1b3e6281))
-    (pin "2" (uuid e1c89d23-810f-47c0-98bb-c34f6ce30f0b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3508f6d2-8867-4535-a2fe-dcbb1c7737b5)
-    (property "Reference" "D110" (at 30.48 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3805bb07-9b77-48c1-b03a-f2ba837fb125))
-    (pin "2" (uuid e658e927-e073-4667-83d5-95a0ad1b7643))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D110") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35827986-7004-4f70-a10a-6ceb42f33d9f)
-    (property "Reference" "RC1-2" (at 58.42 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 879d3b07-b41e-4233-b196-e223f635bdf3))
-    (pin "2" (uuid 641f8ea7-6306-4550-92c8-e3cc0ed3e5a5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3598234f-e6ed-4eb6-b25a-52bde6e19729)
-    (property "Reference" "D82" (at 193.04 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f8d7980-fcb9-49ec-8704-044fa4175b07))
-    (pin "2" (uuid e2992df7-1f75-4c2b-bd16-ce868f4adf82))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D82") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35c1fb5b-1af9-421e-8d64-2023ee2a5f4d)
-    (property "Reference" "RC9-10" (at 220.98 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c26958a6-21d1-4ac5-9a1c-1b25108edf8e))
-    (pin "2" (uuid c3db45c0-8e01-4eab-a638-8ba75be1666f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 369ff51e-db51-4132-aa26-7b5d981cba74)
-    (property "Reference" "D17" (at 50.8 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9b5adb2f-c180-494e-86cd-ef0a68591be2))
-    (pin "2" (uuid 24774a87-3207-4ab9-a94d-2b9e1b568e65))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D17") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 37da2014-affc-4731-b642-c4245ff411f2)
-    (property "Reference" "RC5-7" (at 139.7 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ac410347-ba8b-493b-832e-a3f9e3359951))
-    (pin "2" (uuid 4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3811148a-f93d-405c-9479-c81e5555fcd8)
-    (property "Reference" "RC7-7" (at 180.34 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f8a4ff2-ec9f-4d19-88f7-72ef280fb836))
-    (pin "2" (uuid ea1c4b45-e89f-41d8-a596-654ae6328f49))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976)
-    (property "Reference" "D43" (at 111.76 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7d6fb6c4-b36c-4ff1-879b-43826c273a72))
-    (pin "2" (uuid 198c65f6-b3df-4780-9f6d-1c910e870a1b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D43") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3a9b19be-43ef-409c-9489-c069efbfa3ee)
-    (property "Reference" "RC0-7" (at 38.1 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 898cdd62-8ad6-4d58-b6f7-f4db79a4cca2))
-    (pin "2" (uuid 277b2226-c100-403c-a519-ef9cdc3923fe))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ac53e86-aa26-4394-9e99-e33f3c863b14)
-    (property "Reference" "RC7-1" (at 180.34 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e6efb38c-f391-43d6-9511-8c7da50b3d51))
-    (pin "2" (uuid 03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ad37b9b-353e-40fc-ac40-f5195f3dc605)
-    (property "Reference" "RC1-8" (at 58.42 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3efa7b0a-a125-48e1-96a0-b756f7dea902))
-    (pin "2" (uuid e99d0060-9d73-4fee-8521-d18593d0656b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef0222e-2eac-4930-ac36-0f395f4593b6)
-    (property "Reference" "RC1-0" (at 58.42 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f0b9b8-9322-4d89-a423-dd3d807d99ff))
-    (pin "2" (uuid ce54609e-9d1d-4a3b-81a2-5a384dbe41c8))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef86e49-a152-4515-afb0-4098f497c742)
-    (property "Reference" "D31" (at 91.44 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a))
-    (pin "2" (uuid b917ad78-96a8-428f-ad4f-d49149b5b97b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D31") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 402f0f46-5eb8-421b-9b9f-01a54b5cfa87)
-    (property "Reference" "RC4-1" (at 119.38 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cb206c0-1fab-4ac5-b301-f9678369525b))
-    (pin "2" (uuid b99c2ecc-04a5-4c54-a491-d99fe2562dcc))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 40d8058d-714e-4f99-a508-f64f9c8b575b)
-    (property "Reference" "D60" (at 152.4 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 66710233-d2ab-4921-aa86-488ee87fbb3a))
-    (pin "2" (uuid a9636da9-222c-478f-bc5b-71d3f0473300))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D60") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 411a5386-edd0-4032-883d-ba445f257b99)
-    (property "Reference" "D93" (at 213.36 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 21f0660e-6a0c-4492-a9e5-01821c71a5fe))
-    (pin "2" (uuid 096c2860-22cd-4d22-bbb5-2c4452c158a3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D93") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 430b936d-b8ad-4c28-b93d-4046aec980c7)
-    (property "Reference" "D67" (at 152.4 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9255475-7a77-44cc-9bd9-589d63ced82b))
-    (pin "2" (uuid 9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D67") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 433f3f09-0867-41a3-8ac6-5f00bd3314fc)
-    (property "Reference" "D32" (at 91.44 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 11a29637-fd50-4473-bb70-d4116312a4f5))
-    (pin "2" (uuid 53f6307d-8380-45e9-b3fa-4d05a2bd575d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44499808-710f-44ae-bed2-0632db78b8c8)
-    (property "Reference" "D71" (at 172.72 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8805b31-9770-4092-b10a-101cf112fd76))
-    (pin "2" (uuid 9f3056b1-b197-421f-9d54-08cf5cc88970))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D71") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4461a601-2e4b-4cf8-8094-5e4d8e990676)
-    (property "Reference" "RC5-8" (at 139.7 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f54d1c0f-d68b-4769-9ef7-ac6475687d30))
-    (pin "2" (uuid 49768dd5-fbea-4db4-9154-60b22afd8a29))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44de9323-bd5d-49cd-bf0a-70392801309d)
-    (property "Reference" "D45" (at 111.76 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb2b185b-5d98-46b8-8516-9e5c980291cf))
-    (pin "2" (uuid f730da3b-5ef9-4abc-8c8d-0794fe3feb87))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D45") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 454ad926-1c6a-4aa4-b6f8-25297463de18)
-    (property "Reference" "RC3-2" (at 99.06 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f0aebfce-7e76-40f1-83ef-5914b8ebbcc7))
-    (pin "2" (uuid 744fce2b-a15c-45a6-92b0-e880efafb5f6))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 247.65 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 459f552c-e7ba-420b-a932-a01ab9ea9597)
-    (property "Reference" "DS10" (at 238.76 248.285 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 238.76 245.745 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6319e419-e05e-49bb-bac5-81d105e9b55a))
-    (pin "2" (uuid 6024f692-10e3-4e3a-9d57-759288b90eca))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 48.26 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46348ccc-126c-461a-8e39-f93f389ddaa7)
-    (property "Reference" "DI0" (at 262.89 44.45 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 50.8 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c86bf5fa-c113-44c1-b93d-7a5d4ac11904))
-    (pin "2" (uuid dbd8322f-50c7-4271-821c-b0005fd066b2))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4a7f7b3d-918b-431a-b79d-c66494b3ec50)
-    (property "Reference" "D52" (at 132.08 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd114d76-87b2-4089-b211-b7b541ac42b3))
-    (pin "2" (uuid a360aa38-116c-4dd0-a569-f6a7a5a88a05))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D52") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4d978207-10b9-4a43-a474-2e66421925a0)
-    (property "Reference" "D64" (at 152.4 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 27529674-e97c-460d-9de8-89cd61c8a6eb))
-    (pin "2" (uuid 57e77ee6-e62d-402e-a614-a833da3fbafb))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D64") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4e9036c3-3848-485b-8b45-7e377c05efba)
-    (property "Reference" "D86" (at 193.04 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cebd91c6-213c-407e-8871-b40d23e32e3c))
-    (pin "2" (uuid 209631a2-8c98-4e88-8a48-286a9aadd110))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D86") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 50dfbd73-3671-493b-8466-ba295a53891e)
-    (property "Reference" "D69" (at 152.4 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12473813-984c-45f7-a1ec-6b60de9f4230))
-    (pin "2" (uuid ef3a08d5-f80f-45b3-9407-fe76d147d1fb))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D69") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 50e4b379-7602-45c8-aa05-dfc9b3f70f58)
-    (property "Reference" "RC9-2" (at 220.98 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6d506f53-ffcf-4d12-ae8f-d5b7539fbeba))
-    (pin "2" (uuid 3324ce76-0743-47e2-af09-b4daae2fb475))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5466fd2d-f22f-409b-b7da-f8d297aeb7a2)
-    (property "Reference" "RC6-5" (at 160.02 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffdd8419-9afa-4f38-bfbf-7dc4e869b438))
-    (pin "2" (uuid 0db27643-51f5-4634-a791-2c4813885195))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5518d7f7-6de1-409b-a6d0-90efa78c0b82)
-    (property "Reference" "D7" (at 30.48 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9bdf2265-17dd-4712-9f75-996577068823))
-    (pin "2" (uuid cd2654f9-f2c1-4ff7-bbce-8fe664862762))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 553a576d-44a1-4bad-9211-394526206f63)
-    (property "Reference" "D41" (at 111.76 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4a035e61-91c9-41ba-9328-bc9b284e86c2))
-    (pin "2" (uuid 8628539f-d3cd-4957-a6bb-5c605649e715))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D41") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55c4f5cb-c530-414c-92f5-fbf9e58a8885)
-    (property "Reference" "D37" (at 91.44 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64d90630-a755-4eae-b416-80d8ff93fde4))
-    (pin "2" (uuid 77e4ef56-5ac3-4295-aacb-04ae680de9b7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D37") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55dc1959-7c17-496b-b079-56725e7400ff)
-    (property "Reference" "RC7-6" (at 180.34 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d91f51f-9558-44e7-9b69-c9ba25dbac1f))
-    (pin "2" (uuid f7ee2403-2740-4116-96fa-c5f3c0c9f293))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 563bf078-cf50-4f0f-84d6-a83a0feddd45)
-    (property "Reference" "D70" (at 172.72 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 91318668-36ae-48a7-a13c-18d4c2f08036))
-    (pin "2" (uuid 29b99e4d-eeeb-4f18-b49f-b44a360c9eac))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D70") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 207.01 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5642ac65-20dd-447b-a5a3-1b21218d5bac)
-    (property "Reference" "DS8" (at 198.12 207.645 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 198.12 205.105 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6d406bb4-8771-4842-b48d-4d5e1f3de0cf))
-    (pin "2" (uuid bcdb56a4-4458-438f-b33a-abdcc29a1ebf))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 568f737d-6752-4b16-be92-273eb7ac8c9d)
-    (property "Reference" "D98" (at 213.36 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 96fa163e-1e2c-4d82-ada6-6b53530a015e))
-    (pin "2" (uuid eef2dd73-ade2-4fd8-a1e4-1b0837b59db5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D98") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 68.58 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5692cd7d-67c7-4fe7-8b4d-c8bc86968b31)
-    (property "Reference" "DI1" (at 262.89 64.77 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9abe1fc5-b3c1-424f-8519-d12916c57a11))
-    (pin "2" (uuid 168b1203-c5fc-4b69-b8e5-94d0bdc27e41))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 57e7516d-643d-4cd1-9646-d8696e387a16)
-    (property "Reference" "D38" (at 91.44 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c0d30413-2127-456f-a30c-24a92d981ac9))
-    (pin "2" (uuid a92161f1-81a1-4199-93bf-ab8287ab6d27))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D38") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5924da97-d274-4fb5-b277-06f309e62438)
-    (property "Reference" "D79" (at 172.72 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eb3328cf-70d1-402a-9b12-5297b037e47d))
-    (pin "2" (uuid 44a70a68-2fd3-413e-8aa0-d6527cb0cab5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D79") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59263e5e-1eeb-458b-9b02-ca162d4a65d7)
-    (property "Reference" "D21" (at 71.12 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2372f523-257f-414c-92f4-8d433cfbee15))
-    (pin "2" (uuid 21891727-1d09-4cab-bd90-75c57b141f7c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D21") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 593e930a-15e9-4d16-a6ed-7df7f9d1e843)
-    (property "Reference" "RC10-6" (at 241.3 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 56a5df9f-e166-423f-b625-6488b2d49a99))
-    (pin "2" (uuid 3319214e-0ac1-4b68-9da8-94a53c1267f8))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59fdee43-9b65-471d-9ea8-5dc40dc65f6e)
-    (property "Reference" "D35" (at 91.44 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5834d436-0e26-481b-a20d-40fa6346502e))
-    (pin "2" (uuid 59af1ddc-701f-49c0-b6cd-778072695c5c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D35") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5aeb247f-6f79-4df2-b767-9ca89069182c)
-    (property "Reference" "D56" (at 132.08 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d46c0cdd-d9c1-44c1-ba6c-034fc547ff01))
-    (pin "2" (uuid 53f3e198-3ef2-40c4-a8f7-298435eddd0b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D56") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5c60f960-fb0a-46f6-9aff-5d8144586231)
-    (property "Reference" "RC4-6" (at 119.38 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 990f1ee1-d6da-4ae8-809a-1911d8099a4c))
-    (pin "2" (uuid a8276c00-b61f-4db4-8f4f-e51e512de654))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5f21a75c-b9ee-47bf-adcf-39a03e42660f)
-    (property "Reference" "D15" (at 50.8 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1))
-    (pin "2" (uuid 7a8a84c2-38d2-473b-955d-81dd816a398e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D15") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5fa8cce4-fbbf-4784-a459-71364b77e1a7)
-    (property "Reference" "RC0-2" (at 38.1 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cb7750fa-a378-43a3-a1c6-638c32a1c79e))
-    (pin "2" (uuid 67dfe958-6bd5-4618-98a3-d513db4ad5c0))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5ff7733c-a36f-4b29-a8e7-bdf79fabdf72)
-    (property "Reference" "D4" (at 30.48 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ed6062e9-f00a-474a-840f-39685bd66d70))
-    (pin "2" (uuid c0e85db4-b88d-4383-8de6-9f7370be62a6))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61b2e3fc-583b-407b-beff-dd8441f2f403)
-    (property "Reference" "RC2-6" (at 78.74 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 752f308d-4723-4468-9745-81de18307ba3))
-    (pin "2" (uuid 3267c09c-2818-42d7-96a9-6aaa2d6c4a92))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61c18e3c-3eec-4917-af6e-9f406067d77e)
-    (property "Reference" "RC8-8" (at 200.66 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c083f528-7a3d-45a8-9372-aa710d031803))
-    (pin "2" (uuid ec242614-cf3f-4f5b-a1ac-1c89a34c79dc))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61f6b776-77f0-46d6-a562-1c8ec4a3e59d)
-    (property "Reference" "RC1-1" (at 58.42 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 841c88df-72b0-48a9-8e43-aa23d2c1bd13))
-    (pin "2" (uuid 39a4522a-a28d-471f-b74c-927ab042e90e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 62b34fc5-3988-4735-af8d-33fe194ac6ce)
-    (property "Reference" "D105" (at 233.68 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fe07ea24-09ee-4d8b-9b26-e3b9b6f6e23d))
-    (pin "2" (uuid a27722ac-a8b1-4fe6-8952-6f38def7c08a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D105") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6368f5d6-df20-4a23-a72c-e29e990ea131)
-    (property "Reference" "D36" (at 91.44 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cd72461-15a2-466d-828d-9560639fb78b))
-    (pin "2" (uuid e26d27e6-f81a-4557-bc98-f3f953d25d26))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D36") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 64616073-76e8-465f-9707-663a78749bf1)
-    (property "Reference" "RC7-3" (at 180.34 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0925180b-4c04-468a-84a3-7e0c543a243b))
-    (pin "2" (uuid 000c5508-f583-4022-ad6d-ee3a9a754164))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6692c134-d619-4b90-b4c4-ab21aa3df3a5)
-    (property "Reference" "RC8-7" (at 200.66 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 453a02c7-7770-40fc-8f21-06b63fd625f1))
-    (pin "2" (uuid 3ebf9656-8129-4c66-8b10-67f0c0e2bb28))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 227.33 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 678223ff-e0fe-486b-b260-417e9028494d)
-    (property "Reference" "DS9" (at 218.44 227.965 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 218.44 225.425 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6cfbc946-abd5-4358-933d-727d4186f547))
-    (pin "2" (uuid b5044718-d927-48a8-a198-355f14c09004))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 67aba0e0-2c92-4816-99a5-9091230a7899)
-    (property "Reference" "RC3-6" (at 99.06 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9c252319-dc79-4365-afaa-77dcde3e6c4e))
-    (pin "2" (uuid a5f35312-d094-4f22-9eb9-0edc1f8fb9c4))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 68966b55-0a95-4b34-bc89-5c7298da3231)
-    (property "Reference" "D95" (at 213.36 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2fe5baba-e2be-4676-a63d-cc166ce0c4ba))
-    (pin "2" (uuid 72f97c9f-1d3c-4a38-bcaa-aad4f2a66c32))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D95") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 695f4c79-90d6-4b0a-967b-42733076b01e)
-    (property "Reference" "D106" (at 233.68 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 903b20d6-c578-4888-8730-d3c0e18aa06e))
-    (pin "2" (uuid 404b33f7-bdf7-4f68-83c6-a160bf1fb2f7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D106") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6aa79de9-555a-4ed1-93d3-b801685ebd28)
-    (property "Reference" "D53" (at 132.08 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2031fe-ef72-48a9-afa6-c06144a31b2c))
-    (pin "2" (uuid 7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D53") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6b349af3-e96d-42ed-a60b-1fcc6b2649ce)
-    (property "Reference" "D92" (at 213.36 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bb4396c1-91b0-45de-ba96-3d4f74f6cf48))
-    (pin "2" (uuid b8385798-a88a-45df-851b-dcd7d4329aec))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D92") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6bdaf872-00b8-4813-a1b1-3be3a6e9f042)
-    (property "Reference" "RC2-9" (at 78.74 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b47928c2-316d-4b2a-9b65-93bc5a6a16f7))
-    (pin "2" (uuid 4fe94ff2-bac5-49bb-b97c-9a9ebef4c923))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6df07c86-7d3d-4752-94e1-ef193764a6be)
-    (property "Reference" "D108" (at 233.68 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8996cfc8-a40d-4e18-bba0-a53b24949546))
-    (pin "2" (uuid 3f3c5bd0-2a23-44ca-87a1-4ba1ae73b733))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D108") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6ef4f980-15ce-420f-b02f-d66ae810e188)
-    (property "Reference" "D78" (at 172.72 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 680d9493-5437-446a-836f-9ed5bb999bdf))
-    (pin "2" (uuid d64a76a9-3b5d-48b1-9a48-ee12b0cd1ab7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D78") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 70d661b8-51f1-49b8-ad84-9ce8d120c0fc)
-    (property "Reference" "RC6-2" (at 160.02 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2175ea2-22e6-4720-ab54-24959d43a616))
-    (pin "2" (uuid 63a1bf12-3f2f-4dc8-8a86-7932361b8306))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 712ade27-46b2-4d0c-b658-ec3775a1c528)
-    (property "Reference" "RC3-8" (at 99.06 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4811e298-73bc-4ac1-af58-3ae7f508d1d7))
-    (pin "2" (uuid ac21b718-c133-4ed3-a2f4-c437b7879cce))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7167cfb1-88a6-4287-88a0-a986fb3f21f5)
-    (property "Reference" "D101" (at 233.68 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0c8392eb-a8a3-486f-b665-59319eb216e5))
-    (pin "2" (uuid 5fbffba4-390b-4eeb-aae2-52f7131f4dc4))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D101") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 72047ccc-8813-4e13-ae4a-04618a9ab771)
-    (property "Reference" "D23" (at 71.12 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84))
-    (pin "2" (uuid 6dee3493-b1eb-401e-abb4-cbdef0ef3867))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D23") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7295efa3-e253-4b6b-ad8d-641bcea1e272)
-    (property "Reference" "D68" (at 152.4 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0450f5cb-94f5-4de3-b50e-da553aca1ff3))
-    (pin "2" (uuid 47f460cc-5812-4c14-b97e-030930a4c1aa))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D68") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7322809e-8332-47c6-af41-fcf3bbcec7d0)
-    (property "Reference" "D34" (at 91.44 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e3b096d1-dbd9-4fb8-8775-725a7aed0bc4))
-    (pin "2" (uuid 63756bb0-b693-4bbc-82da-e89a6b927e71))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D34") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 73fe2e30-76b5-4c9f-968f-cc1ed14e142d)
-    (property "Reference" "D116" (at 152.4 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b5e08441-3e51-488f-9243-b159a8be9e4c))
-    (pin "2" (uuid 49e66f6b-8bce-4939-aaaf-5836c6eb7e43))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D116") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 75e13388-d7c5-4583-8a3d-9b2d5836631d)
-    (property "Reference" "RC9-0" (at 220.98 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df3fb1ca-e1d7-4dba-9f10-debc4bd28da0))
-    (pin "2" (uuid 8e4b1d03-6eb1-4014-a87e-35bcdd8c8002))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 76054860-648b-474e-9b4d-cc9d83653495)
-    (property "Reference" "D10" (at 50.8 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d7e8bc-1ac3-4327-ab17-369de6ee755c))
-    (pin "2" (uuid c8283bba-c907-48e0-9745-e0818ca7ab04))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 77aa25a5-82c7-42c3-9d55-8606dd65ffa8)
-    (property "Reference" "RC5-1" (at 139.7 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51db5d58-5004-4c9c-b8d1-c184bfb493da))
-    (pin "2" (uuid 16d6f605-4627-49bd-9180-8203902febfd))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7876e2e4-9d5a-416f-b97a-e958a989e5b8)
-    (property "Reference" "D16" (at 50.8 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8bd5710-8f18-4748-9b3c-a975f78342a1))
-    (pin "2" (uuid da0aa924-203b-4985-9bff-4185f3555d43))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D16") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7b85c895-ed2f-4daf-bbd5-9b0e9148eed9)
-    (property "Reference" "RC7-8" (at 180.34 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6604866-4e4a-4cb4-bf09-ea0fa22fde38))
-    (pin "2" (uuid 0729bbae-70ee-4c7e-8da7-29c0812b5be7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8010e136-1dd3-496f-b7ef-81fb0c8b419e)
-    (property "Reference" "D20" (at 71.12 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5aa5bf69-e040-48d4-81fc-332aff45c2f9))
-    (pin "2" (uuid f5458189-75e2-45c3-bf32-0320ebe63391))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D20") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80a5b4aa-1a01-46e1-a016-7ed59d3b23df)
-    (property "Reference" "D109" (at 233.68 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b1ab302a-29f6-42be-bbd0-64440eaa5e08))
-    (pin "2" (uuid 9d2d85fb-6651-43ce-bf4b-5fd87aa66988))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D109") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80c46ab4-724f-418d-bb6f-e89792097e1a)
-    (property "Reference" "RC2-4" (at 78.74 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc0fd3d-897b-4e06-ac65-16066b68709e))
-    (pin "2" (uuid b7b98128-d37a-4ac7-b049-5cf9bdd5aadb))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 814545b5-c5a6-4c45-83b2-5c1b5ef43a22)
-    (property "Reference" "D57" (at 132.08 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid adc35f03-9c02-4ca4-bbc5-866d317a7469))
-    (pin "2" (uuid f05a395b-0185-4ab8-bf1d-fa0561316ad4))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D57") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 816cdc19-a693-48c3-988d-f7be0c4ea986)
-    (property "Reference" "D103" (at 233.68 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a6b3fcb4-74af-40e0-8945-de2253b431d8))
-    (pin "2" (uuid 3ccd5a59-b066-4c26-aaf7-7ea481a9509d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D103") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 81912d5a-1def-44e9-a6ef-abaf3ecd517d)
-    (property "Reference" "RC6-1" (at 160.02 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fa9aca31-bd8b-4e2e-8b86-05d191575df9))
-    (pin "2" (uuid fce38bd6-fb8f-42a6-8d68-ecda7f1a588f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 820f9c2f-0705-41a0-aa6a-3a211d61773f)
-    (property "Reference" "RC6-7" (at 160.02 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eb135129-1d78-4d36-9389-941aee94da0a))
-    (pin "2" (uuid 2a32e7b7-f134-4c47-a153-d8fce8404094))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 827c7160-8cd9-45ad-ab1d-e47e85f01713)
-    (property "Reference" "RC0-10" (at 38.1 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 38b5b850-4e9b-41a1-9787-c20514d29999))
-    (pin "2" (uuid 702d7ea7-e102-48d3-ac2a-bf8aee7adc03))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83cc3bf3-09a0-4d14-be9d-180ca479485f)
-    (property "Reference" "D73" (at 172.72 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 22a68b69-e4e9-436e-b154-616fe8bb66c2))
-    (pin "2" (uuid b8e81b5d-9257-4482-8c33-cdfcb13c22e7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D73") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83fb734e-dbcd-4939-9bb9-d97efd05ec97)
-    (property "Reference" "RC5-6" (at 139.7 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7315a9fc-fd63-46c2-90db-bee656dc7568))
-    (pin "2" (uuid f2997912-9551-49e9-aab8-387875819f56))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8408f1ce-a660-4217-a7dd-6677d6fa5c0c)
-    (property "Reference" "D96" (at 213.36 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eaa398b7-f50e-4597-99f7-b1dcab75a526))
-    (pin "2" (uuid 5719d7b4-74f2-42c4-b1c6-34b59ae5b787))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D96") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 84146f81-04f3-4efb-b753-bdc596c8e7a9)
-    (property "Reference" "RC4-3" (at 119.38 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 774ced50-3b17-48fe-b2d7-22681b1dd1f7))
-    (pin "2" (uuid bad310c0-ca25-47d0-b27e-42438b959c7b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 845c03a4-a29f-4060-99ff-96f7d714901d)
-    (property "Reference" "D113" (at 91.44 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90e2b51e-2aec-4797-944d-5cb436a4d4c1))
-    (pin "2" (uuid 4770df96-19a9-4485-a1b6-ea90ea64b2cb))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D113") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8475a219-4e20-438a-84d8-4847d5d45c64)
-    (property "Reference" "RC9-5" (at 220.98 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8668fb6-f91a-4502-9f57-a2869aa9f6f1))
-    (pin "2" (uuid 8e2e3508-e150-49c5-a82e-0ccd478af757))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 85a68001-32f0-411b-bf16-3041cb3149f9)
-    (property "Reference" "RC10-4" (at 241.3 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7542bca1-7e3d-46dc-a73b-a5a78a75187f))
-    (pin "2" (uuid bb178a6d-6e6c-4b4c-a89e-2573f4dafa3c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 85c7a9fb-2ee2-4035-ac87-9de0421b7051)
-    (property "Reference" "D119" (at 213.36 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8ed1820b-4233-41ce-9b35-a126d7cf3f3e))
-    (pin "2" (uuid 385695f7-ce9d-4258-947a-541bacc5ac20))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D119") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 86602dfb-ea19-4060-ad39-496c613a47cb)
-    (property "Reference" "D30" (at 91.44 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 02958e5d-18b7-48f3-9883-661ceaa75da5))
-    (pin "2" (uuid abed4b13-9431-40c7-848f-b30c05e39dfd))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D30") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 89d1107f-b11c-4e03-8d61-d6ad988c2118)
-    (property "Reference" "RC2-2" (at 78.74 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0c23c54e-b888-47bc-8530-d2ba6720b448))
-    (pin "2" (uuid 467d094f-64c9-4904-ad4f-dbacf7eda38e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8af20987-c3c2-465e-8640-61ab0bd7d8fa)
-    (property "Reference" "D81" (at 193.04 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9f42cdbf-02ba-4b39-8586-bbff1b6ed80b))
-    (pin "2" (uuid 7d939371-3ab1-4f18-b55f-07048dcfe21f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D81") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8b2b0803-8190-43b4-9c0d-a9a9edc27829)
-    (property "Reference" "RC2-7" (at 78.74 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8e9f64d-5849-4a62-8bf4-dafc65fcdd75))
-    (pin "2" (uuid e45fa11d-c755-4d62-baa5-974f973ba20f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8c168cda-0a39-478d-9d71-1073400c7ed7)
-    (property "Reference" "RC1-5" (at 58.42 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d2851af-db15-44cf-8e07-da339bdc18b2))
-    (pin "2" (uuid 94b381a2-7c19-4916-9f9a-ee00221d04d3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 129.54 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7)
-    (property "Reference" "DI4" (at 262.89 125.73 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c02807d6-1705-4325-bcb0-203f4e9a5baa))
-    (pin "2" (uuid d6c46059-bf9c-4959-836e-e4d33dcc5edd))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8eb7a7fa-054b-460a-a80c-73a56219fecd)
-    (property "Reference" "RC7-0" (at 180.34 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be9c1065-912d-49b5-8f2f-271b4a0c1db2))
-    (pin "2" (uuid 626f5614-e69d-4277-acf6-7ff35b08ddb4))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 90049005-7b99-4d2f-9282-dbf53b76b55d)
-    (property "Reference" "RC3-7" (at 99.06 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 62acb361-e48a-40de-9689-6c103c4c7663))
-    (pin "2" (uuid f3ee11cf-4f81-4591-ab5d-f41aece910dc))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 186.69 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 91a5d9b4-63df-4567-88f7-1d2f7ac8c33d)
-    (property "Reference" "DS7" (at 177.8 187.325 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 177.8 184.785 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2ec7f316-054f-444d-9c0b-c2c6e1d51faf))
-    (pin "2" (uuid e22dc61a-a86f-42a7-9c26-623bb8233a05))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 92030355-9e31-45db-a9ef-a705772288a6)
-    (property "Reference" "RC6-9" (at 160.02 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 83a62e7f-2925-4bbe-9dad-6089ad98ff2d))
-    (pin "2" (uuid c1b87b81-e623-49b5-bacd-1c525772e150))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 933178a7-83a9-4f29-88ef-1e369645dcaa)
-    (property "Reference" "RC2-8" (at 78.74 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4d133f2b-f4f1-4994-a89d-7141989cf18e))
-    (pin "2" (uuid 9ed70267-ef82-4b49-85af-67297365ea60))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 93921179-259f-4393-a6ae-bfcb2df690b6)
-    (property "Reference" "D80" (at 193.04 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d32d457e-c0ce-46dc-ac4a-08e965633eab))
-    (pin "2" (uuid 0645b564-d7c5-4845-82b9-8702f3f470a4))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D80") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 93dd9936-9573-4973-8fb2-a71d5e19f115)
-    (property "Reference" "D94" (at 213.36 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7beb185a-6309-4671-8dd9-da0c3ef9bc52))
-    (pin "2" (uuid baeb1083-702e-43e8-9a5d-760812497130))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D94") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 954ebd6c-531e-47b1-a7ea-7de1ed03bb85)
-    (property "Reference" "RC6-6" (at 160.02 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6bd2ec94-c1bf-43e5-93c3-e16c69deda42))
-    (pin "2" (uuid bc20e945-7eb5-47aa-ba38-8dbe3eaede1c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9578a4b6-1a56-40b7-be8d-56404ef59fdf)
-    (property "Reference" "RC1-6" (at 58.42 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0b899b44-3ae3-40be-a452-1f16eaa5f4af))
-    (pin "2" (uuid 11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 109.22 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 957e7a82-ca9c-46a8-bca9-099b05fe7e8f)
-    (property "Reference" "DI3" (at 262.89 105.41 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 111.76 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc53fac9-006c-4101-8113-949ab8e05afb))
-    (pin "2" (uuid f6122429-5885-4b7a-b72a-162ca49c70c2))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9789c79d-d74e-4c16-a474-31201e3b4997)
-    (property "Reference" "RC0-9" (at 38.1 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9b4d335e-fe84-4869-8670-3368a7ef15e9))
-    (pin "2" (uuid 3a372e91-311a-4276-8504-54c40aee2304))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 98a45ae1-6346-4607-b0c8-1479c51b1f75)
-    (property "Reference" "D49" (at 111.76 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 245fa70b-724d-4379-9c74-b8f5c8d9569d))
-    (pin "2" (uuid 964a681d-53eb-46ee-b5d9-73ca4400bb74))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D49") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9963ab0b-003e-4aca-bc8b-9e0a5e01de7f)
-    (property "Reference" "RC3-3" (at 99.06 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0e78455b-408f-4532-8244-190950de64ff))
-    (pin "2" (uuid 51c789b0-4434-42e9-80fa-6817bda53d0d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9af5b930-d274-4b05-b0bf-e2c27b7e71dd)
-    (property "Reference" "D6" (at 30.48 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bdad3d4-58ec-438c-beb8-3eea36a29d95))
-    (pin "2" (uuid 5ff4e8af-dd18-4010-b183-21b8178cd684))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 88.9 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd)
-    (property "Reference" "DI2" (at 262.89 85.09 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 91.44 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a))
-    (pin "2" (uuid 81e4b9c6-9b09-4e38-94e9-cebdeae457ee))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9e96ab02-44ee-4ac7-8251-0d309b7409ad)
-    (property "Reference" "RC5-3" (at 139.7 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd85b120-1be2-4f17-a3d7-505a734afc72))
-    (pin "2" (uuid 666e03ce-bf1c-4b58-ac4e-f01557ca11fd))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a026138b-aabb-432d-b516-5341ad9fe06b)
-    (property "Reference" "D39" (at 91.44 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6257e834-355d-4e0b-a5bb-744bef7d141f))
-    (pin "2" (uuid 8be7ee86-36bb-4b87-9942-9d15d9003e1c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D39") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a0ceebe8-8bed-40e1-b6c6-b65a1c2e15c7)
-    (property "Reference" "D115" (at 132.08 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 75df5fc5-2bbb-479d-b927-92c2a479919f))
-    (pin "2" (uuid bacdf9a6-57fe-4ece-ba49-00f48d544136))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D115") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a1e6073b-e736-4ea3-b4f5-31effb1ededc)
-    (property "Reference" "D112" (at 71.12 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 04d10445-42c8-4462-b56c-145fa5cb598d))
-    (pin "2" (uuid 4d1b5ab5-c53c-49d9-ae4e-3cb42d0a2b8e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D112") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a3969e5a-abe0-44e9-adf1-6255946e3f4c)
-    (property "Reference" "RC6-0" (at 160.02 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bc4d6aea-ec1e-45c7-842c-68cd7e21336f))
-    (pin "2" (uuid f785fa77-0ac2-41ff-9704-1acbb4a72c84))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a400377f-e146-4099-97e7-db21e16d5759)
-    (property "Reference" "D3" (at 30.48 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bfc71c1-6349-4b3f-bf89-22c83277904e))
-    (pin "2" (uuid dafd4b6c-6c2f-41e0-95ab-05ead276d86d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a4f847ba-a334-4631-aef3-ca47db1a1700)
-    (property "Reference" "D29" (at 71.12 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc5b522c-bddd-4a8d-8ded-7fc36acfc178))
-    (pin "2" (uuid 8e96df26-db08-4a3c-92ce-ba5029c624ac))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D29") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a576c983-0812-4f76-8327-d260ce9c2826)
-    (property "Reference" "D27" (at 71.12 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c11deb1a-dbe0-4d39-8303-331b09dd3cc0))
-    (pin "2" (uuid 9251c46a-97e6-41c1-9326-a6a8b52abc12))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D27") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a71b771b-4e14-4d95-98e7-86a6250f569e)
-    (property "Reference" "RC0-4" (at 38.1 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 95049e61-b78e-490f-86e1-aba711db5c19))
-    (pin "2" (uuid 6e474ba8-5b88-41c8-9259-b0ebfb6012f0))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a7415034-f7b1-4b4a-bc99-efb9b1d73bd0)
-    (property "Reference" "D102" (at 233.68 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 231d155d-b8f1-4a91-b6f0-625ec31124f7))
-    (pin "2" (uuid 1889e496-f8e9-418d-9a77-7351d4b4828c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D102") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid aac180ff-c5e7-4a0e-9a07-44c1b3bcc7fe)
-    (property "Reference" "D59" (at 132.08 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c6b5d04d-906d-4f18-b7a3-382b3a768815))
-    (pin "2" (uuid d74367e2-5126-4fe7-ac31-7039cd9552e5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D59") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid abf3c9d9-a279-4546-abcf-5e4f6862bc48)
-    (property "Reference" "D2" (at 30.48 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3499f31-3593-4cd9-977b-3b6479091d7b))
-    (pin "2" (uuid 17f09d49-1093-4838-8e5c-8fc4c42e5d05))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac10b530-144b-4dfc-ab37-ad7a8ced8612)
-    (property "Reference" "RC4-5" (at 119.38 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6c95156-54b9-4f54-a278-f808b4871687))
-    (pin "2" (uuid c3dc8d92-1759-4195-a3c9-81260bc6d8b1))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac95bba7-885e-446e-b059-0ba3c38e43f7)
-    (property "Reference" "D19" (at 50.8 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 63ad0fd9-4009-4287-bfa1-9dc63b978ef3))
-    (pin "2" (uuid d7eafe2c-7576-4ddd-821f-8f8bca43ff92))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D19") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 85.09 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid accba515-4e8d-4804-afea-f36f436141c3)
-    (property "Reference" "DS2" (at 76.2 85.725 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 76.2 83.185 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 034e4344-7cda-43bc-a12a-f56b6e8f68f5))
-    (pin "2" (uuid 6f0bef00-c613-46da-9667-752b92174ad1))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ad352cc7-0ffd-4a04-82ac-bc693299cd86)
-    (property "Reference" "D83" (at 193.04 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9662d2b8-61ec-4840-a8f1-af48833c11eb))
-    (pin "2" (uuid 4d0c4f9f-b435-4d30-95d7-23d9f87d5f48))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D83") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ae019221-3fd0-468c-9cf0-dac8d7470e8e)
-    (property "Reference" "RC9-3" (at 220.98 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be20235f-2999-4595-bedf-c52cf23b7bd1))
-    (pin "2" (uuid f57afa4c-8044-4217-b32d-12bed3437591))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid afcc8d67-6ed8-4a82-aef7-417b4229ad61)
-    (property "Reference" "RC7-4" (at 180.34 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 982715f0-55ee-4146-b98e-756e5b630dca))
-    (pin "2" (uuid 7f384a84-9632-4ac9-a8b6-05778cf49f62))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b05bbd1d-9d65-4ef7-a639-885ae69d8b01)
-    (property "Reference" "RC8-0" (at 200.66 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 16c6866c-1d06-4257-9cde-9d9c6f4c3642))
-    (pin "2" (uuid 70b152f6-7e7d-4a93-9ef0-b6ec51ff9b25))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 247.65 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b1c53fc7-e42c-414d-ae3a-1dfd6dab01ad)
-    (property "Reference" "D111" (at 50.8 247.015 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 249.555 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 247.65 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid af2c92cb-5c58-4d6d-908e-91654bde79db))
-    (pin "2" (uuid d2964c5f-b1ae-499b-b6cc-5eb8d8150b62))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D111") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b2bdfb59-b351-44dd-8797-c36e151a03c2)
-    (property "Reference" "RC4-4" (at 119.38 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6d389aae-8651-49ec-9923-0a9cfe96d0b0))
-    (pin "2" (uuid f92b3875-8420-4f8e-a622-19ee07fc28bf))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b2cc8c06-500a-41ac-a412-7baf61e0f24c)
-    (property "Reference" "RC6-3" (at 160.02 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0a77d5cb-df53-4102-99ed-4829fa686656))
-    (pin "2" (uuid 22df81c2-2a06-44e2-bed1-a6d6c14df76a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 146.05 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3573dc3-ef18-4f4c-817b-c984ae7cfae9)
-    (property "Reference" "DS5" (at 137.16 146.685 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 137.16 144.145 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 813e7cf6-f821-4e03-95cc-308010bed54e))
-    (pin "2" (uuid 9669a028-42d7-436f-8ec5-bc3423db62d6))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b39d56f9-3079-43e4-bb1b-80277fdae425)
-    (property "Reference" "RC4-2" (at 119.38 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b205d044-9ffa-4dce-82fd-f51ba622a818))
-    (pin "2" (uuid 29ce7588-4a17-4be4-9207-ea3ed2669aa1))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3c497a9-b81f-4161-88cf-2e58ddb4cdd8)
-    (property "Reference" "RC3-4" (at 99.06 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ae78f0d3-f75a-49c8-ab9b-8a9831e434d7))
-    (pin "2" (uuid a59e897c-0784-437d-9243-baf91d40a453))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b4258223-eb85-47a5-b84c-0db880fc4f11)
-    (property "Reference" "RC10-5" (at 241.3 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 59599fa7-6060-470f-b661-a270f65a3960))
-    (pin "2" (uuid 8b45f29d-0cbd-414e-9212-2948f143ec62))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b92624bc-936a-4bc6-ac7c-dbc9faa7208a)
-    (property "Reference" "D8" (at 30.48 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0ef02d0f-103e-468b-b30c-fac4e90fb218))
-    (pin "2" (uuid aa510cff-115d-4ad1-9c78-bf1246172261))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba3c5bf2-9824-404a-befe-7584c286e012)
-    (property "Reference" "D48" (at 111.76 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 38e4de38-525a-4e2c-8e51-9d4770973903))
-    (pin "2" (uuid e71e068d-4f7e-493a-960b-e49aa171ca56))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D48") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba9018cb-07e4-4089-9c00-6840b6e47ce6)
-    (property "Reference" "RC10-0" (at 241.3 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1ec01f7f-759e-4fa4-9f08-5c89efa2cc11))
-    (pin "2" (uuid 7927caf8-4f39-475e-ab72-b869d94229b3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba927934-b2e1-4953-b21b-54ef02be8935)
-    (property "Reference" "RC0-5" (at 38.1 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cadba0a-3bb3-40cd-acea-644da4b3e05f))
-    (pin "2" (uuid 1368ebac-096c-415f-acaf-9afb071e729f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bb2c72f0-a908-44e7-b7d5-67df52eed516)
-    (property "Reference" "DS4" (at 116.84 126.365 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 116.84 123.825 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5ab0b348-3e2a-4517-90b3-fad111de6205))
-    (pin "2" (uuid 6e7351bb-5d09-464f-9e8d-535ba0f5c6f3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 207.01 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bbc3ae57-e1db-475c-9bc3-18c822e7531a)
-    (property "Reference" "D28" (at 71.12 206.375 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 208.915 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 207.01 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90783402-edc5-4638-ae16-d31c3aaf5e2b))
-    (pin "2" (uuid f9e9c399-273d-43fc-9007-1e5ca67fea38))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D28") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be02506a-2bb1-4713-b046-f0327dae72de)
-    (property "Reference" "RC0-1" (at 38.1 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 97a92abd-708c-465e-baf7-79fa35370a7c))
-    (pin "2" (uuid c9056b1e-419e-478d-9fc4-be1e95902d28))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be554787-60ed-4b8f-b7bc-2220fcd28430)
-    (property "Reference" "RC8-3" (at 200.66 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 76eac86e-4d5a-4833-a702-c89fc5eb96e0))
-    (pin "2" (uuid 6e41d262-c7fe-4c54-b525-59ae026a918d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d)
-    (property "Reference" "RC5-2" (at 139.7 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f22c39d-012a-4297-b61c-1ff841801333))
-    (pin "2" (uuid adbe8c88-ad34-405b-866a-efb64899002f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bf639842-72e9-4bdd-be11-7972d8d5c3c4)
-    (property "Reference" "RC3-9" (at 99.06 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8015b627-c562-4073-8a9c-3d88306d5597))
-    (pin "2" (uuid b34e9dd8-5aad-496e-81b0-f2f5cb3bdb66))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c11b6807-83e7-46af-9d7e-9d56aab4109c)
-    (property "Reference" "D46" (at 111.76 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46))
-    (pin "2" (uuid 6764bae9-067c-4178-897e-2c25048ade8b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D46") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c164cb58-7d29-400c-b219-f07036f5e8c9)
-    (property "Reference" "RC0-3" (at 38.1 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92164ea1-76d0-4223-80cc-32c093c14fcd))
-    (pin "2" (uuid e615b2e5-6986-47ac-8f35-da60c20b811c))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c38cba3d-abb3-4489-8620-78b7017d5c40)
-    (property "Reference" "D100" (at 233.68 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eba02688-21b5-4572-9e9b-df8382a314e1))
-    (pin "2" (uuid 106a2fb9-b74c-4d49-b2ef-4fc3f78df241))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D100") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c43b92c2-4283-44f7-8cb3-665623564383)
-    (property "Reference" "D42" (at 111.76 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0929e13-ab77-4737-9d55-142bd9901b1c))
-    (pin "2" (uuid 0f45988c-1752-479c-97d5-fbada14f9a42))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D42") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c64cc71e-aae1-49fa-83d0-4d8a51355bc6)
-    (property "Reference" "D9" (at 30.48 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 328932ea-b1f6-431f-8c23-8a2d8eae8bba))
-    (pin "2" (uuid 10eab654-b7fb-42dd-bf39-41b39e8328d6))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c72dd108-be98-47d5-b809-561778aa3212)
-    (property "Reference" "RC2-5" (at 78.74 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d2f0fd-ce69-4d4e-a4ab-163c1691ef24))
-    (pin "2" (uuid 03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c7f185b3-c785-4ddb-9c6f-f854c93057c1)
-    (property "Reference" "D85" (at 193.04 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b8f08018-67e0-4945-91d2-9a40292e0a1a))
-    (pin "2" (uuid 096b6293-e540-4273-b6aa-9e314016c840))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D85") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe)
-    (property "Reference" "D50" (at 132.08 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a606860e-126b-4f3e-bcfe-a2dfa8adc9c8))
-    (pin "2" (uuid 59120505-a333-4c63-8904-aa379cfb043b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D50") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c996541a-3b07-4fed-9687-afa9b7ffb878)
-    (property "Reference" "RC7-5" (at 180.34 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 560b334e-ed5f-40a2-b100-5974e92ce94c))
-    (pin "2" (uuid 55bbe733-1ff6-4a73-b892-49d49c6c0fc9))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce521a1c-e123-4f49-866e-f4f51848f864)
-    (property "Reference" "RC7-2" (at 180.34 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2a9b15ea-df9e-4ef0-a128-13d2e129d7f7))
-    (pin "2" (uuid e9530707-f705-4741-a308-e08f558f67a1))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e)
-    (property "Reference" "D51" (at 132.08 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48596e1c-4629-46bb-98c1-de11cd41e539))
-    (pin "2" (uuid f7decfb7-c4ef-4861-ba8a-043f44f3b09e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D51") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cf81ef85-b58f-422a-b88a-7b7914aa3581)
-    (property "Reference" "D12" (at 50.8 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e34c154b-a3cb-467d-891b-2f2891056190))
-    (pin "2" (uuid dc926c49-c915-470d-b2b5-00749f3505bb))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D12") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d2a28b21-08a4-472a-9f34-48db4deebb9f)
-    (property "Reference" "RC10-9" (at 241.3 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e8b2d3fe-8c4b-40e0-b791-ed869e3b96f2))
-    (pin "2" (uuid b9d47461-c0d0-4606-9625-d5e52d2e1041))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d2e0ab87-3807-4a88-be47-f5c2586bfeb9)
-    (property "Reference" "RC1-9" (at 58.42 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 905c7978-373b-43c6-894f-f9da59358409))
-    (pin "2" (uuid 9dabc73f-860c-4bde-9950-7e2511b1e9b3))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 227.33 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d352da38-bdf9-428f-a8d9-8df6c9a36ec3)
-    (property "Reference" "D89" (at 193.04 226.695 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 229.235 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 227.33 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4c3fc4a6-4570-4b34-b7cc-c9d681cef14a))
-    (pin "2" (uuid 7d95533d-af2b-4a4c-b205-9385c93624cd))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D89") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d40b4fbb-e58c-433e-b2c5-236bb8aa92c5)
-    (property "Reference" "D1" (at 30.48 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90049b07-ff34-407c-ad1c-bcb8b89b241c))
-    (pin "2" (uuid 7bd5d68f-4902-47f7-bc35-be0973d0d904))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578)
-    (property "Reference" "RC5-0" (at 139.7 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5729530-792d-44f2-80ff-f6315aae335e))
-    (pin "2" (uuid 01f42ec4-9037-47c0-8fc0-8f7345fd0a2b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d69b760e-d231-449e-ae78-5289569bfcf8)
-    (property "Reference" "RC4-8" (at 119.38 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b2174dcf-3936-44c4-b9c9-8a8c2ffd5559))
-    (pin "2" (uuid 553bf002-fd89-4554-b1c2-ed094fd5fe57))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d7b98385-4339-43e1-a83a-6daba8def1f8)
-    (property "Reference" "RC0-8" (at 38.1 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c3a8852b-59c8-4849-9f9f-edc39c43f8e6))
-    (pin "2" (uuid f4bfef10-0157-4077-9c8b-8858eccf5c1a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69)
-    (property "Reference" "RC2-1" (at 78.74 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ba2015a3-c3ad-44cf-b530-b2a60bac2c12))
-    (pin "2" (uuid 12bdf482-8bd0-4b7d-a511-fcaadc8ab54d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid daefbaa6-3e17-4eca-837b-024ccac5fc10)
-    (property "Reference" "D14" (at 50.8 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12e5236e-b23d-4e38-9768-e28d1693b6eb))
-    (pin "2" (uuid 1be4fe23-ac83-4b50-b43f-2e4b33c335d7))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D14") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid dbb7c48e-1b69-4840-9f8a-f0ac68b4296d)
-    (property "Reference" "RC10-8" (at 241.3 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0b11d916-53f3-4439-97e3-3f053db0d0f4))
-    (pin "2" (uuid 26e77532-f2b2-4eab-89dc-7fae6951ac49))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 215.9 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid de9b7bb1-afa1-4e19-b963-4516a18a17bf)
-    (property "Reference" "D91" (at 213.36 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 213.36 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 215.9 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6167a490-f64e-4925-8d8a-b4543a48c019))
-    (pin "2" (uuid b78fba3b-33a1-4c3a-941e-dc9814c91e24))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D91") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid df14ac0c-5b64-41d1-ac61-954e84a88f4b)
-    (property "Reference" "D47" (at 111.76 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7284aa2f-4456-4e07-9251-a86b7acd95b1))
-    (pin "2" (uuid c06243a0-5a23-4af5-88df-f2a88bfb1da0))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D47") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e214b496-153e-40f8-93df-30f96574576d)
-    (property "Reference" "RC6-8" (at 160.02 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 762c516c-df17-4ae0-8f7f-03315e74925e))
-    (pin "2" (uuid 874fed4d-cc1d-47bf-b14e-533fedfc9875))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e255666b-19cd-45a4-b5c1-8997235eb1ad)
-    (property "Reference" "D72" (at 172.72 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92803ca1-7814-4c2f-986c-c7a2afaea4b2))
-    (pin "2" (uuid f1e544c9-5e94-460f-960c-d30fdb857f44))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D72") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 203.2 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e345b77c-4943-4943-8fff-9d2c0a863651)
-    (property "Reference" "RC9-8" (at 220.98 196.85 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 199.39 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 198.12 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3c5bbf7f-11d9-45e3-9492-3b3f4802883c))
-    (pin "2" (uuid 8e4fc19e-5f68-43e8-b4a4-baf188b4cd3a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-8") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 195.58 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e433e872-70f0-4e5b-b473-1ebd1af79f33)
-    (property "Reference" "D84" (at 193.04 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 193.04 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 195.58 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2c838395-b13b-44f3-9cda-ae0061827054))
-    (pin "2" (uuid b7abe52a-50b6-4b31-8da0-3b0e1433e922))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D84") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e4362acf-dcaf-47ae-b824-45cc81be26fd)
-    (property "Reference" "RC9-4" (at 220.98 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 59031059-0660-4b8b-bc7c-d25dfdf99292))
-    (pin "2" (uuid 8d191698-0ba8-4bfd-9183-392ad5be38af))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e490f25a-1360-4f95-aa79-5f1d93892bb3)
-    (property "Reference" "RC3-5" (at 99.06 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 056973a8-92e3-49be-9b21-fe961241d12f))
-    (pin "2" (uuid 01c4c06b-d45d-4ffb-ad72-57ca7686fd55))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 236.22 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e5c1c88e-f9c7-4c87-a0c4-3ca2d142293b)
-    (property "Reference" "D107" (at 233.68 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 233.68 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 236.22 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 236.22 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 236.22 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 236.22 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4007740f-9871-42e9-bc5a-88a1bd3cb05c))
-    (pin "2" (uuid 2d6b89ec-44b6-409d-98ce-d034565337e0))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D107") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e6262d19-9b35-41b6-845a-39c20b831416)
-    (property "Reference" "D76" (at 172.72 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8324bd70-bd5e-4513-bc52-cc4e838003e8))
-    (pin "2" (uuid 64285f25-2c5b-4231-8d94-7ba284d5a2d2))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D76") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e97aeea5-7475-4b9f-a312-6f51452496a5)
-    (property "Reference" "RC8-4" (at 200.66 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b5d442a-c78e-4d0d-8f8c-3cc6c91bf307))
-    (pin "2" (uuid 4b2eebd0-ccb3-482c-8c43-2690e285e66f))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 105.41 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b)
-    (property "Reference" "DS3" (at 96.52 106.045 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 96.52 103.505 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 738869bf-f410-43b7-b7e7-4e927d69911a))
-    (pin "2" (uuid 71649a24-87f4-49fb-9896-e50c64c03a31))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb153eb2-74b0-4cb9-b105-af356654d60d)
-    (property "Reference" "D24" (at 71.12 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77c4fd5e-5c79-4799-aab6-2f07a57c7df3))
-    (pin "2" (uuid a062346b-452b-46dc-a106-fab01848555d))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D24") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 262.89 231.14 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid ec0ebda2-e0b5-4648-83ee-afd68a4093ad)
-    (property "Reference" "DI9" (at 262.89 227.33 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 264.795 233.68 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 262.89 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 262.89 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 262.89 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 262.89 231.14 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 941790dd-6c84-4d17-8c86-cd053db9749e))
-    (pin "2" (uuid 1cfb4960-1c24-46af-9168-505412fc1763))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ee3742e9-8e22-4413-88a6-b893a7cb3439)
-    (property "Reference" "RC8-6" (at 200.66 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12157fba-1ac0-4b59-9ef4-f0b7f556fda2))
-    (pin "2" (uuid a6fa6d7f-615c-410e-9188-d1867808891a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eeca0e5b-e9f9-4790-9c32-e398887f1254)
-    (property "Reference" "RC8-9" (at 200.66 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ee863615-0428-4134-aa77-1d7c4e3647ad))
-    (pin "2" (uuid 7b155375-a70f-42ef-9309-987f1f53d011))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ef64a689-efe5-479a-a53a-19c9f4177765)
-    (property "Reference" "D74" (at 172.72 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fc4be4a8-3bcc-4a9b-8dca-654b73020c91))
-    (pin "2" (uuid 982449b6-25db-4afc-abf2-592e07b23449))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D74") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 241.3 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f122c030-5a9c-45f5-b8ba-c45e0254028c)
-    (property "Reference" "RC10-1" (at 241.3 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 241.3 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 241.3 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 241.3 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a518542d-a321-474d-a528-b1ac405432fb))
-    (pin "2" (uuid 8e1d9e00-0513-42d1-90ae-77a92818504e))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC10-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1920e34-64a4-41c9-8680-7fa42f5dfb9d)
-    (property "Reference" "RC2-0" (at 78.74 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9242378-4df5-4b90-afbf-1098ccb8067f))
-    (pin "2" (uuid a135b9b9-316d-4cb2-a5a5-8d618a00a752))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1a5bcca-72b0-4fb1-9570-8abc0f731fb7)
-    (property "Reference" "RC1-7" (at 58.42 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 058cb33f-3013-4884-ba52-2b175c6e6f25))
-    (pin "2" (uuid cb54004f-a1b9-489e-9cdf-00b812c2d5fa))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 243.84 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f2d1b442-f332-4cd5-8f37-082347d04ad7)
-    (property "Reference" "RC5-5" (at 139.7 237.49 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 240.03 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 238.76 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b711bbbc-f96f-4962-a5e2-7b5cebc42152))
-    (pin "2" (uuid d05d308e-04e6-403d-8d5f-72c7cf2f105a))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 220.98 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f31d54be-89a7-479b-90a6-e9bcd6257412)
-    (property "Reference" "RC9-7" (at 220.98 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 220.98 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 220.98 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 220.98 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f83ff9f6-7715-4e86-b4bf-0de9179fec70))
-    (pin "2" (uuid 2a257b84-25fd-4cd2-9e3d-5ac106f662f8))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC9-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f735328c-2a24-4fb3-983d-b3e512d5a5cf)
-    (property "Reference" "RC8-5" (at 200.66 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid af0d403b-f1be-40d9-bf46-12c29a8b07f1))
-    (pin "2" (uuid cf12207d-8835-4b4d-855b-207eb48891b5))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 223.52 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f93938b2-5ce6-4ad4-aef1-bcec2b0c3413)
-    (property "Reference" "RC4-9" (at 119.38 217.17 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 219.71 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 218.44 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb557f65-fb80-44d7-9e25-f09389e948a7))
-    (pin "2" (uuid ef20bae4-a01f-4ba7-8d51-cad542d569ba))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-9") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 200.66 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f9c61822-7d54-487f-93d1-920e041f55a6)
-    (property "Reference" "RC8-2" (at 200.66 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 200.66 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 200.66 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 200.66 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffd61ace-0250-4fd9-8d0c-c2c917d0d4b5))
-    (pin "2" (uuid d354ba15-00ca-4efb-954b-871f951259db))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC8-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fc941f43-b642-4fef-8515-f8f851adced2)
-    (property "Reference" "D13" (at 50.8 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c))
-    (pin "2" (uuid ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D13") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fcc35b13-8da5-4271-981a-5470b3add3e5)
-    (property "Reference" "D25" (at 71.12 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0d662a-16b3-4c76-b4ee-49de18b57b47))
-    (pin "2" (uuid ba9a1f4c-173e-4b32-907f-fe9b31df718b))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D25") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fd13d6af-afdf-4367-a43b-1889348eabd8)
-    (property "Reference" "RC0-6" (at 38.1 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 854af50a-a007-4ba3-a405-76f0f99e9817))
-    (pin "2" (uuid bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142))
-    (instances
-      (project "round-robin-12-110"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "cbac505e-77a6-4a00-a758-435de33cca16")
+	(paper "A3" portrait)
+	(lib_symbols
+		(symbol "Diode:1N4148"
+			(pin_numbers hide)
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "1N4148"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "100V 0.15A standard switching diode, DO-35"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Device" "D"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "D*DO?35*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "1N4148_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "1N4148_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 165.1 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "00d75863-bb9f-4d4c-ae8f-f64498ed1533")
+	)
+	(junction
+		(at 266.7 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "04d157fc-c063-40ca-ad05-26c77c1c313c")
+	)
+	(junction
+		(at 215.9 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "057080d9-d7cd-490d-ab5f-b591aaae58fa")
+	)
+	(junction
+		(at 185.42 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "05e510f3-8ca9-490a-bdc5-77faace67735")
+	)
+	(junction
+		(at 104.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06a6d1a8-0f12-4174-b63e-d35d8ca618bf")
+	)
+	(junction
+		(at 43.18 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06e66b38-0070-40a1-8fc5-70306b17897f")
+	)
+	(junction
+		(at 246.38 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "088d9831-391b-4393-b317-222e60d64881")
+	)
+	(junction
+		(at 165.1 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "09e82fd3-a43f-4071-83d2-fb0a65931c0e")
+	)
+	(junction
+		(at 195.58 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a12de08-1706-4b9c-a033-35ba5807ef7b")
+	)
+	(junction
+		(at 63.5 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a9113d4-8a8c-4abc-b886-f22c92ad18dc")
+	)
+	(junction
+		(at 165.1 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a95c2d4-251b-4df1-a8c0-c0fc6241e43d")
+	)
+	(junction
+		(at 124.46 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29")
+	)
+	(junction
+		(at 73.66 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c7244ee-ddfb-470b-a70b-1cfc53f83773")
+	)
+	(junction
+		(at 134.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c73479c-4e07-428a-85f3-93341c42ca57")
+	)
+	(junction
+		(at 93.98 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5f3a7a-dc5d-4973-8743-eafaa1c1a462")
+	)
+	(junction
+		(at 43.18 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0fa898f1-7f7f-49aa-98b2-974fb5bba30b")
+	)
+	(junction
+		(at 43.18 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "10cae212-bc64-40b9-b44f-13fd4a0406a6")
+	)
+	(junction
+		(at 53.34 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "122dbfee-176c-4f21-802f-09581864dffb")
+	)
+	(junction
+		(at 83.82 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1278b5e3-5eff-46d6-a162-44fde2066970")
+	)
+	(junction
+		(at 53.34 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14bb4fc2-d7df-49aa-b10e-882abdd2aa5f")
+	)
+	(junction
+		(at 215.9 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "15ad1e9e-3a46-4b63-85e5-8965649033ac")
+	)
+	(junction
+		(at 185.42 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "15daf298-357b-4f73-8767-34988eed6eb8")
+	)
+	(junction
+		(at 104.14 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17f3773a-2c02-426d-bcd6-7a35c59a710a")
+	)
+	(junction
+		(at 205.74 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1943e8ad-b21d-4f7c-9e48-baf07472bdf8")
+	)
+	(junction
+		(at 114.3 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a11ada5-19c8-45ac-810c-daedbb80ad5b")
+	)
+	(junction
+		(at 195.58 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a6176d3-a6a6-4f72-9be0-2812f8861a46")
+	)
+	(junction
+		(at 73.66 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c386ee6-5b9d-4eae-92b5-9440e81067f6")
+	)
+	(junction
+		(at 266.7 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "216bc563-0bc0-4447-af79-7933fdef7d63")
+	)
+	(junction
+		(at 93.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21e320b6-a0c4-4d5d-babf-ee5274120507")
+	)
+	(junction
+		(at 205.74 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "22da1369-0217-4ceb-b653-345b9ee68839")
+	)
+	(junction
+		(at 185.42 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23554013-cd0d-4767-9f22-8c19a7d8c5ca")
+	)
+	(junction
+		(at 154.94 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23916c3a-0d37-416a-91d3-82a34b3ade4a")
+	)
+	(junction
+		(at 165.1 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2501dc30-a271-4271-9ca6-b085328a23ec")
+	)
+	(junction
+		(at 73.66 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2654ce54-6e59-4c49-bfbf-12326c83c638")
+	)
+	(junction
+		(at 226.06 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "28c72d93-951d-432a-abf9-c3f05af6b90f")
+	)
+	(junction
+		(at 154.94 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2af4d5cf-36e8-471b-be0a-21fb2d03facc")
+	)
+	(junction
+		(at 124.46 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2b2b66bc-905d-4b48-89f5-1c62f6c27dbb")
+	)
+	(junction
+		(at 134.62 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c5878fe-fb0a-42a4-a883-ea4209708ea5")
+	)
+	(junction
+		(at 104.14 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c97cd17-57cb-4fbf-859b-370fde839231")
+	)
+	(junction
+		(at 175.26 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2cae1312-83d6-4b55-a6a7-5303ad6d6c6c")
+	)
+	(junction
+		(at 154.94 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2cf168f3-fe97-43f2-b72e-223dd4e6b386")
+	)
+	(junction
+		(at 73.66 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2f562ace-9050-4ec1-bf70-b5691b93259e")
+	)
+	(junction
+		(at 73.66 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30c9eca3-7c32-4704-8819-3599d7b84f53")
+	)
+	(junction
+		(at 93.98 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "31a1b16e-8174-4fea-bc42-9c75ed9182a0")
+	)
+	(junction
+		(at 83.82 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3")
+	)
+	(junction
+		(at 114.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "347306fc-87ef-43e1-a98f-ca29ac9473e6")
+	)
+	(junction
+		(at 124.46 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "352af8be-9d08-4866-961e-b8632013179f")
+	)
+	(junction
+		(at 104.14 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "356b49b0-20ac-4c33-8df8-9b27dee0b312")
+	)
+	(junction
+		(at 175.26 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "357aa667-d746-4e3e-ab2a-484493e6765a")
+	)
+	(junction
+		(at 266.7 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c")
+	)
+	(junction
+		(at 175.26 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "39869536-29f6-4e84-a33a-473fa8fb0f36")
+	)
+	(junction
+		(at 185.42 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3abcfbc6-0288-48d7-a0e0-144f99e6dd30")
+	)
+	(junction
+		(at 144.78 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3d987483-3b5e-44fb-b675-40705bf855c1")
+	)
+	(junction
+		(at 73.66 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ddc125c-fcd9-4032-ab01-48905fc95e1f")
+	)
+	(junction
+		(at 134.62 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ddd9e62-5556-463c-9539-c0d582cc40e9")
+	)
+	(junction
+		(at 215.9 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3e3c4ece-47a6-47a0-92bc-290b69884d25")
+	)
+	(junction
+		(at 43.18 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4420dc63-3aee-4086-92ad-39d849507e61")
+	)
+	(junction
+		(at 175.26 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "461b5e1e-26c0-464b-90de-d503b74d31b2")
+	)
+	(junction
+		(at 236.22 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "46349b1a-d4af-45cd-a544-99bbfc4dc176")
+	)
+	(junction
+		(at 246.38 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "47663216-b5b6-46c0-86b4-2eecf37e4714")
+	)
+	(junction
+		(at 205.74 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4788fde7-f606-4229-8a7b-9fa04f56d3d4")
+	)
+	(junction
+		(at 114.3 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "490a89d7-a161-4f1a-9b45-a55729d9d59b")
+	)
+	(junction
+		(at 114.3 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "49621764-c8ec-44d3-917e-f33f018f3c73")
+	)
+	(junction
+		(at 124.46 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c74baef-72cb-4cdf-b4eb-a3d28782257d")
+	)
+	(junction
+		(at 53.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c7a50e9-7650-493b-b0a7-057b900a13a7")
+	)
+	(junction
+		(at 63.5 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9")
+	)
+	(junction
+		(at 144.78 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4ca8463c-17c1-4081-98f7-058f3e24afa5")
+	)
+	(junction
+		(at 165.1 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4df4e0a7-6e46-4c32-959d-094f3457d75b")
+	)
+	(junction
+		(at 43.18 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e641ba8-cbcf-42cf-89f0-ac977902bf98")
+	)
+	(junction
+		(at 73.66 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fc826ad-ef7b-406a-9b89-76eb2c211523")
+	)
+	(junction
+		(at 53.34 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fce0301-62b3-4ef1-9bae-8d55ea745d66")
+	)
+	(junction
+		(at 185.42 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "508ddd33-e065-44a5-a999-5944a523ef76")
+	)
+	(junction
+		(at 175.26 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "50f2ad43-aa07-4fd1-8d58-f22d767da31f")
+	)
+	(junction
+		(at 215.9 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5139e9d8-9859-4a06-8a53-2bb6b6b13b50")
+	)
+	(junction
+		(at 185.42 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "51c7f5d6-d0e7-40a3-b648-cddc977cf840")
+	)
+	(junction
+		(at 195.58 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "51dbbda9-bf1e-445e-9a43-5f378a7d2f7f")
+	)
+	(junction
+		(at 215.9 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "520e65e5-7987-406d-915b-7bab05f2eec5")
+	)
+	(junction
+		(at 53.34 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53bb27f5-9b54-4704-b90e-33b3053be6c4")
+	)
+	(junction
+		(at 246.38 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "568866d4-b9be-4a7c-a92b-303ebf890e4c")
+	)
+	(junction
+		(at 236.22 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "59d94e1a-df14-41a9-ac17-b3e09684cb2e")
+	)
+	(junction
+		(at 114.3 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b35d564-88c3-4b41-864f-a4f82bc4c871")
+	)
+	(junction
+		(at 43.18 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5bfc49c0-36f2-431c-81ea-cf78c71d7681")
+	)
+	(junction
+		(at 266.7 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5e5c2547-fedb-4174-9d5d-8b097a3c440f")
+	)
+	(junction
+		(at 124.46 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5fc4155a-3665-4a3a-bfc7-8b7bed175ee0")
+	)
+	(junction
+		(at 215.9 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "622ffcf7-d6fa-402d-9dd5-75baba79ad71")
+	)
+	(junction
+		(at 246.38 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "64b2f9ba-796d-4b73-a2bf-61e94b67dfc1")
+	)
+	(junction
+		(at 83.82 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6540c8f5-821c-412a-807a-c3ef62138fbb")
+	)
+	(junction
+		(at 63.5 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "65600a9a-e392-4668-8020-aa25d35ebf98")
+	)
+	(junction
+		(at 104.14 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "65f27e9a-164b-490a-b847-29af22012c0c")
+	)
+	(junction
+		(at 63.5 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "670a793c-4c48-41d1-9f07-66b1d7d84b06")
+	)
+	(junction
+		(at 83.82 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "672e2ce9-8f2c-43ff-9498-0e342bc1c65e")
+	)
+	(junction
+		(at 246.38 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "67489099-7e87-45d2-97ff-6d98a41edce4")
+	)
+	(junction
+		(at 175.26 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "69e63d66-faab-411c-9093-a81235a7547c")
+	)
+	(junction
+		(at 134.62 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6a52e2bd-c4f2-4694-96d3-9fbd895ea66f")
+	)
+	(junction
+		(at 63.5 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6b0b87a9-8a81-4bd1-ac24-ffcd6512236b")
+	)
+	(junction
+		(at 43.18 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6bfc7531-8adc-4c87-bf8a-788404262765")
+	)
+	(junction
+		(at 134.62 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1")
+	)
+	(junction
+		(at 154.94 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6ff7fc69-ca50-4b66-851e-eb36da3cadd8")
+	)
+	(junction
+		(at 63.5 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "712da204-b8e1-4637-b967-521ccf7b108c")
+	)
+	(junction
+		(at 246.38 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71a71501-1b26-4915-93b4-96a7dee3a44f")
+	)
+	(junction
+		(at 73.66 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71e77471-d824-448e-a6de-31cce05e17c2")
+	)
+	(junction
+		(at 205.74 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "72e4e912-d3a6-49dd-a5cd-3717c5b10d71")
+	)
+	(junction
+		(at 73.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "742ecb41-f257-40d3-a6f3-d155d6036628")
+	)
+	(junction
+		(at 154.94 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "74eb0a18-3ddb-4ea4-a352-4c8a041470e2")
+	)
+	(junction
+		(at 53.34 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7710d08c-fec8-48ed-9536-82f00f1cfc8b")
+	)
+	(junction
+		(at 226.06 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77bb30a6-a1de-4dd1-a9f1-aff61d4e98ac")
+	)
+	(junction
+		(at 93.98 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "782ee96d-a257-4c78-ac0f-a3b5279bef37")
+	)
+	(junction
+		(at 53.34 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7943e9ed-5e22-49d3-a238-47d875f3e823")
+	)
+	(junction
+		(at 236.22 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "79f1a6f6-1219-460c-9c15-e032107323da")
+	)
+	(junction
+		(at 43.18 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7dbcae2f-e000-4aff-92b3-5518ea113182")
+	)
+	(junction
+		(at 246.38 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7e1e558a-0687-4da1-890d-e5b08d32906f")
+	)
+	(junction
+		(at 236.22 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "802959db-8c82-47e0-a5cd-84de44b3e860")
+	)
+	(junction
+		(at 236.22 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "81204729-3be0-4723-b09e-5baeace0ae6e")
+	)
+	(junction
+		(at 104.14 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "822096c9-a5b4-460b-8639-9bbf1bb1a2fa")
+	)
+	(junction
+		(at 93.98 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84442e81-a253-49f6-ab0f-8ece0b39f637")
+	)
+	(junction
+		(at 53.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "86d88f2b-6e5b-493a-b3a4-5436a8374fae")
+	)
+	(junction
+		(at 246.38 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "882f2a13-7075-40af-8a18-844f6b92a1f3")
+	)
+	(junction
+		(at 104.14 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "88441b0d-9a40-4e18-8fc9-814cc1cb4d3e")
+	)
+	(junction
+		(at 185.42 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8a6c81db-4db5-4eb7-a06a-31575c90f62f")
+	)
+	(junction
+		(at 83.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bf191a4-2dcd-4018-b67a-91aef9fad846")
+	)
+	(junction
+		(at 93.98 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d0975e0-03e3-4038-81bb-699f429e5e7b")
+	)
+	(junction
+		(at 144.78 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d88bb99-f0e4-4a81-b464-31814877675a")
+	)
+	(junction
+		(at 195.58 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8de5a888-7283-4e9f-99ef-73d74bb27108")
+	)
+	(junction
+		(at 246.38 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8eb3e5bb-f2c3-42a2-a6bc-5eddd7433f5d")
+	)
+	(junction
+		(at 205.74 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "90d2cc8f-50ae-48a5-81ff-9df8ee53f514")
+	)
+	(junction
+		(at 215.9 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "90dd44b9-9dd3-4690-8a0a-64e100872339")
+	)
+	(junction
+		(at 205.74 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "91635678-4449-4ed4-88c1-10b19deef1b0")
+	)
+	(junction
+		(at 266.7 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95b0c111-7d27-49ee-a08f-b6f35d9d5b54")
+	)
+	(junction
+		(at 236.22 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96160b01-68f8-4d57-83d8-bf1fa6b0ffdd")
+	)
+	(junction
+		(at 93.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96a12dd2-d02f-4a86-aa6d-3a7015c06462")
+	)
+	(junction
+		(at 195.58 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "98319cb9-c3ce-4829-b82f-df8af9cb7381")
+	)
+	(junction
+		(at 134.62 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99c67f58-7bde-4417-a08c-823e6af847f2")
+	)
+	(junction
+		(at 93.98 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9a57387e-9b4d-41d6-99cb-8b5046a4210a")
+	)
+	(junction
+		(at 63.5 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9c5d2aae-598c-438e-b7da-ebb8546ddaff")
+	)
+	(junction
+		(at 195.58 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9cbabbae-21a8-4838-be56-56e992e4b864")
+	)
+	(junction
+		(at 124.46 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9d2b0f02-b19d-4907-8835-9e7f8a8b9c34")
+	)
+	(junction
+		(at 226.06 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9e2bd5cb-7b23-4384-a3c5-2d4acf752984")
+	)
+	(junction
+		(at 215.9 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a2c3f4db-e97d-4584-bc55-22a1f47c7221")
+	)
+	(junction
+		(at 93.98 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a2db7df7-b835-49df-98be-3c291238016c")
+	)
+	(junction
+		(at 185.42 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a3593416-7fea-415d-a48b-ed5f49c771b2")
+	)
+	(junction
+		(at 114.3 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a47737c8-d0f1-4d7f-a269-cdad9b41d18b")
+	)
+	(junction
+		(at 246.38 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a52ed26a-ac7f-4cb2-a1c7-12172b24c4ab")
+	)
+	(junction
+		(at 185.42 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a63b450e-8bb6-4430-a1a8-c471d275241a")
+	)
+	(junction
+		(at 63.5 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a6cd881c-1146-4d92-9184-bf83a80c20c4")
+	)
+	(junction
+		(at 165.1 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a7400bf6-86c3-4d41-886e-57235a457a4c")
+	)
+	(junction
+		(at 165.1 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9baaad2-c62c-4b79-a10b-261651ef4961")
+	)
+	(junction
+		(at 266.7 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9ece8f4-f868-428b-b7ff-a3dc07b47d6c")
+	)
+	(junction
+		(at 144.78 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aa4f9edb-d8b6-45e2-8d16-270f3c9fc990")
+	)
+	(junction
+		(at 104.14 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ab0811a2-347a-4a90-b4d0-f1b1ba038333")
+	)
+	(junction
+		(at 195.58 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ac27d187-5d39-4e20-a98d-006d06095529")
+	)
+	(junction
+		(at 226.06 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ac7cf2c1-f0eb-4f3a-bdfc-60426aa052ac")
+	)
+	(junction
+		(at 63.5 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ace95043-3b32-415f-8735-1487cbd49332")
+	)
+	(junction
+		(at 124.46 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b1e2ebf4-6a50-4b42-af1b-0294cfee2751")
+	)
+	(junction
+		(at 83.82 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b23bc3a0-3ebe-44a5-9126-8b5c4d648e08")
+	)
+	(junction
+		(at 205.74 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b3d0ee10-bd96-4305-9675-c2f1f7a7662b")
+	)
+	(junction
+		(at 114.3 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b5ce3eda-e357-44e1-9c69-f84009fc7a87")
+	)
+	(junction
+		(at 154.94 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b7093823-b63a-4a1a-b279-5afe0127ec9d")
+	)
+	(junction
+		(at 266.7 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b98759bc-77be-4dce-9aa2-cc5ce3889034")
+	)
+	(junction
+		(at 154.94 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b995f4ca-5e8d-4350-aff6-b7bea568d7f5")
+	)
+	(junction
+		(at 53.34 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3")
+	)
+	(junction
+		(at 205.74 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb9843d1-ea35-45a8-bd3d-5b381b0dc875")
+	)
+	(junction
+		(at 175.26 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bbd2fe65-aac5-437c-9177-9832921486d5")
+	)
+	(junction
+		(at 175.26 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bcf6a98c-2d79-4afb-9a5e-6558bb743cec")
+	)
+	(junction
+		(at 226.06 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bdaa210f-5df4-43b3-b2cb-9563b1c2f196")
+	)
+	(junction
+		(at 154.94 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be75ea2d-b3b9-4fd0-812b-104329fac661")
+	)
+	(junction
+		(at 144.78 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "befc6138-873b-4406-bc9e-e5a72f7f36fe")
+	)
+	(junction
+		(at 175.26 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf44b855-bf79-4ceb-a9a9-021d72c7f67c")
+	)
+	(junction
+		(at 83.82 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0")
+	)
+	(junction
+		(at 83.82 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c179a6f6-d6cf-4784-b7f0-70633ed08609")
+	)
+	(junction
+		(at 134.62 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c29c26fc-c285-45ba-9e88-4c2a02375307")
+	)
+	(junction
+		(at 165.1 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c331d35d-23c9-43ea-b243-b660cb5f4bdb")
+	)
+	(junction
+		(at 134.62 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c3f1775c-0d63-41d3-b7d8-a4c96d241ce3")
+	)
+	(junction
+		(at 93.98 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c41e97f8-87c8-4e82-92ed-e4644d6f526e")
+	)
+	(junction
+		(at 236.22 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c4319a07-1f8f-4ae0-928a-04e03c76b2be")
+	)
+	(junction
+		(at 124.46 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c51de65b-dd06-4a71-8763-eab77eba6638")
+	)
+	(junction
+		(at 266.7 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c56d20e0-377b-42bf-89fc-25b698ca10b4")
+	)
+	(junction
+		(at 114.3 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c5afc93c-0846-4cf9-8f93-4c8f2232c9fa")
+	)
+	(junction
+		(at 83.82 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c7d88142-1b7e-4dd1-b026-f2267e06dab1")
+	)
+	(junction
+		(at 43.18 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8f222f6-943e-4d7d-919b-3278ca0ede33")
+	)
+	(junction
+		(at 195.58 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c9e3ffd4-a7b6-4729-8189-cdaba274ef13")
+	)
+	(junction
+		(at 144.78 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc2d9922-84c9-42ce-883b-c028a251c101")
+	)
+	(junction
+		(at 266.7 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc477f6c-44d3-44d1-b104-0f5c17b8e6fa")
+	)
+	(junction
+		(at 124.46 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cd054c4e-f9d4-4701-a538-16740432e58d")
+	)
+	(junction
+		(at 226.06 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cd48bbd4-ca90-4b55-bc6b-cf9da8cf6333")
+	)
+	(junction
+		(at 195.58 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cf841124-1985-4dfd-858c-868589098888")
+	)
+	(junction
+		(at 63.5 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cfd86ddc-0810-4057-8a79-4468ec7b2424")
+	)
+	(junction
+		(at 205.74 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d07b66d1-3d51-4607-8fd1-974bbf8f9371")
+	)
+	(junction
+		(at 53.34 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d328f077-6d93-4470-a2b2-f4c9287daff0")
+	)
+	(junction
+		(at 205.74 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d3f7612d-781e-42f5-a5f0-fe2744aa5d60")
+	)
+	(junction
+		(at 144.78 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d4ac21a4-2c41-454b-9f76-4f3d030f7ac8")
+	)
+	(junction
+		(at 83.82 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5a179bd-82b1-4661-aebc-4c4d4801bdff")
+	)
+	(junction
+		(at 144.78 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b7ef4f-419a-421c-a02d-fd71016e6c97")
+	)
+	(junction
+		(at 154.94 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d774ae68-7d44-45a8-babf-4a5136fe82a1")
+	)
+	(junction
+		(at 236.22 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d82f4811-d69b-4b67-86ec-58dc2b09efce")
+	)
+	(junction
+		(at 185.42 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d8d69513-50ec-441c-a953-5a6c226b729f")
+	)
+	(junction
+		(at 236.22 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d9d8d322-c1a6-4620-97f8-79c4d7399c0b")
+	)
+	(junction
+		(at 226.06 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dc26fb26-3b4c-4f5f-8838-a826029b5e11")
+	)
+	(junction
+		(at 195.58 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dc8b09d2-1c55-4758-be69-6f8072d6abe0")
+	)
+	(junction
+		(at 114.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcab5abe-0f5a-44d8-b554-722164ca6a23")
+	)
+	(junction
+		(at 154.94 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dded6bb5-453a-4491-9278-65d2368e4bc0")
+	)
+	(junction
+		(at 93.98 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dece07f3-2868-47c6-b119-0ca286e7cc50")
+	)
+	(junction
+		(at 215.9 251.46)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e1ae70a8-71e4-4b07-b504-14219374e1fa")
+	)
+	(junction
+		(at 236.22 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e3118c0a-3d75-4cb1-a7c3-cdeb1c9e52bc")
+	)
+	(junction
+		(at 165.1 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e3259dd4-fd6c-4d03-8afb-b6f306558bb6")
+	)
+	(junction
+		(at 175.26 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e3827bb6-d8e8-410a-8c19-3e64c8191b94")
+	)
+	(junction
+		(at 215.9 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e4337269-24a1-47d0-90ce-0190655362a9")
+	)
+	(junction
+		(at 154.94 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e46432a2-96f1-448e-8928-bfcbbf445ca9")
+	)
+	(junction
+		(at 175.26 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e66342f0-16d5-4367-b00a-d7cf257720d9")
+	)
+	(junction
+		(at 226.06 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e7e968af-bf0e-4847-a623-74d007921b9f")
+	)
+	(junction
+		(at 165.1 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ed20875e-b9a5-4926-97e0-c3921a5eb1cd")
+	)
+	(junction
+		(at 215.9 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ed60b040-01a3-47a4-9e4e-0093442edfae")
+	)
+	(junction
+		(at 114.3 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee17efa1-5df9-47d0-aec2-a440d8b33e4c")
+	)
+	(junction
+		(at 104.14 182.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f0d84c95-52f0-41cd-8742-4de83021f783")
+	)
+	(junction
+		(at 134.62 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f1379b2f-59c4-4b61-a98f-3645b6e5fe6b")
+	)
+	(junction
+		(at 104.14 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f24e6016-cf0c-4fe9-b584-ca06dfdbe767")
+	)
+	(junction
+		(at 134.62 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f299a1cc-612f-4d6b-9276-fe837e4e91d9")
+	)
+	(junction
+		(at 134.62 210.82)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f368e14e-0af5-4e13-a581-f1a139c24e5c")
+	)
+	(junction
+		(at 226.06 223.52)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f46f02fc-54c8-4580-bd05-1da63b3c8bbc")
+	)
+	(junction
+		(at 43.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6f817c6-438a-4497-93b1-8dc1f36a395c")
+	)
+	(junction
+		(at 226.06 203.2)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f70d9535-4e8c-4a08-92e9-2c160ff79eff")
+	)
+	(junction
+		(at 53.34 231.14)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f7606fcd-7602-4f5d-b31b-5fb97e1ca534")
+	)
+	(junction
+		(at 124.46 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd")
+	)
+	(junction
+		(at 144.78 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8b3b54a-7c03-49e4-8762-b4ef31db5afd")
+	)
+	(junction
+		(at 266.7 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa2795fd-0138-4010-b310-3d5e73c1be1c")
+	)
+	(junction
+		(at 195.58 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fb315348-48a4-4210-8623-991734f6ee66")
+	)
+	(junction
+		(at 73.66 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbda2010-a213-45bb-958d-0c9446d51e42")
+	)
+	(junction
+		(at 73.66 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc393c80-fb90-44e5-ac86-763463fd8acd")
+	)
+	(junction
+		(at 114.3 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc6abd7a-92c0-4b05-85ed-b3bd910676e1")
+	)
+	(junction
+		(at 144.78 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdc0071f-cdad-424a-87db-7bd8a0569159")
+	)
+	(junction
+		(at 236.22 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fe54d4f8-4808-4257-a695-1a4bbd144566")
+	)
+	(wire
+		(pts
+			(xy 83.82 60.96) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022d84d0-7bcb-4024-8618-6f3a7f7b41aa")
+	)
+	(wire
+		(pts
+			(xy 144.78 25.4) (xy 144.78 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0406a358-3219-4537-99c7-cfb994e5303c")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0429bfe1-2992-4c6f-bb22-b2e8e5724910")
+	)
+	(wire
+		(pts
+			(xy 215.9 129.54) (xy 236.22 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "04b771e3-dd4b-454d-b08d-2ba0a456c1cb")
+	)
+	(wire
+		(pts
+			(xy 205.74 182.88) (xy 205.74 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "04f743f4-6844-43ab-a149-4db3a42e61b3")
+	)
+	(wire
+		(pts
+			(xy 185.42 203.2) (xy 185.42 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "054d0701-89e5-4918-a35c-1668152b63f2")
+	)
+	(wire
+		(pts
+			(xy 236.22 129.54) (xy 259.08 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "065b1c3f-f9a5-4c91-b47a-16d2b0f4b78c")
+	)
+	(wire
+		(pts
+			(xy 205.74 203.2) (xy 205.74 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0698b251-ec3b-4a4c-821a-adad423d20ba")
+	)
+	(wire
+		(pts
+			(xy 63.5 60.96) (xy 63.5 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06b94062-ab90-4776-acd7-64603720a270")
+	)
+	(wire
+		(pts
+			(xy 185.42 162.56) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "070c607f-224b-4963-a847-a5abbe4e2e9d")
+	)
+	(wire
+		(pts
+			(xy 73.66 109.22) (xy 93.98 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07ee4d30-e80a-41ae-829d-e3cecf87d77e")
+	)
+	(wire
+		(pts
+			(xy 226.06 81.28) (xy 226.06 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0805b235-8597-4158-8971-28b691867ce0")
+	)
+	(wire
+		(pts
+			(xy 114.3 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0897e94f-d1e3-47ff-89f6-5de7a1349783")
+	)
+	(wire
+		(pts
+			(xy 226.06 182.88) (xy 226.06 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "08999926-6e91-4cd1-80de-7963ec46f28b")
+	)
+	(wire
+		(pts
+			(xy 246.38 121.92) (xy 246.38 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0909471f-383c-4975-9a61-5008689e9193")
+	)
+	(wire
+		(pts
+			(xy 175.26 109.22) (xy 195.58 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0a962d83-8897-42a2-883b-90f8b3b46e9e")
+	)
+	(wire
+		(pts
+			(xy 266.7 68.58) (xy 266.7 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aee33c0-3781-43dc-99cb-690f399192cd")
+	)
+	(wire
+		(pts
+			(xy 154.94 48.26) (xy 175.26 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b08be29-0149-48a5-b5a3-9614befb1784")
+	)
+	(wire
+		(pts
+			(xy 266.7 231.14) (xy 266.7 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b495840-7c14-4d0f-aea8-1a6a34972054")
+	)
+	(wire
+		(pts
+			(xy 195.58 203.2) (xy 205.74 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0bbfe73f-3f00-4157-8def-4fa012c6902e")
+	)
+	(wire
+		(pts
+			(xy 53.34 231.14) (xy 73.66 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0cfcf878-b8da-4ac7-be72-6319dfc721fd")
+	)
+	(wire
+		(pts
+			(xy 43.18 182.88) (xy 43.18 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e0cdb3f-d11e-41fa-b224-dbdc3dd27130")
+	)
+	(wire
+		(pts
+			(xy 43.18 40.64) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f76c070-bcf8-4924-a8c5-3abe13c36f41")
+	)
+	(wire
+		(pts
+			(xy 63.5 81.28) (xy 63.5 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ef6261-91ba-4d4c-99ef-8991b7c91dc8")
+	)
+	(wire
+		(pts
+			(xy 104.14 101.6) (xy 104.14 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12080e73-a151-4804-ac9b-ac3ac13653e9")
+	)
+	(wire
+		(pts
+			(xy 73.66 48.26) (xy 93.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12a939e2-2ab8-4d74-a5c9-6d61a9528b6e")
+	)
+	(wire
+		(pts
+			(xy 63.5 182.88) (xy 63.5 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "13961bb6-28aa-4ee0-a270-8bc7b0339a4b")
+	)
+	(wire
+		(pts
+			(xy 154.94 68.58) (xy 175.26 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "14d9635b-ccaf-4f8c-a2a6-101eb19eb42d")
+	)
+	(wire
+		(pts
+			(xy 134.62 210.82) (xy 154.94 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "150130ef-d28d-4782-b4fc-0c67b58e9b8e")
+	)
+	(wire
+		(pts
+			(xy 93.98 190.5) (xy 114.3 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1767f007-bd12-458a-9e69-f01cc8a5ed24")
+	)
+	(wire
+		(pts
+			(xy 246.38 203.2) (xy 246.38 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1822529b-8f09-4adb-aaae-0504083bb89e")
+	)
+	(wire
+		(pts
+			(xy 205.74 142.24) (xy 205.74 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "18ccb399-8ad2-4b42-b317-de1e9939e9e9")
+	)
+	(wire
+		(pts
+			(xy 104.14 25.4) (xy 104.14 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af5b449-9a68-414b-a41f-d6f6cba715a8")
+	)
+	(wire
+		(pts
+			(xy 165.1 203.2) (xy 165.1 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1bc4e1a4-fd5a-4e45-a9b9-9fd07d45de91")
+	)
+	(wire
+		(pts
+			(xy 73.66 81.28) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0140d1-6775-49db-9fd5-7ecf63ae1284")
+	)
+	(wire
+		(pts
+			(xy 205.74 223.52) (xy 205.74 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1f10ac4d-394d-4f34-a8e8-91d9d3ca5fd5")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "211f763f-7ef6-4fb5-98df-2e2ff37faa42")
+	)
+	(wire
+		(pts
+			(xy 236.22 68.58) (xy 259.08 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23d9c8d8-62ef-48ef-a21d-8c042f11ec2f")
+	)
+	(wire
+		(pts
+			(xy 63.5 40.64) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23f46f84-f16d-4b0b-b463-c2c0244adcc0")
+	)
+	(wire
+		(pts
+			(xy 83.82 203.2) (xy 83.82 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24025a56-ae5c-4c1a-a354-e66bbbcc4688")
+	)
+	(wire
+		(pts
+			(xy 33.02 129.54) (xy 53.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24da3fea-844d-4666-b730-f8d7b708f242")
+	)
+	(wire
+		(pts
+			(xy 185.42 40.64) (xy 185.42 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "265c8115-55ea-4d09-95c1-3178314bfa04")
+	)
+	(wire
+		(pts
+			(xy 53.34 129.54) (xy 73.66 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26f78b89-ba4b-4b48-90d1-1245694ead6f")
+	)
+	(wire
+		(pts
+			(xy 83.82 162.56) (xy 83.82 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2703e5ce-9651-45e1-8bd6-144e60387b78")
+	)
+	(wire
+		(pts
+			(xy 215.9 88.9) (xy 236.22 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "271ac63e-22d2-4815-976d-7e67fdaefe83")
+	)
+	(wire
+		(pts
+			(xy 33.02 109.22) (xy 53.34 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2832f642-62e7-4a51-b112-f728658e7714")
+	)
+	(wire
+		(pts
+			(xy 195.58 68.58) (xy 215.9 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "28f7b63d-6686-4459-afe8-f6dd162a4f81")
+	)
+	(wire
+		(pts
+			(xy 53.34 68.58) (xy 73.66 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29a0e612-9a4c-422c-a9b8-8a9fe3879b8a")
+	)
+	(wire
+		(pts
+			(xy 83.82 101.6) (xy 83.82 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a44e441-f6d5-4994-b7ba-34283a1facc7")
+	)
+	(wire
+		(pts
+			(xy 124.46 121.92) (xy 124.46 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0")
+	)
+	(wire
+		(pts
+			(xy 53.34 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a62b555-17b9-46f9-8a2e-f1db0d1e286c")
+	)
+	(wire
+		(pts
+			(xy 114.3 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a65926a-d988-49f6-92e7-6e4d5936462f")
+	)
+	(wire
+		(pts
+			(xy 195.58 170.18) (xy 215.9 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ada3dc7-0276-4fb5-993b-c6f072f33b85")
+	)
+	(wire
+		(pts
+			(xy 165.1 162.56) (xy 165.1 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2afd7500-0a15-4710-acc0-4f03472785c3")
+	)
+	(wire
+		(pts
+			(xy 165.1 60.96) (xy 165.1 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b8c9def-eaec-4abd-b08a-c3613e6389df")
+	)
+	(wire
+		(pts
+			(xy 53.34 109.22) (xy 73.66 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd")
+	)
+	(wire
+		(pts
+			(xy 195.58 48.26) (xy 215.9 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2eb5b021-cd36-4ec2-99b5-3504f408e676")
+	)
+	(wire
+		(pts
+			(xy 124.46 25.4) (xy 124.46 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3115f7a7-e786-49c1-9e4c-25c171cfeb33")
+	)
+	(wire
+		(pts
+			(xy 73.66 68.58) (xy 93.98 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3197b37c-ee5b-406a-ab67-08670d4b8c09")
+	)
+	(wire
+		(pts
+			(xy 215.9 223.52) (xy 226.06 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "331adf6b-edc7-41b1-8701-a50d3af94787")
+	)
+	(wire
+		(pts
+			(xy 165.1 182.88) (xy 165.1 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "335e6f69-208d-4946-a709-07b34240cbfe")
+	)
+	(wire
+		(pts
+			(xy 63.5 223.52) (xy 63.5 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34351d11-022e-4b57-b2c7-81036e999059")
+	)
+	(wire
+		(pts
+			(xy 185.42 223.52) (xy 185.42 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34a6214b-f3a2-4b07-8c59-5326fa1f0444")
+	)
+	(wire
+		(pts
+			(xy 175.26 231.14) (xy 195.58 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "34d9b895-8709-4ae3-8234-e9c042dd7992")
+	)
+	(wire
+		(pts
+			(xy 154.94 88.9) (xy 175.26 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35f5724f-e5dd-4205-b169-9ef9f7b3efa2")
+	)
+	(wire
+		(pts
+			(xy 236.22 48.26) (xy 259.08 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "379018e3-d7a0-42c0-abbf-14d4c107728d")
+	)
+	(wire
+		(pts
+			(xy 266.7 210.82) (xy 266.7 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a9fab7b-7f53-4445-b1a0-755685a5b87b")
+	)
+	(wire
+		(pts
+			(xy 134.62 68.58) (xy 154.94 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b15c81d-3687-4710-9aa6-d57ee4885603")
+	)
+	(wire
+		(pts
+			(xy 63.5 121.92) (xy 63.5 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5")
+	)
+	(wire
+		(pts
+			(xy 134.62 251.46) (xy 154.94 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3bdb9bc8-9458-4811-8b47-c38bf9331962")
+	)
+	(wire
+		(pts
+			(xy 114.3 190.5) (xy 134.62 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb")
+	)
+	(wire
+		(pts
+			(xy 195.58 109.22) (xy 215.9 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3d4e19e8-2fb5-4e22-930a-612c1a48f37c")
+	)
+	(wire
+		(pts
+			(xy 226.06 25.4) (xy 226.06 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3e8a4dda-891b-4819-a0ec-6d09bab41776")
+	)
+	(wire
+		(pts
+			(xy 43.18 223.52) (xy 43.18 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f02d1c4-e975-4454-aaaf-b01003921ce8")
+	)
+	(wire
+		(pts
+			(xy 154.94 231.14) (xy 175.26 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f7461c6-c2c3-4fe0-b1c0-d702c7e88622")
+	)
+	(wire
+		(pts
+			(xy 226.06 60.96) (xy 226.06 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40278c5a-7892-4426-82ce-3b5f75d33db8")
+	)
+	(wire
+		(pts
+			(xy 73.66 170.18) (xy 93.98 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40ad23e4-b284-4d51-a92e-26a2272af251")
+	)
+	(wire
+		(pts
+			(xy 165.1 121.92) (xy 165.1 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "411efa8a-c2b6-469e-b517-3b3f24ffe025")
+	)
+	(wire
+		(pts
+			(xy 73.66 190.5) (xy 93.98 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "432577d5-87d0-4924-a72a-e407dd2ee4b0")
+	)
+	(wire
+		(pts
+			(xy 134.62 170.18) (xy 154.94 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44b0d7a3-542f-48ea-8a2f-25ca02bd7f05")
+	)
+	(wire
+		(pts
+			(xy 53.34 170.18) (xy 73.66 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4554fe48-1b8d-466c-b3f4-c87fb3d79947")
+	)
+	(wire
+		(pts
+			(xy 43.18 60.96) (xy 43.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456f0365-d37d-43a2-afac-d06c44cc48af")
+	)
+	(wire
+		(pts
+			(xy 154.94 129.54) (xy 175.26 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "462b3865-9668-49d6-a9d9-1406a843104e")
+	)
+	(wire
+		(pts
+			(xy 215.9 48.26) (xy 236.22 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4666d04a-04e6-40ed-be2c-4247995ce902")
+	)
+	(wire
+		(pts
+			(xy 114.3 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "473d672b-6459-459b-93fc-780e5d8f9818")
+	)
+	(wire
+		(pts
+			(xy 226.06 121.92) (xy 226.06 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4905f532-fc39-4175-9bc0-d3b0b2aab86e")
+	)
+	(wire
+		(pts
+			(xy 124.46 81.28) (xy 124.46 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "495f9334-ca7f-4aa5-8d75-09576f1afa2c")
+	)
+	(wire
+		(pts
+			(xy 104.14 182.88) (xy 104.14 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4bc89a8f-f8d9-4d47-a286-fb87f34a3ba1")
+	)
+	(wire
+		(pts
+			(xy 215.9 149.86) (xy 236.22 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c0ce08b-4ec4-4aec-a724-210098f01260")
+	)
+	(wire
+		(pts
+			(xy 63.5 203.2) (xy 63.5 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d757dc1-e039-4666-8204-33ddd2c3d535")
+	)
+	(wire
+		(pts
+			(xy 73.66 251.46) (xy 93.98 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50546e55-dd78-410b-802d-e2e542a3aeb8")
+	)
+	(wire
+		(pts
+			(xy 165.1 81.28) (xy 165.1 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f7b113-f5f8-43e0-9da7-2a02dc224210")
+	)
+	(wire
+		(pts
+			(xy 266.7 190.5) (xy 266.7 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5194f352-1f61-4ee5-af2e-f0eb341e3d13")
+	)
+	(wire
+		(pts
+			(xy 226.06 162.56) (xy 226.06 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "530fd8d7-df39-43ed-b05c-34496eb7d3a1")
+	)
+	(wire
+		(pts
+			(xy 215.9 190.5) (xy 236.22 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "54aeade9-047f-465a-b676-344776802b0f")
+	)
+	(wire
+		(pts
+			(xy 33.02 190.5) (xy 53.34 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55243e41-6164-4661-b707-a6f503f12968")
+	)
+	(wire
+		(pts
+			(xy 53.34 190.5) (xy 73.66 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "557847f5-42a8-4c4a-a4d9-d21678c28920")
+	)
+	(wire
+		(pts
+			(xy 236.22 210.82) (xy 259.08 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55c45ac0-23c6-495d-9bfd-1e1f6c945956")
+	)
+	(wire
+		(pts
+			(xy 104.14 60.96) (xy 104.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5837ecd4-cf70-4c14-9c7b-bb5f05f8274a")
+	)
+	(wire
+		(pts
+			(xy 93.98 231.14) (xy 114.3 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "59384b6c-2072-4474-b0f7-71a68de7f080")
+	)
+	(wire
+		(pts
+			(xy 104.14 81.28) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6ae0de-21c8-4433-a4e0-a3b552474fb0")
+	)
+	(wire
+		(pts
+			(xy 154.94 190.5) (xy 175.26 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5baecb37-4d65-4174-bd66-a5145576e2b9")
+	)
+	(wire
+		(pts
+			(xy 154.94 149.86) (xy 175.26 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5bf40b1a-0569-4c54-9cc9-b9bf89658c72")
+	)
+	(wire
+		(pts
+			(xy 215.9 170.18) (xy 236.22 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d453d03-4d0f-4be1-b096-6496e136bcf8")
+	)
+	(wire
+		(pts
+			(xy 134.62 48.26) (xy 154.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d63c1a3-5086-42ca-8afa-60afe2472b23")
+	)
+	(wire
+		(pts
+			(xy 246.38 142.24) (xy 246.38 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ead2e45-47c8-46fa-90d4-a4246ed8dc04")
+	)
+	(wire
+		(pts
+			(xy 93.98 210.82) (xy 114.3 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f73184b-d2cf-4b7b-afcf-f14e002f7ce1")
+	)
+	(wire
+		(pts
+			(xy 236.22 231.14) (xy 259.08 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ffd8e81-92ad-4f1f-939a-305b07eaf56b")
+	)
+	(wire
+		(pts
+			(xy 53.34 88.9) (xy 73.66 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b5d548-d07f-40b1-8e16-72d513f499f2")
+	)
+	(wire
+		(pts
+			(xy 124.46 203.2) (xy 124.46 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62806607-b508-4eb1-86e9-30fc018db27c")
+	)
+	(wire
+		(pts
+			(xy 33.02 210.82) (xy 53.34 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6329f5e0-c3e3-42c6-b639-2bebe7a40e8b")
+	)
+	(wire
+		(pts
+			(xy 195.58 210.82) (xy 215.9 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "63344b6a-026f-4395-b562-d9979a7e5b8f")
+	)
+	(wire
+		(pts
+			(xy 93.98 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6414e19f-a27a-435d-a47f-a63cba9086f1")
+	)
+	(wire
+		(pts
+			(xy 134.62 109.22) (xy 154.94 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64344100-c91d-4b5c-a8eb-9406d47360dd")
+	)
+	(wire
+		(pts
+			(xy 154.94 109.22) (xy 175.26 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "650e246e-9637-4cff-aa82-0f918369ac6f")
+	)
+	(wire
+		(pts
+			(xy 165.1 223.52) (xy 165.1 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "661899e2-86b7-446b-a2a9-e69172119b47")
+	)
+	(wire
+		(pts
+			(xy 144.78 223.52) (xy 144.78 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "66fa373c-afc7-4261-a808-153f4c2367ba")
+	)
+	(wire
+		(pts
+			(xy 33.02 68.58) (xy 53.34 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68161b0c-a285-475d-a645-59648d12bc07")
+	)
+	(wire
+		(pts
+			(xy 134.62 149.86) (xy 154.94 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690a405c-1ac3-4b57-a93b-778dda168d2c")
+	)
+	(wire
+		(pts
+			(xy 134.62 190.5) (xy 154.94 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b21e6c7-ab97-41de-aae4-339e943db88e")
+	)
+	(wire
+		(pts
+			(xy 134.62 231.14) (xy 154.94 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b5263f0-0631-4b01-9161-0e209326bf8d")
+	)
+	(wire
+		(pts
+			(xy 165.1 40.64) (xy 165.1 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc")
+	)
+	(wire
+		(pts
+			(xy 114.3 251.46) (xy 134.62 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6dd9cb59-fa4c-43ef-b035-62559ec6a185")
+	)
+	(wire
+		(pts
+			(xy 195.58 129.54) (xy 215.9 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6de11233-64b7-40cd-8526-970a6c43cb30")
+	)
+	(wire
+		(pts
+			(xy 246.38 60.96) (xy 246.38 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6e16ce81-dfc9-4083-ad2c-ab9c4532be39")
+	)
+	(wire
+		(pts
+			(xy 205.74 40.64) (xy 205.74 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f1d74d1-18f8-4f5b-8c5d-e1587ab09b83")
+	)
+	(wire
+		(pts
+			(xy 266.7 149.86) (xy 266.7 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f77a68c-1e32-433a-820e-9683e6fd5e12")
+	)
+	(wire
+		(pts
+			(xy 205.74 162.56) (xy 205.74 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7083b47b-e7bb-4169-bf41-06719234452e")
+	)
+	(wire
+		(pts
+			(xy 266.7 88.9) (xy 266.7 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70c6e975-f457-4759-9791-1d1de45afbb3")
+	)
+	(wire
+		(pts
+			(xy 134.62 129.54) (xy 154.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70f3f37d-4259-413e-b59a-babccfdc3a89")
+	)
+	(wire
+		(pts
+			(xy 43.18 121.92) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "727cc522-ef34-45d4-b711-997054ff0b37")
+	)
+	(wire
+		(pts
+			(xy 33.02 48.26) (xy 53.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "737596e8-f579-4b1f-aa71-a489d8ba56da")
+	)
+	(wire
+		(pts
+			(xy 93.98 149.86) (xy 114.3 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "770cc50c-0085-42e2-b068-cd0ae3b59919")
+	)
+	(wire
+		(pts
+			(xy 266.7 25.4) (xy 266.7 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "794205f1-2f7e-4200-b59c-c02481b0416f")
+	)
+	(wire
+		(pts
+			(xy 73.66 88.9) (xy 93.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79a42c80-d7a4-4e03-9070-f9fff835a239")
+	)
+	(wire
+		(pts
+			(xy 33.02 40.64) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a4231d0-fb4b-4c65-9cc1-75d3ed714150")
+	)
+	(wire
+		(pts
+			(xy 195.58 88.9) (xy 215.9 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7c26a162-db98-4260-be20-c438c861d890")
+	)
+	(wire
+		(pts
+			(xy 185.42 142.24) (xy 185.42 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7caa1de0-1c5d-4933-9515-38159a29c856")
+	)
+	(wire
+		(pts
+			(xy 236.22 251.46) (xy 259.08 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8296ef34-62aa-49fd-9583-d43eff4a9c61")
+	)
+	(wire
+		(pts
+			(xy 236.22 88.9) (xy 259.08 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "841d8f67-3e67-46e5-8955-042c5899dc70")
+	)
+	(wire
+		(pts
+			(xy 104.14 203.2) (xy 104.14 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8487a4c1-7c32-44ea-a841-69a619e14d61")
+	)
+	(wire
+		(pts
+			(xy 165.1 25.4) (xy 165.1 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8506f273-12d6-426d-910b-0c9eecbe3765")
+	)
+	(wire
+		(pts
+			(xy 134.62 88.9) (xy 154.94 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86d6e974-6898-4932-91cb-e8a4c4c283b7")
+	)
+	(wire
+		(pts
+			(xy 93.98 251.46) (xy 114.3 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8a13c872-e78a-41c8-b365-f6f2f0595fb7")
+	)
+	(wire
+		(pts
+			(xy 215.9 210.82) (xy 236.22 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ab98883-52fd-4210-a5b1-42a74e144026")
+	)
+	(wire
+		(pts
+			(xy 104.14 162.56) (xy 104.14 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c3cf446-d0cc-4b1b-9218-75f38db02fb3")
+	)
+	(wire
+		(pts
+			(xy 53.34 210.82) (xy 73.66 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d25f923-67ff-47ea-9485-05bc5282bdab")
+	)
+	(wire
+		(pts
+			(xy 93.98 48.26) (xy 114.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d73bae8-988b-435b-a882-ae9668b41d7e")
+	)
+	(wire
+		(pts
+			(xy 104.14 142.24) (xy 104.14 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dd624a1-3da3-42c1-929d-9366cd043e3d")
+	)
+	(wire
+		(pts
+			(xy 266.7 48.26) (xy 266.7 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f339462-56e0-4361-9d9b-983c75fb21ef")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "909384ab-bc1c-47d8-a34d-c3d137febfc2")
+	)
+	(wire
+		(pts
+			(xy 124.46 101.6) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91eea887-ea8a-4221-ba92-e5ec1caacc4f")
+	)
+	(wire
+		(pts
+			(xy 124.46 142.24) (xy 124.46 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94397688-ce0e-48d4-a59c-7257120bf834")
+	)
+	(wire
+		(pts
+			(xy 185.42 60.96) (xy 185.42 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96776fa9-dbd1-46ef-91bd-e95f23cda112")
+	)
+	(wire
+		(pts
+			(xy 175.26 170.18) (xy 195.58 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "969acf2b-33fe-4e89-abf2-451f22e884f4")
+	)
+	(wire
+		(pts
+			(xy 205.74 101.6) (xy 205.74 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "97a65ef9-5994-4805-9e12-ca2b38a42461")
+	)
+	(wire
+		(pts
+			(xy 33.02 251.46) (xy 53.34 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9a3c8ad8-1ef2-4bd9-9b4e-28f46f2d15bb")
+	)
+	(wire
+		(pts
+			(xy 195.58 190.5) (xy 215.9 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9be28702-7d58-41e0-b741-6f1abaea8222")
+	)
+	(wire
+		(pts
+			(xy 114.3 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c79c76c-a95b-401f-9edb-a06a0cceaa4b")
+	)
+	(wire
+		(pts
+			(xy 185.42 182.88) (xy 185.42 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d4fc90e-2670-42d9-b5a8-2138817fee8a")
+	)
+	(wire
+		(pts
+			(xy 53.34 48.26) (xy 73.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ec847-5716-4125-b40b-fdbd3a1587a7")
+	)
+	(wire
+		(pts
+			(xy 165.1 101.6) (xy 165.1 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f711890-a6d6-4440-8bc1-ed469cb6acc4")
+	)
+	(wire
+		(pts
+			(xy 83.82 182.88) (xy 83.82 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a0b86442-47da-481e-aac6-2c18430e056b")
+	)
+	(wire
+		(pts
+			(xy 93.98 101.6) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a226d887-7662-4dbd-b58b-e683f5d85955")
+	)
+	(wire
+		(pts
+			(xy 114.3 231.14) (xy 134.62 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2aaec3e-8eba-49bd-8096-322f6bbfda7c")
+	)
+	(wire
+		(pts
+			(xy 215.9 251.46) (xy 236.22 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a357144a-4c42-404f-a2bc-b2fa39b75cb6")
+	)
+	(wire
+		(pts
+			(xy 246.38 25.4) (xy 246.38 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a56378d0-e1be-4b80-bccf-56cd522e32fd")
+	)
+	(wire
+		(pts
+			(xy 124.46 40.64) (xy 124.46 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a67c0815-f186-4f70-926f-1b264c84d8d8")
+	)
+	(wire
+		(pts
+			(xy 215.9 109.22) (xy 236.22 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a68793c4-3c89-4b82-b021-9e6aae767eeb")
+	)
+	(wire
+		(pts
+			(xy 154.94 162.56) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a803bbba-64cc-448d-a04f-7f03127ebddd")
+	)
+	(wire
+		(pts
+			(xy 226.06 101.6) (xy 226.06 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8d4ba45-df5e-48fe-a1d7-c8d45db9b645")
+	)
+	(wire
+		(pts
+			(xy 175.26 251.46) (xy 195.58 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a9724538-37b8-4ff1-b631-6f0ee30d3df6")
+	)
+	(wire
+		(pts
+			(xy 53.34 149.86) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aac914ea-c9a3-4a8f-94e1-1f91cdd136a3")
+	)
+	(wire
+		(pts
+			(xy 93.98 129.54) (xy 114.3 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab578e4e-a4bf-4ab4-80fc-d97d4aea6370")
+	)
+	(wire
+		(pts
+			(xy 114.3 210.82) (xy 134.62 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abd1d27d-b9d9-4cf6-b486-65a2a8efef41")
+	)
+	(wire
+		(pts
+			(xy 175.26 88.9) (xy 195.58 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "acc95df4-5464-4718-a58a-e43a56e1893a")
+	)
+	(wire
+		(pts
+			(xy 83.82 121.92) (xy 83.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73")
+	)
+	(wire
+		(pts
+			(xy 104.14 223.52) (xy 104.14 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "add1312b-e7f6-4d87-b931-7c2a8ddeb1dd")
+	)
+	(wire
+		(pts
+			(xy 175.26 48.26) (xy 195.58 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "adf35dfa-3831-4e3a-9fdd-7a4ac7f5230d")
+	)
+	(wire
+		(pts
+			(xy 93.98 68.58) (xy 114.3 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aea6a633-b213-403d-b447-42d91d3ab4da")
+	)
+	(wire
+		(pts
+			(xy 246.38 162.56) (xy 246.38 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b042fde0-5041-4313-8349-0fa8c4f38c49")
+	)
+	(wire
+		(pts
+			(xy 175.26 68.58) (xy 195.58 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2797b5c-16d1-4c35-814c-4b30f0a6683b")
+	)
+	(wire
+		(pts
+			(xy 236.22 170.18) (xy 259.08 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b319eab6-824b-4699-8ec0-ab7034aad5e2")
+	)
+	(wire
+		(pts
+			(xy 114.3 170.18) (xy 134.62 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3e14390-7dc6-416b-bbd5-cdf868192ca4")
+	)
+	(wire
+		(pts
+			(xy 73.66 129.54) (xy 93.98 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f6f053-44f0-4391-9873-b6231b8014db")
+	)
+	(wire
+		(pts
+			(xy 124.46 223.52) (xy 124.46 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b5f86959-3a69-4c8e-bb87-f427afde7482")
+	)
+	(wire
+		(pts
+			(xy 154.94 210.82) (xy 175.26 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b78fdc14-2c27-4eca-a54c-9e333096c8b6")
+	)
+	(wire
+		(pts
+			(xy 144.78 101.6) (xy 144.78 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7b2475f-30dc-4ea2-b799-96c21242154c")
+	)
+	(wire
+		(pts
+			(xy 175.26 210.82) (xy 195.58 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7c3f0e9-4787-4050-9c72-cdbaf3e08cfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 81.28) (xy 83.82 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5")
+	)
+	(wire
+		(pts
+			(xy 226.06 223.52) (xy 226.06 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b92dec59-82b2-4a2b-8ab2-ee9822afe59d")
+	)
+	(wire
+		(pts
+			(xy 266.7 170.18) (xy 266.7 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba045c1c-f33c-4ee8-bfe6-db2af30446e4")
+	)
+	(wire
+		(pts
+			(xy 43.18 101.6) (xy 43.18 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb49a3de-620b-45ad-a54c-29dcceaf0796")
+	)
+	(wire
+		(pts
+			(xy 195.58 251.46) (xy 215.9 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bd4b76ea-10fa-4f47-a569-ae3d4d93ab96")
+	)
+	(wire
+		(pts
+			(xy 144.78 121.92) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf12198a-9e62-45c3-b466-f5d86de75219")
+	)
+	(wire
+		(pts
+			(xy 73.66 210.82) (xy 93.98 210.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c007dc03-0700-44f8-b7e3-69868fe31a12")
+	)
+	(wire
+		(pts
+			(xy 205.74 60.96) (xy 205.74 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0bbd51b-0041-4026-a546-37b4ba305884")
+	)
+	(wire
+		(pts
+			(xy 63.5 25.4) (xy 63.5 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1a940de-fa49-4106-a8b9-697952eec2a2")
+	)
+	(wire
+		(pts
+			(xy 246.38 182.88) (xy 246.38 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c28b063a-d950-494b-9533-b480d5393152")
+	)
+	(wire
+		(pts
+			(xy 104.14 121.92) (xy 104.14 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c298ba49-6974-4340-859f-5d5a2b4132ff")
+	)
+	(wire
+		(pts
+			(xy 124.46 182.88) (xy 124.46 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3555de4-415f-4041-a3dd-bd91effa102c")
+	)
+	(wire
+		(pts
+			(xy 236.22 243.84) (xy 246.38 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3f0abaa-920a-49c5-8ee8-d7e02ba230ca")
+	)
+	(wire
+		(pts
+			(xy 175.26 182.88) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3f1f747-e966-4c2c-8090-4f190e07864a")
+	)
+	(wire
+		(pts
+			(xy 124.46 162.56) (xy 124.46 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6080a0e-4059-4120-b2e7-12c9aff607b7")
+	)
+	(wire
+		(pts
+			(xy 246.38 101.6) (xy 246.38 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c8a7fdb7-185d-4eaf-81e7-2129f2a8c65a")
+	)
+	(wire
+		(pts
+			(xy 124.46 60.96) (xy 124.46 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c950d145-c024-47a8-ba57-97efd7bb658b")
+	)
+	(wire
+		(pts
+			(xy 175.26 149.86) (xy 195.58 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca3290da-38da-422f-ab90-d843d9ab6e32")
+	)
+	(wire
+		(pts
+			(xy 144.78 142.24) (xy 144.78 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca92ed7f-ae97-4c0c-81e4-820de1c001c1")
+	)
+	(wire
+		(pts
+			(xy 154.94 251.46) (xy 175.26 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cca7e5a2-d6cf-4d12-bd12-5ddc06a47c9e")
+	)
+	(wire
+		(pts
+			(xy 246.38 40.64) (xy 246.38 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd4bb4a7-b480-4eff-a68f-b9e74cef84d3")
+	)
+	(wire
+		(pts
+			(xy 236.22 149.86) (xy 259.08 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cd7336a6-7179-450e-82ce-ab60fef82201")
+	)
+	(wire
+		(pts
+			(xy 266.7 109.22) (xy 266.7 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdde081d-7bdd-42e6-869e-3ff07b8b464b")
+	)
+	(wire
+		(pts
+			(xy 185.42 121.92) (xy 185.42 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cee2f4f4-6cbc-4838-b71a-3189173bbcfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 40.64) (xy 83.82 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cff15ec3-f29c-4d36-8776-64c5d29be534")
+	)
+	(wire
+		(pts
+			(xy 83.82 25.4) (xy 83.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1088709-a9b9-4e05-8ea2-f87942ee2796")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 93.98 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1347903-ae03-46a2-a707-154093060583")
+	)
+	(wire
+		(pts
+			(xy 195.58 231.14) (xy 215.9 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d212462e-72b0-4fc0-81a2-e9aa2cbc9694")
+	)
+	(wire
+		(pts
+			(xy 144.78 40.64) (xy 144.78 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2183fb3-afd3-46ca-955e-993ea31aa5d3")
+	)
+	(wire
+		(pts
+			(xy 185.42 25.4) (xy 185.42 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2951d7e-82c5-4b56-9a90-ca8ae6d71e44")
+	)
+	(wire
+		(pts
+			(xy 205.74 25.4) (xy 205.74 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4107bae-81df-4028-a211-ea4ab3232bfc")
+	)
+	(wire
+		(pts
+			(xy 226.06 142.24) (xy 226.06 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d4fda796-f5de-4013-bf1e-6a92a02b00f9")
+	)
+	(wire
+		(pts
+			(xy 43.18 162.56) (xy 43.18 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d56982aa-6580-4d04-83ea-6bf3a85282cc")
+	)
+	(wire
+		(pts
+			(xy 185.42 101.6) (xy 185.42 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d675b927-bdff-4eac-82e7-3f468caedaf2")
+	)
+	(wire
+		(pts
+			(xy 43.18 142.24) (xy 43.18 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d76ad758-0ae0-4ce6-9f67-c689c066c744")
+	)
+	(wire
+		(pts
+			(xy 144.78 182.88) (xy 144.78 203.2)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d8747c5c-1650-4a8e-b6a0-4fa4acd098ae")
+	)
+	(wire
+		(pts
+			(xy 205.74 81.28) (xy 205.74 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d920ca82-8ad7-4105-a47d-6c01f55c13d9")
+	)
+	(wire
+		(pts
+			(xy 83.82 223.52) (xy 83.82 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d952f794-a9ef-400a-b190-92d1381a7bd5")
+	)
+	(wire
+		(pts
+			(xy 33.02 149.86) (xy 53.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da80b027-904b-4ca2-99c6-5937c80c825c")
+	)
+	(wire
+		(pts
+			(xy 63.5 142.24) (xy 63.5 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db492971-48ff-4667-996c-f5d540a20741")
+	)
+	(wire
+		(pts
+			(xy 205.74 121.92) (xy 205.74 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc91af22-52c4-4234-961f-adc3ed363a9c")
+	)
+	(wire
+		(pts
+			(xy 165.1 142.24) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dccfde3a-ff1d-42ec-97d5-a8f6cccea832")
+	)
+	(wire
+		(pts
+			(xy 33.02 170.18) (xy 53.34 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de8e54c6-84d9-47e5-8f08-dc3e96b8afdb")
+	)
+	(wire
+		(pts
+			(xy 43.18 81.28) (xy 43.18 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df5c3763-e66c-46c4-9070-0f73d8115bc4")
+	)
+	(wire
+		(pts
+			(xy 266.7 129.54) (xy 266.7 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfb5a082-e4d5-46ea-8dc8-c65064cd598b")
+	)
+	(wire
+		(pts
+			(xy 226.06 203.2) (xy 226.06 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e006a777-74b0-4f5f-bb4c-3ab7b31924c0")
+	)
+	(wire
+		(pts
+			(xy 93.98 170.18) (xy 114.3 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb")
+	)
+	(wire
+		(pts
+			(xy 144.78 81.28) (xy 144.78 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e444742a-24b1-4bbf-b7ee-438e6dffc9cc")
+	)
+	(wire
+		(pts
+			(xy 175.26 190.5) (xy 195.58 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5e38d44-8bf0-426b-a99f-727527ca9657")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6d06035-ccb7-4d3e-ae70-d73150e65bbb")
+	)
+	(wire
+		(pts
+			(xy 215.9 231.14) (xy 236.22 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e75ebd5e-5f93-4d1a-a8cb-e4f158ba626b")
+	)
+	(wire
+		(pts
+			(xy 236.22 190.5) (xy 259.08 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e7dd0479-d978-4c9d-ac31-40cf0582e439")
+	)
+	(wire
+		(pts
+			(xy 53.34 251.46) (xy 73.66 251.46)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e91e3b45-5a4a-4cad-8f6d-8da054a1776d")
+	)
+	(wire
+		(pts
+			(xy 114.3 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa")
+	)
+	(wire
+		(pts
+			(xy 246.38 243.84) (xy 246.38 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea05e2af-fd29-4a7e-aa30-c8e742f8574e")
+	)
+	(wire
+		(pts
+			(xy 195.58 149.86) (xy 215.9 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ea36985b-5a45-46a7-be39-a5ceee9dc964")
+	)
+	(wire
+		(pts
+			(xy 63.5 101.6) (xy 63.5 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edeeb0d9-51cc-411d-aac4-77f10b619702")
+	)
+	(wire
+		(pts
+			(xy 43.18 203.2) (xy 43.18 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee312ce0-2ae6-4337-8d15-666961b7d179")
+	)
+	(wire
+		(pts
+			(xy 154.94 170.18) (xy 175.26 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ee36c21a-970c-453e-93f8-ab4961c20f44")
+	)
+	(wire
+		(pts
+			(xy 104.14 40.64) (xy 104.14 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5c9f05-d71b-4562-9939-852432c066c5")
+	)
+	(wire
+		(pts
+			(xy 144.78 162.56) (xy 144.78 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "efa47227-d3f9-4214-af64-a7e9107c0edb")
+	)
+	(wire
+		(pts
+			(xy 144.78 203.2) (xy 144.78 223.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f09677ca-cfdb-4119-9431-13dd6580ce71")
+	)
+	(wire
+		(pts
+			(xy 144.78 60.96) (xy 144.78 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0ce7c2b-d80c-49f2-bf63-62b750f7ca47")
+	)
+	(wire
+		(pts
+			(xy 236.22 109.22) (xy 259.08 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f275e971-a5b1-41ee-ac80-764aa694f4e1")
+	)
+	(wire
+		(pts
+			(xy 73.66 231.14) (xy 93.98 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f2cc3c58-efff-41fa-a09a-222ad0afe609")
+	)
+	(wire
+		(pts
+			(xy 63.5 162.56) (xy 63.5 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5658dea-a5b6-4ba9-9360-11c3315c15be")
+	)
+	(wire
+		(pts
+			(xy 134.62 142.24) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f781a362-e0d4-48be-9d13-5686e05b406f")
+	)
+	(wire
+		(pts
+			(xy 246.38 81.28) (xy 246.38 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f88e1e07-ac9e-4cbd-a0af-8963c31f296c")
+	)
+	(wire
+		(pts
+			(xy 33.02 231.14) (xy 53.34 231.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f8f8e54e-33a9-4d2a-b35e-9b373b3563c7")
+	)
+	(wire
+		(pts
+			(xy 175.26 129.54) (xy 195.58 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f940918e-7aa4-499c-8be1-c536835b2ed6")
+	)
+	(wire
+		(pts
+			(xy 215.9 68.58) (xy 236.22 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f9bf6b2c-c726-44fd-afa9-844550de8af2")
+	)
+	(wire
+		(pts
+			(xy 226.06 40.64) (xy 226.06 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa54e42a-1d6a-433e-bb23-df8ec8cd3dca")
+	)
+	(wire
+		(pts
+			(xy 43.18 25.4) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa765e67-a220-4a00-944c-7663298f0ead")
+	)
+	(wire
+		(pts
+			(xy 83.82 142.24) (xy 83.82 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b")
+	)
+	(wire
+		(pts
+			(xy 185.42 81.28) (xy 185.42 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ffe6085a-a7be-4653-b911-c10de4574454")
+	)
+	(global_label "IO 3"
+		(shape bidirectional)
+		(at 104.14 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "24ec698b-5cae-4571-b9c4-c0e35d64a64d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 104.14 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 1"
+		(shape bidirectional)
+		(at 63.5 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d4b15a5-8b6c-4ca3-a7bb-7848c8036590")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 63.5 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 9"
+		(shape bidirectional)
+		(at 226.06 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "388f2ae3-3697-4b0d-bb82-8cc7f8e58abf")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 226.06 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 7"
+		(shape bidirectional)
+		(at 185.42 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "45d4e03e-6cff-41ce-b946-708382da0601")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 185.42 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 0"
+		(shape bidirectional)
+		(at 43.18 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "465a517d-f0e1-4825-8675-1cce54bfa7a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 43.18 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "INTR"
+		(shape bidirectional)
+		(at 266.7 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4e12b932-2346-4e84-b5a4-80468334f3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 274.89 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 10"
+		(shape bidirectional)
+		(at 246.38 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "5fc8da19-2489-4964-a31f-4b81b27f0926")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 246.38 16.061 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 2"
+		(shape bidirectional)
+		(at 83.82 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70d42e66-a74c-4de2-af96-d1860851d3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 83.82 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 165.1 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 165.1 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 144.78 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d44cceb0-f409-4e5f-a98a-9feead2e845d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 8"
+		(shape bidirectional)
+		(at 205.74 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e036ec60-274a-4de6-9324-dafd5b920142")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 205.74 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 4"
+		(shape bidirectional)
+		(at 124.46 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f36f49e4-227f-479f-b914-786aa44dd568")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 251.46 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "00fc2774-1e85-42dc-993a-cdcdc9df2e68")
+		(property "Reference" "DI10"
+			(at 262.89 247.65 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 254 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 251.46 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad12a4a2-a558-4a9d-83b2-f1e4f7bf7638")
+		)
+		(pin "2"
+			(uuid "ab764813-e248-4da7-9ff1-1f698a422085")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 190.5 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0188dba3-054f-4958-9440-27c9ca673633")
+		(property "Reference" "DI7"
+			(at 262.89 186.69 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 193.04 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "deea1889-824f-4f7a-a6be-9546db353c85")
+		)
+		(pin "2"
+			(uuid "2080be86-a538-40a8-8f30-ead2a96d02d3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0263b847-a932-4a31-9f35-35bb23f7000d")
+		(property "Reference" "D62"
+			(at 152.4 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc2e60ca-c74f-4e4b-a0a0-9705327e9578")
+		)
+		(pin "2"
+			(uuid "d12efbfe-85ac-442f-8c0f-ddbe5646c7d5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D62")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04430572-8314-4d21-974c-22350cead1a6")
+		(property "Reference" "DS1"
+			(at 55.88 65.405 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 55.88 62.865 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3e433df4-9fec-4cfb-b60f-eebca7c574cf")
+		)
+		(pin "2"
+			(uuid "9bcc1487-0612-4bdb-a2de-a8b2f590b28f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080a5952-914c-46a1-ba80-7cc09f9efbdf")
+		(property "Reference" "D114"
+			(at 111.76 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cd20c400-0339-492e-b713-e3ef1c01763f")
+		)
+		(pin "2"
+			(uuid "19944e75-22c9-4237-a2b2-cdf3ae3d739b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D114")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 44.45 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080aaa87-0974-4a77-bf63-185495f411a0")
+		(property "Reference" "DS0"
+			(at 35.56 45.085 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 35.56 42.545 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bfacad1-28fd-4f2e-93dc-68f478b8a6ba")
+		)
+		(pin "2"
+			(uuid "376f73f9-79fa-4153-ae38-31ed5446db52")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09606075-7d6f-4679-9228-3a303ca4f40c")
+		(property "Reference" "RC9-1"
+			(at 220.98 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f5b128f-eb55-44dc-974a-3ac8a1869c2d")
+		)
+		(pin "2"
+			(uuid "9783c397-46c8-4a54-ad23-28d37f071b25")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09d14922-c46a-4bf1-bb2c-1d224060568c")
+		(property "Reference" "D40"
+			(at 111.76 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c2f1a1d2-df3d-4680-9706-2ca411fa6890")
+		)
+		(pin "2"
+			(uuid "f58fd788-6016-46e7-b903-3606dd2ec21d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D40")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 149.86 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d18473f-e37a-4136-b721-5a2e40e4f8ed")
+		(property "Reference" "DI5"
+			(at 262.89 146.05 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 152.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5a885ca-5076-44e6-9a84-d07474947dde")
+		)
+		(pin "2"
+			(uuid "047b5b54-de8b-4afc-abc2-c6d1f2d17bd2")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 170.18 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0ef17723-f7f8-4fdb-8913-5a4ceefbc065")
+		(property "Reference" "DI6"
+			(at 262.89 166.37 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 172.72 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df5a6b10-ba48-4f34-96ce-3832d480a7ee")
+		)
+		(pin "2"
+			(uuid "59f34a55-6ac4-496d-8c40-1b8f1eafbcb5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0f5e4226-91a2-4a41-9aae-518534f05932")
+		(property "Reference" "RC7-9"
+			(at 180.34 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e144b30-8fd2-4ccc-b8e5-b1ca3fb409ba")
+		)
+		(pin "2"
+			(uuid "0e4a0bb0-3e0e-44e1-9c80-03f9a9aa8952")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0fadd319-be81-4c25-8d23-e7495a114aa7")
+		(property "Reference" "RC4-0"
+			(at 119.38 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "efb1c47f-fe25-4bea-8081-43d3c19de5cd")
+		)
+		(pin "2"
+			(uuid "9138c970-6e3d-46df-9354-5174df2a4e52")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ff76361-9578-4f9f-a20c-f042e24a7755")
+		(property "Reference" "D5"
+			(at 30.48 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06")
+		)
+		(pin "2"
+			(uuid "cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "11f01cd8-f751-497f-9599-50fe1fc0a618")
+		(property "Reference" "RC5-4"
+			(at 139.7 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc28293-fab9-4f93-b3d5-ca9ee69110c4")
+		)
+		(pin "2"
+			(uuid "088ac770-af1e-4c4f-ad11-5b44a20594d8")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "13ddd48d-7d2b-415d-b8fa-15c71e245acc")
+		(property "Reference" "D61"
+			(at 152.4 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "745d89b9-e75a-40ae-97bc-d1eadf220f02")
+		)
+		(pin "2"
+			(uuid "7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D61")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1597bfb0-dabd-48b6-a2ca-f9171da312d5")
+		(property "Reference" "RC10-3"
+			(at 241.3 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22a87d66-e5d9-4630-bb65-e557654257a9")
+		)
+		(pin "2"
+			(uuid "586aafd1-f8f9-4fea-8263-558415220f6f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "17d027e3-2b58-470b-9fc5-f21e547cdc82")
+		(property "Reference" "RC8-1"
+			(at 200.66 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7f893b29-9b1f-44b8-bac5-e11991e6b604")
+		)
+		(pin "2"
+			(uuid "6b5e04e4-6889-4e49-9600-35d15ee54578")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "19f0de4f-d7ab-4f51-9796-79808aba650f")
+		(property "Reference" "D97"
+			(at 213.36 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad12892f-d26f-4434-82fd-3de2937c1d41")
+		)
+		(pin "2"
+			(uuid "8b061bcb-2b37-4d89-bd19-fcd574e79f03")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D97")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1a21ce9e-a70d-4048-80c2-b67a7c165b7f")
+		(property "Reference" "D117"
+			(at 172.72 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1f6173a6-5b9d-47d1-8fc5-4539bbfab6f3")
+		)
+		(pin "2"
+			(uuid "c72e39dc-ef93-42be-afff-91188bea0ab7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D117")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1b13866a-6fbf-441b-9c64-56258379f43a")
+		(property "Reference" "D65"
+			(at 152.4 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c70f4670-9685-4aab-ac4f-4ebaf44d5847")
+		)
+		(pin "2"
+			(uuid "8b9c860d-59e1-424e-a148-1aa2c0db4056")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D65")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a")
+		(property "Reference" "RC6-4"
+			(at 160.02 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3427b432-e194-40af-9dcb-04dccafe2b0f")
+		)
+		(pin "2"
+			(uuid "8af48a1b-2c49-47d9-959c-ee33cdd6f977")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d4decb6-e690-4f06-b8aa-6dd29b7f2622")
+		(property "Reference" "D58"
+			(at 132.08 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0a89d11-f9ed-4dad-a764-70b931421ce9")
+		)
+		(pin "2"
+			(uuid "e072fab0-4e83-437a-8387-943f8bcc1213")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D58")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1e5f084d-4db5-48ad-a2a3-76f186559614")
+		(property "Reference" "RC3-1"
+			(at 99.06 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa")
+		)
+		(pin "2"
+			(uuid "40b7f115-b5d7-4fa0-b12b-c1c7b6866feb")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 210.82 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "210fa303-e6c4-43b3-8ff0-f2f9178c950d")
+		(property "Reference" "DI8"
+			(at 262.89 207.01 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 213.36 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cad82d1c-a62b-40c6-a2ae-61d28ed2d913")
+		)
+		(pin "2"
+			(uuid "ca0c8c70-cbfc-4421-833b-b58ab5f50511")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "213aaf81-8580-4880-9130-4c9d596a7095")
+		(property "Reference" "D90"
+			(at 213.36 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "441dc052-fc8b-4f81-9c35-f08ea1ca4cf5")
+		)
+		(pin "2"
+			(uuid "b7690702-7874-4b26-89ba-a175fce3360b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D90")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "213dd8be-31f7-488d-b5dc-6770d78fccd5")
+		(property "Reference" "RC9-6"
+			(at 220.98 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "593996ed-485e-495f-9d29-6951be77f078")
+		)
+		(pin "2"
+			(uuid "fa5ec1f4-4786-4d7c-9bb1-ab1ce7ad3038")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "22a72d93-d5b5-4a6b-95f6-755ac10ccf50")
+		(property "Reference" "RC4-7"
+			(at 119.38 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "18c97ab1-62df-42bc-9dfa-dba3415ee8e2")
+		)
+		(pin "2"
+			(uuid "ff0eb9a3-538a-4ebf-a42b-97fe870ddfea")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "244b7f9d-3923-4908-be6d-02c49eb4663c")
+		(property "Reference" "RC2-3"
+			(at 78.74 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1d79440a-2f90-4c0b-8d60-528615b0bd65")
+		)
+		(pin "2"
+			(uuid "7f1d0566-f385-4126-b190-2379308ed05b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 166.37 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2518146c-59f4-45b7-a4fa-f618686ab064")
+		(property "Reference" "DS6"
+			(at 157.48 167.005 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 157.48 164.465 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cee2f461-8f62-48d8-ac7b-1698deb984c1")
+		)
+		(pin "2"
+			(uuid "460b9088-619c-4166-a615-45e17ecf1f0d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2519cd5e-8ecf-41a4-a9d0-5b856882cb05")
+		(property "Reference" "D63"
+			(at 152.4 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ea1c9827-ebfa-43f1-b2c6-5a572466713e")
+		)
+		(pin "2"
+			(uuid "0496ba9c-818c-4d39-979a-e8785e06d12a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D63")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "270e65d5-141a-497e-af55-d32d80c01617")
+		(property "Reference" "D118"
+			(at 193.04 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fce64b77-c994-40f7-be6f-e1d7fe43ea57")
+		)
+		(pin "2"
+			(uuid "9567d8aa-8f12-417f-8460-1af89c257716")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D118")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "28137b00-0d76-493b-92b8-23037474163f")
+		(property "Reference" "RC1-3"
+			(at 58.42 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3")
+		)
+		(pin "2"
+			(uuid "41d35b0f-21b5-4da8-92df-229c816b63c5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2a208574-f638-4917-a68f-bc3ff176d324")
+		(property "Reference" "D75"
+			(at 172.72 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "503e8179-7a4a-4075-8fcf-2d7bb00a3908")
+		)
+		(pin "2"
+			(uuid "a744b0f2-49c4-46a7-9ec2-cefb21173879")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D75")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c50947a-4bb9-43c2-b65c-4726e224b6b0")
+		(property "Reference" "RC3-0"
+			(at 99.06 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b")
+		)
+		(pin "2"
+			(uuid "30241adf-a2e7-4976-a53a-5c267616618e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c9d0815-f6d3-49dd-89d8-cea98629f461")
+		(property "Reference" "D104"
+			(at 233.68 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d4aa1a8c-5efd-48af-8e22-4c35fa0cdce0")
+		)
+		(pin "2"
+			(uuid "64108911-fd65-4f0f-b0f7-cf192f04f6e7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D104")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2cd8f716-5a6b-4cee-ad2e-612d075ffebf")
+		(property "Reference" "RC5-9"
+			(at 139.7 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f37bc637-a5fa-420e-ae7d-11681e40308a")
+		)
+		(pin "2"
+			(uuid "97b6ff47-ae10-45e9-81f0-a4902039b249")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2e38accc-5291-44a5-82e8-9bec928b99c0")
+		(property "Reference" "D18"
+			(at 50.8 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20ca8cf6-b241-4581-b5e1-dadf97a2cf3f")
+		)
+		(pin "2"
+			(uuid "dc0b457e-4296-4b82-a953-b255f1e09c5c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D18")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2f872c45-59ae-4f02-abee-114e38b97a80")
+		(property "Reference" "D87"
+			(at 193.04 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4139db20-9977-4a84-b30c-e04c47ec888a")
+		)
+		(pin "2"
+			(uuid "bdc078b6-22f8-427e-a1f3-872c3722a746")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D87")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30340eba-9ed0-42ff-b11f-98a864f7223e")
+		(property "Reference" "RC1-4"
+			(at 58.42 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aa956a67-c26e-4a57-9ddb-59688a6476ad")
+		)
+		(pin "2"
+			(uuid "23cd0d93-5050-40ea-9d49-879bbcbb8bcd")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30b60f6a-8d20-44dd-b832-1906a957c513")
+		(property "Reference" "D54"
+			(at 132.08 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2ad1a4-b254-49a0-8435-d3a374353ffc")
+		)
+		(pin "2"
+			(uuid "27a3cb64-baf1-430a-b797-bd52c0e46cbe")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D54")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30f8682e-9109-46d6-80ea-6dedfc8c0eee")
+		(property "Reference" "RC10-7"
+			(at 241.3 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f5e4ae69-f050-4591-8a39-3444621f4976")
+		)
+		(pin "2"
+			(uuid "78cf5cbb-b4aa-487d-9661-5dfbf52cb0b3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "310fec10-f10c-41d7-9446-87c12744e146")
+		(property "Reference" "D26"
+			(at 71.12 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e1d524d3-5d24-4c87-b480-74c57a74b567")
+		)
+		(pin "2"
+			(uuid "c0e9aa05-6318-4fdc-abee-cb43875c8e46")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D26")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "32c1c5fd-b6bc-4aba-a718-d9540ec4db69")
+		(property "Reference" "RC10-2"
+			(at 241.3 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "69777a23-120f-4e97-b9ca-87ed1b3e6281")
+		)
+		(pin "2"
+			(uuid "e1c89d23-810f-47c0-98bb-c34f6ce30f0b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3508f6d2-8867-4535-a2fe-dcbb1c7737b5")
+		(property "Reference" "D110"
+			(at 30.48 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3805bb07-9b77-48c1-b03a-f2ba837fb125")
+		)
+		(pin "2"
+			(uuid "e658e927-e073-4667-83d5-95a0ad1b7643")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D110")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35827986-7004-4f70-a10a-6ceb42f33d9f")
+		(property "Reference" "RC1-2"
+			(at 58.42 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "879d3b07-b41e-4233-b196-e223f635bdf3")
+		)
+		(pin "2"
+			(uuid "641f8ea7-6306-4550-92c8-e3cc0ed3e5a5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3598234f-e6ed-4eb6-b25a-52bde6e19729")
+		(property "Reference" "D82"
+			(at 193.04 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f8d7980-fcb9-49ec-8704-044fa4175b07")
+		)
+		(pin "2"
+			(uuid "e2992df7-1f75-4c2b-bd16-ce868f4adf82")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D82")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35c1fb5b-1af9-421e-8d64-2023ee2a5f4d")
+		(property "Reference" "RC9-10"
+			(at 220.98 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c26958a6-21d1-4ac5-9a1c-1b25108edf8e")
+		)
+		(pin "2"
+			(uuid "c3db45c0-8e01-4eab-a638-8ba75be1666f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "369ff51e-db51-4132-aa26-7b5d981cba74")
+		(property "Reference" "D17"
+			(at 50.8 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b5adb2f-c180-494e-86cd-ef0a68591be2")
+		)
+		(pin "2"
+			(uuid "24774a87-3207-4ab9-a94d-2b9e1b568e65")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D17")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "37da2014-affc-4731-b642-c4245ff411f2")
+		(property "Reference" "RC5-7"
+			(at 139.7 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ac410347-ba8b-493b-832e-a3f9e3359951")
+		)
+		(pin "2"
+			(uuid "4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3811148a-f93d-405c-9479-c81e5555fcd8")
+		(property "Reference" "RC7-7"
+			(at 180.34 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f8a4ff2-ec9f-4d19-88f7-72ef280fb836")
+		)
+		(pin "2"
+			(uuid "ea1c4b45-e89f-41d8-a596-654ae6328f49")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976")
+		(property "Reference" "D43"
+			(at 111.76 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6fb6c4-b36c-4ff1-879b-43826c273a72")
+		)
+		(pin "2"
+			(uuid "198c65f6-b3df-4780-9f6d-1c910e870a1b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D43")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3a9b19be-43ef-409c-9489-c069efbfa3ee")
+		(property "Reference" "RC0-7"
+			(at 38.1 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "898cdd62-8ad6-4d58-b6f7-f4db79a4cca2")
+		)
+		(pin "2"
+			(uuid "277b2226-c100-403c-a519-ef9cdc3923fe")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ac53e86-aa26-4394-9e99-e33f3c863b14")
+		(property "Reference" "RC7-1"
+			(at 180.34 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e6efb38c-f391-43d6-9511-8c7da50b3d51")
+		)
+		(pin "2"
+			(uuid "03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ad37b9b-353e-40fc-ac40-f5195f3dc605")
+		(property "Reference" "RC1-8"
+			(at 58.42 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3efa7b0a-a125-48e1-96a0-b756f7dea902")
+		)
+		(pin "2"
+			(uuid "e99d0060-9d73-4fee-8521-d18593d0656b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef0222e-2eac-4930-ac36-0f395f4593b6")
+		(property "Reference" "RC1-0"
+			(at 58.42 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20f0b9b8-9322-4d89-a423-dd3d807d99ff")
+		)
+		(pin "2"
+			(uuid "ce54609e-9d1d-4a3b-81a2-5a384dbe41c8")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef86e49-a152-4515-afb0-4098f497c742")
+		(property "Reference" "D31"
+			(at 91.44 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a")
+		)
+		(pin "2"
+			(uuid "b917ad78-96a8-428f-ad4f-d49149b5b97b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "402f0f46-5eb8-421b-9b9f-01a54b5cfa87")
+		(property "Reference" "RC4-1"
+			(at 119.38 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cb206c0-1fab-4ac5-b301-f9678369525b")
+		)
+		(pin "2"
+			(uuid "b99c2ecc-04a5-4c54-a491-d99fe2562dcc")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40d8058d-714e-4f99-a508-f64f9c8b575b")
+		(property "Reference" "D60"
+			(at 152.4 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66710233-d2ab-4921-aa86-488ee87fbb3a")
+		)
+		(pin "2"
+			(uuid "a9636da9-222c-478f-bc5b-71d3f0473300")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D60")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "411a5386-edd0-4032-883d-ba445f257b99")
+		(property "Reference" "D93"
+			(at 213.36 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "21f0660e-6a0c-4492-a9e5-01821c71a5fe")
+		)
+		(pin "2"
+			(uuid "096c2860-22cd-4d22-bbb5-2c4452c158a3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D93")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "430b936d-b8ad-4c28-b93d-4046aec980c7")
+		(property "Reference" "D67"
+			(at 152.4 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9255475-7a77-44cc-9bd9-589d63ced82b")
+		)
+		(pin "2"
+			(uuid "9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D67")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "433f3f09-0867-41a3-8ac6-5f00bd3314fc")
+		(property "Reference" "D32"
+			(at 91.44 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11a29637-fd50-4473-bb70-d4116312a4f5")
+		)
+		(pin "2"
+			(uuid "53f6307d-8380-45e9-b3fa-4d05a2bd575d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44499808-710f-44ae-bed2-0632db78b8c8")
+		(property "Reference" "D71"
+			(at 172.72 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8805b31-9770-4092-b10a-101cf112fd76")
+		)
+		(pin "2"
+			(uuid "9f3056b1-b197-421f-9d54-08cf5cc88970")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D71")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4461a601-2e4b-4cf8-8094-5e4d8e990676")
+		(property "Reference" "RC5-8"
+			(at 139.7 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f54d1c0f-d68b-4769-9ef7-ac6475687d30")
+		)
+		(pin "2"
+			(uuid "49768dd5-fbea-4db4-9154-60b22afd8a29")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44de9323-bd5d-49cd-bf0a-70392801309d")
+		(property "Reference" "D45"
+			(at 111.76 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb2b185b-5d98-46b8-8516-9e5c980291cf")
+		)
+		(pin "2"
+			(uuid "f730da3b-5ef9-4abc-8c8d-0794fe3feb87")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D45")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "454ad926-1c6a-4aa4-b6f8-25297463de18")
+		(property "Reference" "RC3-2"
+			(at 99.06 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0aebfce-7e76-40f1-83ef-5914b8ebbcc7")
+		)
+		(pin "2"
+			(uuid "744fce2b-a15c-45a6-92b0-e880efafb5f6")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 247.65 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "459f552c-e7ba-420b-a932-a01ab9ea9597")
+		(property "Reference" "DS10"
+			(at 238.76 248.285 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 238.76 245.745 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6319e419-e05e-49bb-bac5-81d105e9b55a")
+		)
+		(pin "2"
+			(uuid "6024f692-10e3-4e3a-9d57-759288b90eca")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 48.26 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46348ccc-126c-461a-8e39-f93f389ddaa7")
+		(property "Reference" "DI0"
+			(at 262.89 44.45 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 50.8 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c86bf5fa-c113-44c1-b93d-7a5d4ac11904")
+		)
+		(pin "2"
+			(uuid "dbd8322f-50c7-4271-821c-b0005fd066b2")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a7f7b3d-918b-431a-b79d-c66494b3ec50")
+		(property "Reference" "D52"
+			(at 132.08 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd114d76-87b2-4089-b211-b7b541ac42b3")
+		)
+		(pin "2"
+			(uuid "a360aa38-116c-4dd0-a569-f6a7a5a88a05")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D52")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4d978207-10b9-4a43-a474-2e66421925a0")
+		(property "Reference" "D64"
+			(at 152.4 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "27529674-e97c-460d-9de8-89cd61c8a6eb")
+		)
+		(pin "2"
+			(uuid "57e77ee6-e62d-402e-a614-a833da3fbafb")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D64")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4e9036c3-3848-485b-8b45-7e377c05efba")
+		(property "Reference" "D86"
+			(at 193.04 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cebd91c6-213c-407e-8871-b40d23e32e3c")
+		)
+		(pin "2"
+			(uuid "209631a2-8c98-4e88-8a48-286a9aadd110")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D86")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "50dfbd73-3671-493b-8466-ba295a53891e")
+		(property "Reference" "D69"
+			(at 152.4 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12473813-984c-45f7-a1ec-6b60de9f4230")
+		)
+		(pin "2"
+			(uuid "ef3a08d5-f80f-45b3-9407-fe76d147d1fb")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D69")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "50e4b379-7602-45c8-aa05-dfc9b3f70f58")
+		(property "Reference" "RC9-2"
+			(at 220.98 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6d506f53-ffcf-4d12-ae8f-d5b7539fbeba")
+		)
+		(pin "2"
+			(uuid "3324ce76-0743-47e2-af09-b4daae2fb475")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5466fd2d-f22f-409b-b7da-f8d297aeb7a2")
+		(property "Reference" "RC6-5"
+			(at 160.02 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffdd8419-9afa-4f38-bfbf-7dc4e869b438")
+		)
+		(pin "2"
+			(uuid "0db27643-51f5-4634-a791-2c4813885195")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5518d7f7-6de1-409b-a6d0-90efa78c0b82")
+		(property "Reference" "D7"
+			(at 30.48 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9bdf2265-17dd-4712-9f75-996577068823")
+		)
+		(pin "2"
+			(uuid "cd2654f9-f2c1-4ff7-bbce-8fe664862762")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "553a576d-44a1-4bad-9211-394526206f63")
+		(property "Reference" "D41"
+			(at 111.76 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4a035e61-91c9-41ba-9328-bc9b284e86c2")
+		)
+		(pin "2"
+			(uuid "8628539f-d3cd-4957-a6bb-5c605649e715")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55c4f5cb-c530-414c-92f5-fbf9e58a8885")
+		(property "Reference" "D37"
+			(at 91.44 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "64d90630-a755-4eae-b416-80d8ff93fde4")
+		)
+		(pin "2"
+			(uuid "77e4ef56-5ac3-4295-aacb-04ae680de9b7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D37")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55dc1959-7c17-496b-b079-56725e7400ff")
+		(property "Reference" "RC7-6"
+			(at 180.34 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d91f51f-9558-44e7-9b69-c9ba25dbac1f")
+		)
+		(pin "2"
+			(uuid "f7ee2403-2740-4116-96fa-c5f3c0c9f293")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "563bf078-cf50-4f0f-84d6-a83a0feddd45")
+		(property "Reference" "D70"
+			(at 172.72 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "91318668-36ae-48a7-a13c-18d4c2f08036")
+		)
+		(pin "2"
+			(uuid "29b99e4d-eeeb-4f18-b49f-b44a360c9eac")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D70")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 207.01 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5642ac65-20dd-447b-a5a3-1b21218d5bac")
+		(property "Reference" "DS8"
+			(at 198.12 207.645 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 198.12 205.105 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6d406bb4-8771-4842-b48d-4d5e1f3de0cf")
+		)
+		(pin "2"
+			(uuid "bcdb56a4-4458-438f-b33a-abdcc29a1ebf")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "568f737d-6752-4b16-be92-273eb7ac8c9d")
+		(property "Reference" "D98"
+			(at 213.36 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "96fa163e-1e2c-4d82-ada6-6b53530a015e")
+		)
+		(pin "2"
+			(uuid "eef2dd73-ade2-4fd8-a1e4-1b0837b59db5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D98")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 68.58 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5692cd7d-67c7-4fe7-8b4d-c8bc86968b31")
+		(property "Reference" "DI1"
+			(at 262.89 64.77 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9abe1fc5-b3c1-424f-8519-d12916c57a11")
+		)
+		(pin "2"
+			(uuid "168b1203-c5fc-4b69-b8e5-94d0bdc27e41")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "57e7516d-643d-4cd1-9646-d8696e387a16")
+		(property "Reference" "D38"
+			(at 91.44 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c0d30413-2127-456f-a30c-24a92d981ac9")
+		)
+		(pin "2"
+			(uuid "a92161f1-81a1-4199-93bf-ab8287ab6d27")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D38")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5924da97-d274-4fb5-b277-06f309e62438")
+		(property "Reference" "D79"
+			(at 172.72 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb3328cf-70d1-402a-9b12-5297b037e47d")
+		)
+		(pin "2"
+			(uuid "44a70a68-2fd3-413e-8aa0-d6527cb0cab5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D79")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59263e5e-1eeb-458b-9b02-ca162d4a65d7")
+		(property "Reference" "D21"
+			(at 71.12 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2372f523-257f-414c-92f4-8d433cfbee15")
+		)
+		(pin "2"
+			(uuid "21891727-1d09-4cab-bd90-75c57b141f7c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "593e930a-15e9-4d16-a6ed-7df7f9d1e843")
+		(property "Reference" "RC10-6"
+			(at 241.3 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "56a5df9f-e166-423f-b625-6488b2d49a99")
+		)
+		(pin "2"
+			(uuid "3319214e-0ac1-4b68-9da8-94a53c1267f8")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59fdee43-9b65-471d-9ea8-5dc40dc65f6e")
+		(property "Reference" "D35"
+			(at 91.44 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5834d436-0e26-481b-a20d-40fa6346502e")
+		)
+		(pin "2"
+			(uuid "59af1ddc-701f-49c0-b6cd-778072695c5c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D35")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5aeb247f-6f79-4df2-b767-9ca89069182c")
+		(property "Reference" "D56"
+			(at 132.08 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d46c0cdd-d9c1-44c1-ba6c-034fc547ff01")
+		)
+		(pin "2"
+			(uuid "53f3e198-3ef2-40c4-a8f7-298435eddd0b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D56")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5c60f960-fb0a-46f6-9aff-5d8144586231")
+		(property "Reference" "RC4-6"
+			(at 119.38 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "990f1ee1-d6da-4ae8-809a-1911d8099a4c")
+		)
+		(pin "2"
+			(uuid "a8276c00-b61f-4db4-8f4f-e51e512de654")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f21a75c-b9ee-47bf-adcf-39a03e42660f")
+		(property "Reference" "D15"
+			(at 50.8 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1")
+		)
+		(pin "2"
+			(uuid "7a8a84c2-38d2-473b-955d-81dd816a398e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fa8cce4-fbbf-4784-a459-71364b77e1a7")
+		(property "Reference" "RC0-2"
+			(at 38.1 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cb7750fa-a378-43a3-a1c6-638c32a1c79e")
+		)
+		(pin "2"
+			(uuid "67dfe958-6bd5-4618-98a3-d513db4ad5c0")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5ff7733c-a36f-4b29-a8e7-bdf79fabdf72")
+		(property "Reference" "D4"
+			(at 30.48 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed6062e9-f00a-474a-840f-39685bd66d70")
+		)
+		(pin "2"
+			(uuid "c0e85db4-b88d-4383-8de6-9f7370be62a6")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61b2e3fc-583b-407b-beff-dd8441f2f403")
+		(property "Reference" "RC2-6"
+			(at 78.74 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "752f308d-4723-4468-9745-81de18307ba3")
+		)
+		(pin "2"
+			(uuid "3267c09c-2818-42d7-96a9-6aaa2d6c4a92")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61c18e3c-3eec-4917-af6e-9f406067d77e")
+		(property "Reference" "RC8-8"
+			(at 200.66 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c083f528-7a3d-45a8-9372-aa710d031803")
+		)
+		(pin "2"
+			(uuid "ec242614-cf3f-4f5b-a1ac-1c89a34c79dc")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61f6b776-77f0-46d6-a562-1c8ec4a3e59d")
+		(property "Reference" "RC1-1"
+			(at 58.42 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "841c88df-72b0-48a9-8e43-aa23d2c1bd13")
+		)
+		(pin "2"
+			(uuid "39a4522a-a28d-471f-b74c-927ab042e90e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "62b34fc5-3988-4735-af8d-33fe194ac6ce")
+		(property "Reference" "D105"
+			(at 233.68 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fe07ea24-09ee-4d8b-9b26-e3b9b6f6e23d")
+		)
+		(pin "2"
+			(uuid "a27722ac-a8b1-4fe6-8952-6f38def7c08a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D105")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6368f5d6-df20-4a23-a72c-e29e990ea131")
+		(property "Reference" "D36"
+			(at 91.44 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cd72461-15a2-466d-828d-9560639fb78b")
+		)
+		(pin "2"
+			(uuid "e26d27e6-f81a-4557-bc98-f3f953d25d26")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D36")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "64616073-76e8-465f-9707-663a78749bf1")
+		(property "Reference" "RC7-3"
+			(at 180.34 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0925180b-4c04-468a-84a3-7e0c543a243b")
+		)
+		(pin "2"
+			(uuid "000c5508-f583-4022-ad6d-ee3a9a754164")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6692c134-d619-4b90-b4c4-ab21aa3df3a5")
+		(property "Reference" "RC8-7"
+			(at 200.66 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "453a02c7-7770-40fc-8f21-06b63fd625f1")
+		)
+		(pin "2"
+			(uuid "3ebf9656-8129-4c66-8b10-67f0c0e2bb28")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 227.33 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "678223ff-e0fe-486b-b260-417e9028494d")
+		(property "Reference" "DS9"
+			(at 218.44 227.965 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 218.44 225.425 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6cfbc946-abd5-4358-933d-727d4186f547")
+		)
+		(pin "2"
+			(uuid "b5044718-d927-48a8-a198-355f14c09004")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "67aba0e0-2c92-4816-99a5-9091230a7899")
+		(property "Reference" "RC3-6"
+			(at 99.06 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c252319-dc79-4365-afaa-77dcde3e6c4e")
+		)
+		(pin "2"
+			(uuid "a5f35312-d094-4f22-9eb9-0edc1f8fb9c4")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "68966b55-0a95-4b34-bc89-5c7298da3231")
+		(property "Reference" "D95"
+			(at 213.36 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2fe5baba-e2be-4676-a63d-cc166ce0c4ba")
+		)
+		(pin "2"
+			(uuid "72f97c9f-1d3c-4a38-bcaa-aad4f2a66c32")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D95")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "695f4c79-90d6-4b0a-967b-42733076b01e")
+		(property "Reference" "D106"
+			(at 233.68 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "903b20d6-c578-4888-8730-d3c0e18aa06e")
+		)
+		(pin "2"
+			(uuid "404b33f7-bdf7-4f68-83c6-a160bf1fb2f7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D106")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6aa79de9-555a-4ed1-93d3-b801685ebd28")
+		(property "Reference" "D53"
+			(at 132.08 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b2031fe-ef72-48a9-afa6-c06144a31b2c")
+		)
+		(pin "2"
+			(uuid "7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D53")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6b349af3-e96d-42ed-a60b-1fcc6b2649ce")
+		(property "Reference" "D92"
+			(at 213.36 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bb4396c1-91b0-45de-ba96-3d4f74f6cf48")
+		)
+		(pin "2"
+			(uuid "b8385798-a88a-45df-851b-dcd7d4329aec")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D92")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6bdaf872-00b8-4813-a1b1-3be3a6e9f042")
+		(property "Reference" "RC2-9"
+			(at 78.74 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b47928c2-316d-4b2a-9b65-93bc5a6a16f7")
+		)
+		(pin "2"
+			(uuid "4fe94ff2-bac5-49bb-b97c-9a9ebef4c923")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6df07c86-7d3d-4752-94e1-ef193764a6be")
+		(property "Reference" "D108"
+			(at 233.68 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8996cfc8-a40d-4e18-bba0-a53b24949546")
+		)
+		(pin "2"
+			(uuid "3f3c5bd0-2a23-44ca-87a1-4ba1ae73b733")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D108")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6ef4f980-15ce-420f-b02f-d66ae810e188")
+		(property "Reference" "D78"
+			(at 172.72 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "680d9493-5437-446a-836f-9ed5bb999bdf")
+		)
+		(pin "2"
+			(uuid "d64a76a9-3b5d-48b1-9a48-ee12b0cd1ab7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D78")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "70d661b8-51f1-49b8-ad84-9ce8d120c0fc")
+		(property "Reference" "RC6-2"
+			(at 160.02 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e2175ea2-22e6-4720-ab54-24959d43a616")
+		)
+		(pin "2"
+			(uuid "63a1bf12-3f2f-4dc8-8a86-7932361b8306")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "712ade27-46b2-4d0c-b658-ec3775a1c528")
+		(property "Reference" "RC3-8"
+			(at 99.06 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4811e298-73bc-4ac1-af58-3ae7f508d1d7")
+		)
+		(pin "2"
+			(uuid "ac21b718-c133-4ed3-a2f4-c437b7879cce")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7167cfb1-88a6-4287-88a0-a986fb3f21f5")
+		(property "Reference" "D101"
+			(at 233.68 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0c8392eb-a8a3-486f-b665-59319eb216e5")
+		)
+		(pin "2"
+			(uuid "5fbffba4-390b-4eeb-aae2-52f7131f4dc4")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D101")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "72047ccc-8813-4e13-ae4a-04618a9ab771")
+		(property "Reference" "D23"
+			(at 71.12 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84")
+		)
+		(pin "2"
+			(uuid "6dee3493-b1eb-401e-abb4-cbdef0ef3867")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7295efa3-e253-4b6b-ad8d-641bcea1e272")
+		(property "Reference" "D68"
+			(at 152.4 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0450f5cb-94f5-4de3-b50e-da553aca1ff3")
+		)
+		(pin "2"
+			(uuid "47f460cc-5812-4c14-b97e-030930a4c1aa")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D68")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7322809e-8332-47c6-af41-fcf3bbcec7d0")
+		(property "Reference" "D34"
+			(at 91.44 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e3b096d1-dbd9-4fb8-8775-725a7aed0bc4")
+		)
+		(pin "2"
+			(uuid "63756bb0-b693-4bbc-82da-e89a6b927e71")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D34")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "73fe2e30-76b5-4c9f-968f-cc1ed14e142d")
+		(property "Reference" "D116"
+			(at 152.4 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b5e08441-3e51-488f-9243-b159a8be9e4c")
+		)
+		(pin "2"
+			(uuid "49e66f6b-8bce-4939-aaaf-5836c6eb7e43")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D116")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "75e13388-d7c5-4583-8a3d-9b2d5836631d")
+		(property "Reference" "RC9-0"
+			(at 220.98 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df3fb1ca-e1d7-4dba-9f10-debc4bd28da0")
+		)
+		(pin "2"
+			(uuid "8e4b1d03-6eb1-4014-a87e-35bcdd8c8002")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "76054860-648b-474e-9b4d-cc9d83653495")
+		(property "Reference" "D10"
+			(at 50.8 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d7e8bc-1ac3-4327-ab17-369de6ee755c")
+		)
+		(pin "2"
+			(uuid "c8283bba-c907-48e0-9745-e0818ca7ab04")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "77aa25a5-82c7-42c3-9d55-8606dd65ffa8")
+		(property "Reference" "RC5-1"
+			(at 139.7 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51db5d58-5004-4c9c-b8d1-c184bfb493da")
+		)
+		(pin "2"
+			(uuid "16d6f605-4627-49bd-9180-8203902febfd")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7876e2e4-9d5a-416f-b97a-e958a989e5b8")
+		(property "Reference" "D16"
+			(at 50.8 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8bd5710-8f18-4748-9b3c-a975f78342a1")
+		)
+		(pin "2"
+			(uuid "da0aa924-203b-4985-9bff-4185f3555d43")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D16")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7b85c895-ed2f-4daf-bbd5-9b0e9148eed9")
+		(property "Reference" "RC7-8"
+			(at 180.34 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c6604866-4e4a-4cb4-bf09-ea0fa22fde38")
+		)
+		(pin "2"
+			(uuid "0729bbae-70ee-4c7e-8da7-29c0812b5be7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8010e136-1dd3-496f-b7ef-81fb0c8b419e")
+		(property "Reference" "D20"
+			(at 71.12 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5aa5bf69-e040-48d4-81fc-332aff45c2f9")
+		)
+		(pin "2"
+			(uuid "f5458189-75e2-45c3-bf32-0320ebe63391")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80a5b4aa-1a01-46e1-a016-7ed59d3b23df")
+		(property "Reference" "D109"
+			(at 233.68 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b1ab302a-29f6-42be-bbd0-64440eaa5e08")
+		)
+		(pin "2"
+			(uuid "9d2d85fb-6651-43ce-bf4b-5fd87aa66988")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D109")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80c46ab4-724f-418d-bb6f-e89792097e1a")
+		(property "Reference" "RC2-4"
+			(at 78.74 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc0fd3d-897b-4e06-ac65-16066b68709e")
+		)
+		(pin "2"
+			(uuid "b7b98128-d37a-4ac7-b049-5cf9bdd5aadb")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "814545b5-c5a6-4c45-83b2-5c1b5ef43a22")
+		(property "Reference" "D57"
+			(at 132.08 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "adc35f03-9c02-4ca4-bbc5-866d317a7469")
+		)
+		(pin "2"
+			(uuid "f05a395b-0185-4ab8-bf1d-fa0561316ad4")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D57")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "816cdc19-a693-48c3-988d-f7be0c4ea986")
+		(property "Reference" "D103"
+			(at 233.68 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a6b3fcb4-74af-40e0-8945-de2253b431d8")
+		)
+		(pin "2"
+			(uuid "3ccd5a59-b066-4c26-aaf7-7ea481a9509d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D103")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "81912d5a-1def-44e9-a6ef-abaf3ecd517d")
+		(property "Reference" "RC6-1"
+			(at 160.02 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fa9aca31-bd8b-4e2e-8b86-05d191575df9")
+		)
+		(pin "2"
+			(uuid "fce38bd6-fb8f-42a6-8d68-ecda7f1a588f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "820f9c2f-0705-41a0-aa6a-3a211d61773f")
+		(property "Reference" "RC6-7"
+			(at 160.02 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb135129-1d78-4d36-9389-941aee94da0a")
+		)
+		(pin "2"
+			(uuid "2a32e7b7-f134-4c47-a153-d8fce8404094")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "827c7160-8cd9-45ad-ab1d-e47e85f01713")
+		(property "Reference" "RC0-10"
+			(at 38.1 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "38b5b850-4e9b-41a1-9787-c20514d29999")
+		)
+		(pin "2"
+			(uuid "702d7ea7-e102-48d3-ac2a-bf8aee7adc03")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83cc3bf3-09a0-4d14-be9d-180ca479485f")
+		(property "Reference" "D73"
+			(at 172.72 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22a68b69-e4e9-436e-b154-616fe8bb66c2")
+		)
+		(pin "2"
+			(uuid "b8e81b5d-9257-4482-8c33-cdfcb13c22e7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D73")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83fb734e-dbcd-4939-9bb9-d97efd05ec97")
+		(property "Reference" "RC5-6"
+			(at 139.7 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7315a9fc-fd63-46c2-90db-bee656dc7568")
+		)
+		(pin "2"
+			(uuid "f2997912-9551-49e9-aab8-387875819f56")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8408f1ce-a660-4217-a7dd-6677d6fa5c0c")
+		(property "Reference" "D96"
+			(at 213.36 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eaa398b7-f50e-4597-99f7-b1dcab75a526")
+		)
+		(pin "2"
+			(uuid "5719d7b4-74f2-42c4-b1c6-34b59ae5b787")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D96")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "84146f81-04f3-4efb-b753-bdc596c8e7a9")
+		(property "Reference" "RC4-3"
+			(at 119.38 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "774ced50-3b17-48fe-b2d7-22681b1dd1f7")
+		)
+		(pin "2"
+			(uuid "bad310c0-ca25-47d0-b27e-42438b959c7b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "845c03a4-a29f-4060-99ff-96f7d714901d")
+		(property "Reference" "D113"
+			(at 91.44 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90e2b51e-2aec-4797-944d-5cb436a4d4c1")
+		)
+		(pin "2"
+			(uuid "4770df96-19a9-4485-a1b6-ea90ea64b2cb")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D113")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8475a219-4e20-438a-84d8-4847d5d45c64")
+		(property "Reference" "RC9-5"
+			(at 220.98 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8668fb6-f91a-4502-9f57-a2869aa9f6f1")
+		)
+		(pin "2"
+			(uuid "8e2e3508-e150-49c5-a82e-0ccd478af757")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "85a68001-32f0-411b-bf16-3041cb3149f9")
+		(property "Reference" "RC10-4"
+			(at 241.3 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7542bca1-7e3d-46dc-a73b-a5a78a75187f")
+		)
+		(pin "2"
+			(uuid "bb178a6d-6e6c-4b4c-a89e-2573f4dafa3c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "85c7a9fb-2ee2-4035-ac87-9de0421b7051")
+		(property "Reference" "D119"
+			(at 213.36 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8ed1820b-4233-41ce-9b35-a126d7cf3f3e")
+		)
+		(pin "2"
+			(uuid "385695f7-ce9d-4258-947a-541bacc5ac20")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D119")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86602dfb-ea19-4060-ad39-496c613a47cb")
+		(property "Reference" "D30"
+			(at 91.44 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "02958e5d-18b7-48f3-9883-661ceaa75da5")
+		)
+		(pin "2"
+			(uuid "abed4b13-9431-40c7-848f-b30c05e39dfd")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D30")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "89d1107f-b11c-4e03-8d61-d6ad988c2118")
+		(property "Reference" "RC2-2"
+			(at 78.74 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0c23c54e-b888-47bc-8530-d2ba6720b448")
+		)
+		(pin "2"
+			(uuid "467d094f-64c9-4904-ad4f-dbacf7eda38e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8af20987-c3c2-465e-8640-61ab0bd7d8fa")
+		(property "Reference" "D81"
+			(at 193.04 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f42cdbf-02ba-4b39-8586-bbff1b6ed80b")
+		)
+		(pin "2"
+			(uuid "7d939371-3ab1-4f18-b55f-07048dcfe21f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D81")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8b2b0803-8190-43b4-9c0d-a9a9edc27829")
+		(property "Reference" "RC2-7"
+			(at 78.74 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8e9f64d-5849-4a62-8bf4-dafc65fcdd75")
+		)
+		(pin "2"
+			(uuid "e45fa11d-c755-4d62-baa5-974f973ba20f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c168cda-0a39-478d-9d71-1073400c7ed7")
+		(property "Reference" "RC1-5"
+			(at 58.42 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d2851af-db15-44cf-8e07-da339bdc18b2")
+		)
+		(pin "2"
+			(uuid "94b381a2-7c19-4916-9f9a-ee00221d04d3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 129.54 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7")
+		(property "Reference" "DI4"
+			(at 262.89 125.73 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c02807d6-1705-4325-bcb0-203f4e9a5baa")
+		)
+		(pin "2"
+			(uuid "d6c46059-bf9c-4959-836e-e4d33dcc5edd")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8eb7a7fa-054b-460a-a80c-73a56219fecd")
+		(property "Reference" "RC7-0"
+			(at 180.34 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be9c1065-912d-49b5-8f2f-271b4a0c1db2")
+		)
+		(pin "2"
+			(uuid "626f5614-e69d-4277-acf6-7ff35b08ddb4")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "90049005-7b99-4d2f-9282-dbf53b76b55d")
+		(property "Reference" "RC3-7"
+			(at 99.06 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "62acb361-e48a-40de-9689-6c103c4c7663")
+		)
+		(pin "2"
+			(uuid "f3ee11cf-4f81-4591-ab5d-f41aece910dc")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 186.69 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "91a5d9b4-63df-4567-88f7-1d2f7ac8c33d")
+		(property "Reference" "DS7"
+			(at 177.8 187.325 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 177.8 184.785 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2ec7f316-054f-444d-9c0b-c2c6e1d51faf")
+		)
+		(pin "2"
+			(uuid "e22dc61a-a86f-42a7-9c26-623bb8233a05")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "92030355-9e31-45db-a9ef-a705772288a6")
+		(property "Reference" "RC6-9"
+			(at 160.02 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "83a62e7f-2925-4bbe-9dad-6089ad98ff2d")
+		)
+		(pin "2"
+			(uuid "c1b87b81-e623-49b5-bacd-1c525772e150")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "933178a7-83a9-4f29-88ef-1e369645dcaa")
+		(property "Reference" "RC2-8"
+			(at 78.74 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4d133f2b-f4f1-4994-a89d-7141989cf18e")
+		)
+		(pin "2"
+			(uuid "9ed70267-ef82-4b49-85af-67297365ea60")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "93921179-259f-4393-a6ae-bfcb2df690b6")
+		(property "Reference" "D80"
+			(at 193.04 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d32d457e-c0ce-46dc-ac4a-08e965633eab")
+		)
+		(pin "2"
+			(uuid "0645b564-d7c5-4845-82b9-8702f3f470a4")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D80")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "93dd9936-9573-4973-8fb2-a71d5e19f115")
+		(property "Reference" "D94"
+			(at 213.36 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7beb185a-6309-4671-8dd9-da0c3ef9bc52")
+		)
+		(pin "2"
+			(uuid "baeb1083-702e-43e8-9a5d-760812497130")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D94")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "954ebd6c-531e-47b1-a7ea-7de1ed03bb85")
+		(property "Reference" "RC6-6"
+			(at 160.02 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6bd2ec94-c1bf-43e5-93c3-e16c69deda42")
+		)
+		(pin "2"
+			(uuid "bc20e945-7eb5-47aa-ba38-8dbe3eaede1c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9578a4b6-1a56-40b7-be8d-56404ef59fdf")
+		(property "Reference" "RC1-6"
+			(at 58.42 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0b899b44-3ae3-40be-a452-1f16eaa5f4af")
+		)
+		(pin "2"
+			(uuid "11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 109.22 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "957e7a82-ca9c-46a8-bca9-099b05fe7e8f")
+		(property "Reference" "DI3"
+			(at 262.89 105.41 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc53fac9-006c-4101-8113-949ab8e05afb")
+		)
+		(pin "2"
+			(uuid "f6122429-5885-4b7a-b72a-162ca49c70c2")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9789c79d-d74e-4c16-a474-31201e3b4997")
+		(property "Reference" "RC0-9"
+			(at 38.1 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b4d335e-fe84-4869-8670-3368a7ef15e9")
+		)
+		(pin "2"
+			(uuid "3a372e91-311a-4276-8504-54c40aee2304")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "98a45ae1-6346-4607-b0c8-1479c51b1f75")
+		(property "Reference" "D49"
+			(at 111.76 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "245fa70b-724d-4379-9c74-b8f5c8d9569d")
+		)
+		(pin "2"
+			(uuid "964a681d-53eb-46ee-b5d9-73ca4400bb74")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D49")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9963ab0b-003e-4aca-bc8b-9e0a5e01de7f")
+		(property "Reference" "RC3-3"
+			(at 99.06 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0e78455b-408f-4532-8244-190950de64ff")
+		)
+		(pin "2"
+			(uuid "51c789b0-4434-42e9-80fa-6817bda53d0d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9af5b930-d274-4b05-b0bf-e2c27b7e71dd")
+		(property "Reference" "D6"
+			(at 30.48 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bdad3d4-58ec-438c-beb8-3eea36a29d95")
+		)
+		(pin "2"
+			(uuid "5ff4e8af-dd18-4010-b183-21b8178cd684")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 88.9 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd")
+		(property "Reference" "DI2"
+			(at 262.89 85.09 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a")
+		)
+		(pin "2"
+			(uuid "81e4b9c6-9b09-4e38-94e9-cebdeae457ee")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e96ab02-44ee-4ac7-8251-0d309b7409ad")
+		(property "Reference" "RC5-3"
+			(at 139.7 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd85b120-1be2-4f17-a3d7-505a734afc72")
+		)
+		(pin "2"
+			(uuid "666e03ce-bf1c-4b58-ac4e-f01557ca11fd")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a026138b-aabb-432d-b516-5341ad9fe06b")
+		(property "Reference" "D39"
+			(at 91.44 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6257e834-355d-4e0b-a5bb-744bef7d141f")
+		)
+		(pin "2"
+			(uuid "8be7ee86-36bb-4b87-9942-9d15d9003e1c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D39")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a0ceebe8-8bed-40e1-b6c6-b65a1c2e15c7")
+		(property "Reference" "D115"
+			(at 132.08 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "75df5fc5-2bbb-479d-b927-92c2a479919f")
+		)
+		(pin "2"
+			(uuid "bacdf9a6-57fe-4ece-ba49-00f48d544136")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D115")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a1e6073b-e736-4ea3-b4f5-31effb1ededc")
+		(property "Reference" "D112"
+			(at 71.12 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "04d10445-42c8-4462-b56c-145fa5cb598d")
+		)
+		(pin "2"
+			(uuid "4d1b5ab5-c53c-49d9-ae4e-3cb42d0a2b8e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D112")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a3969e5a-abe0-44e9-adf1-6255946e3f4c")
+		(property "Reference" "RC6-0"
+			(at 160.02 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc4d6aea-ec1e-45c7-842c-68cd7e21336f")
+		)
+		(pin "2"
+			(uuid "f785fa77-0ac2-41ff-9704-1acbb4a72c84")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a400377f-e146-4099-97e7-db21e16d5759")
+		(property "Reference" "D3"
+			(at 30.48 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bfc71c1-6349-4b3f-bf89-22c83277904e")
+		)
+		(pin "2"
+			(uuid "dafd4b6c-6c2f-41e0-95ab-05ead276d86d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a4f847ba-a334-4631-aef3-ca47db1a1700")
+		(property "Reference" "D29"
+			(at 71.12 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc5b522c-bddd-4a8d-8ded-7fc36acfc178")
+		)
+		(pin "2"
+			(uuid "8e96df26-db08-4a3c-92ce-ba5029c624ac")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D29")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a576c983-0812-4f76-8327-d260ce9c2826")
+		(property "Reference" "D27"
+			(at 71.12 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c11deb1a-dbe0-4d39-8303-331b09dd3cc0")
+		)
+		(pin "2"
+			(uuid "9251c46a-97e6-41c1-9326-a6a8b52abc12")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D27")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a71b771b-4e14-4d95-98e7-86a6250f569e")
+		(property "Reference" "RC0-4"
+			(at 38.1 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "95049e61-b78e-490f-86e1-aba711db5c19")
+		)
+		(pin "2"
+			(uuid "6e474ba8-5b88-41c8-9259-b0ebfb6012f0")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a7415034-f7b1-4b4a-bc99-efb9b1d73bd0")
+		(property "Reference" "D102"
+			(at 233.68 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "231d155d-b8f1-4a91-b6f0-625ec31124f7")
+		)
+		(pin "2"
+			(uuid "1889e496-f8e9-418d-9a77-7351d4b4828c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D102")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "aac180ff-c5e7-4a0e-9a07-44c1b3bcc7fe")
+		(property "Reference" "D59"
+			(at 132.08 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c6b5d04d-906d-4f18-b7a3-382b3a768815")
+		)
+		(pin "2"
+			(uuid "d74367e2-5126-4fe7-ac31-7039cd9552e5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D59")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "abf3c9d9-a279-4546-abcf-5e4f6862bc48")
+		(property "Reference" "D2"
+			(at 30.48 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a3499f31-3593-4cd9-977b-3b6479091d7b")
+		)
+		(pin "2"
+			(uuid "17f09d49-1093-4838-8e5c-8fc4c42e5d05")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac10b530-144b-4dfc-ab37-ad7a8ced8612")
+		(property "Reference" "RC4-5"
+			(at 119.38 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d6c95156-54b9-4f54-a278-f808b4871687")
+		)
+		(pin "2"
+			(uuid "c3dc8d92-1759-4195-a3c9-81260bc6d8b1")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac95bba7-885e-446e-b059-0ba3c38e43f7")
+		(property "Reference" "D19"
+			(at 50.8 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "63ad0fd9-4009-4287-bfa1-9dc63b978ef3")
+		)
+		(pin "2"
+			(uuid "d7eafe2c-7576-4ddd-821f-8f8bca43ff92")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D19")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 85.09 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "accba515-4e8d-4804-afea-f36f436141c3")
+		(property "Reference" "DS2"
+			(at 76.2 85.725 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 76.2 83.185 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "034e4344-7cda-43bc-a12a-f56b6e8f68f5")
+		)
+		(pin "2"
+			(uuid "6f0bef00-c613-46da-9667-752b92174ad1")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ad352cc7-0ffd-4a04-82ac-bc693299cd86")
+		(property "Reference" "D83"
+			(at 193.04 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9662d2b8-61ec-4840-a8f1-af48833c11eb")
+		)
+		(pin "2"
+			(uuid "4d0c4f9f-b435-4d30-95d7-23d9f87d5f48")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D83")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ae019221-3fd0-468c-9cf0-dac8d7470e8e")
+		(property "Reference" "RC9-3"
+			(at 220.98 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be20235f-2999-4595-bedf-c52cf23b7bd1")
+		)
+		(pin "2"
+			(uuid "f57afa4c-8044-4217-b32d-12bed3437591")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "afcc8d67-6ed8-4a82-aef7-417b4229ad61")
+		(property "Reference" "RC7-4"
+			(at 180.34 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "982715f0-55ee-4146-b98e-756e5b630dca")
+		)
+		(pin "2"
+			(uuid "7f384a84-9632-4ac9-a8b6-05778cf49f62")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b05bbd1d-9d65-4ef7-a639-885ae69d8b01")
+		(property "Reference" "RC8-0"
+			(at 200.66 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "16c6866c-1d06-4257-9cde-9d9c6f4c3642")
+		)
+		(pin "2"
+			(uuid "70b152f6-7e7d-4a93-9ef0-b6ec51ff9b25")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 247.65 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b1c53fc7-e42c-414d-ae3a-1dfd6dab01ad")
+		(property "Reference" "D111"
+			(at 50.8 247.015 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 249.555 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 247.65 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "af2c92cb-5c58-4d6d-908e-91654bde79db")
+		)
+		(pin "2"
+			(uuid "d2964c5f-b1ae-499b-b6cc-5eb8d8150b62")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D111")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b2bdfb59-b351-44dd-8797-c36e151a03c2")
+		(property "Reference" "RC4-4"
+			(at 119.38 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6d389aae-8651-49ec-9923-0a9cfe96d0b0")
+		)
+		(pin "2"
+			(uuid "f92b3875-8420-4f8e-a622-19ee07fc28bf")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b2cc8c06-500a-41ac-a412-7baf61e0f24c")
+		(property "Reference" "RC6-3"
+			(at 160.02 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a77d5cb-df53-4102-99ed-4829fa686656")
+		)
+		(pin "2"
+			(uuid "22df81c2-2a06-44e2-bed1-a6d6c14df76a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 146.05 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3573dc3-ef18-4f4c-817b-c984ae7cfae9")
+		(property "Reference" "DS5"
+			(at 137.16 146.685 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 137.16 144.145 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "813e7cf6-f821-4e03-95cc-308010bed54e")
+		)
+		(pin "2"
+			(uuid "9669a028-42d7-436f-8ec5-bc3423db62d6")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b39d56f9-3079-43e4-bb1b-80277fdae425")
+		(property "Reference" "RC4-2"
+			(at 119.38 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b205d044-9ffa-4dce-82fd-f51ba622a818")
+		)
+		(pin "2"
+			(uuid "29ce7588-4a17-4be4-9207-ea3ed2669aa1")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c497a9-b81f-4161-88cf-2e58ddb4cdd8")
+		(property "Reference" "RC3-4"
+			(at 99.06 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae78f0d3-f75a-49c8-ab9b-8a9831e434d7")
+		)
+		(pin "2"
+			(uuid "a59e897c-0784-437d-9243-baf91d40a453")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b4258223-eb85-47a5-b84c-0db880fc4f11")
+		(property "Reference" "RC10-5"
+			(at 241.3 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "59599fa7-6060-470f-b661-a270f65a3960")
+		)
+		(pin "2"
+			(uuid "8b45f29d-0cbd-414e-9212-2948f143ec62")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b92624bc-936a-4bc6-ac7c-dbc9faa7208a")
+		(property "Reference" "D8"
+			(at 30.48 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0ef02d0f-103e-468b-b30c-fac4e90fb218")
+		)
+		(pin "2"
+			(uuid "aa510cff-115d-4ad1-9c78-bf1246172261")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba3c5bf2-9824-404a-befe-7584c286e012")
+		(property "Reference" "D48"
+			(at 111.76 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "38e4de38-525a-4e2c-8e51-9d4770973903")
+		)
+		(pin "2"
+			(uuid "e71e068d-4f7e-493a-960b-e49aa171ca56")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D48")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba9018cb-07e4-4089-9c00-6840b6e47ce6")
+		(property "Reference" "RC10-0"
+			(at 241.3 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1ec01f7f-759e-4fa4-9f08-5c89efa2cc11")
+		)
+		(pin "2"
+			(uuid "7927caf8-4f39-475e-ab72-b869d94229b3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba927934-b2e1-4953-b21b-54ef02be8935")
+		(property "Reference" "RC0-5"
+			(at 38.1 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cadba0a-3bb3-40cd-acea-644da4b3e05f")
+		)
+		(pin "2"
+			(uuid "1368ebac-096c-415f-acaf-9afb071e729f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bb2c72f0-a908-44e7-b7d5-67df52eed516")
+		(property "Reference" "DS4"
+			(at 116.84 126.365 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 116.84 123.825 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5ab0b348-3e2a-4517-90b3-fad111de6205")
+		)
+		(pin "2"
+			(uuid "6e7351bb-5d09-464f-9e8d-535ba0f5c6f3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 207.01 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bbc3ae57-e1db-475c-9bc3-18c822e7531a")
+		(property "Reference" "D28"
+			(at 71.12 206.375 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 208.915 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 207.01 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90783402-edc5-4638-ae16-d31c3aaf5e2b")
+		)
+		(pin "2"
+			(uuid "f9e9c399-273d-43fc-9007-1e5ca67fea38")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D28")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be02506a-2bb1-4713-b046-f0327dae72de")
+		(property "Reference" "RC0-1"
+			(at 38.1 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97a92abd-708c-465e-baf7-79fa35370a7c")
+		)
+		(pin "2"
+			(uuid "c9056b1e-419e-478d-9fc4-be1e95902d28")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be554787-60ed-4b8f-b7bc-2220fcd28430")
+		(property "Reference" "RC8-3"
+			(at 200.66 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "76eac86e-4d5a-4833-a702-c89fc5eb96e0")
+		)
+		(pin "2"
+			(uuid "6e41d262-c7fe-4c54-b525-59ae026a918d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d")
+		(property "Reference" "RC5-2"
+			(at 139.7 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f22c39d-012a-4297-b61c-1ff841801333")
+		)
+		(pin "2"
+			(uuid "adbe8c88-ad34-405b-866a-efb64899002f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bf639842-72e9-4bdd-be11-7972d8d5c3c4")
+		(property "Reference" "RC3-9"
+			(at 99.06 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8015b627-c562-4073-8a9c-3d88306d5597")
+		)
+		(pin "2"
+			(uuid "b34e9dd8-5aad-496e-81b0-f2f5cb3bdb66")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c11b6807-83e7-46af-9d7e-9d56aab4109c")
+		(property "Reference" "D46"
+			(at 111.76 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46")
+		)
+		(pin "2"
+			(uuid "6764bae9-067c-4178-897e-2c25048ade8b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D46")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c164cb58-7d29-400c-b219-f07036f5e8c9")
+		(property "Reference" "RC0-3"
+			(at 38.1 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92164ea1-76d0-4223-80cc-32c093c14fcd")
+		)
+		(pin "2"
+			(uuid "e615b2e5-6986-47ac-8f35-da60c20b811c")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c38cba3d-abb3-4489-8620-78b7017d5c40")
+		(property "Reference" "D100"
+			(at 233.68 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eba02688-21b5-4572-9e9b-df8382a314e1")
+		)
+		(pin "2"
+			(uuid "106a2fb9-b74c-4d49-b2ef-4fc3f78df241")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D100")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c43b92c2-4283-44f7-8cb3-665623564383")
+		(property "Reference" "D42"
+			(at 111.76 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0929e13-ab77-4737-9d55-142bd9901b1c")
+		)
+		(pin "2"
+			(uuid "0f45988c-1752-479c-97d5-fbada14f9a42")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D42")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c64cc71e-aae1-49fa-83d0-4d8a51355bc6")
+		(property "Reference" "D9"
+			(at 30.48 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "328932ea-b1f6-431f-8c23-8a2d8eae8bba")
+		)
+		(pin "2"
+			(uuid "10eab654-b7fb-42dd-bf39-41b39e8328d6")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c72dd108-be98-47d5-b809-561778aa3212")
+		(property "Reference" "RC2-5"
+			(at 78.74 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d2f0fd-ce69-4d4e-a4ab-163c1691ef24")
+		)
+		(pin "2"
+			(uuid "03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c7f185b3-c785-4ddb-9c6f-f854c93057c1")
+		(property "Reference" "D85"
+			(at 193.04 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b8f08018-67e0-4945-91d2-9a40292e0a1a")
+		)
+		(pin "2"
+			(uuid "096b6293-e540-4273-b6aa-9e314016c840")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D85")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe")
+		(property "Reference" "D50"
+			(at 132.08 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a606860e-126b-4f3e-bcfe-a2dfa8adc9c8")
+		)
+		(pin "2"
+			(uuid "59120505-a333-4c63-8904-aa379cfb043b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D50")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c996541a-3b07-4fed-9687-afa9b7ffb878")
+		(property "Reference" "RC7-5"
+			(at 180.34 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "560b334e-ed5f-40a2-b100-5974e92ce94c")
+		)
+		(pin "2"
+			(uuid "55bbe733-1ff6-4a73-b892-49d49c6c0fc9")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce521a1c-e123-4f49-866e-f4f51848f864")
+		(property "Reference" "RC7-2"
+			(at 180.34 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2a9b15ea-df9e-4ef0-a128-13d2e129d7f7")
+		)
+		(pin "2"
+			(uuid "e9530707-f705-4741-a308-e08f558f67a1")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e")
+		(property "Reference" "D51"
+			(at 132.08 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48596e1c-4629-46bb-98c1-de11cd41e539")
+		)
+		(pin "2"
+			(uuid "f7decfb7-c4ef-4861-ba8a-043f44f3b09e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D51")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf81ef85-b58f-422a-b88a-7b7914aa3581")
+		(property "Reference" "D12"
+			(at 50.8 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e34c154b-a3cb-467d-891b-2f2891056190")
+		)
+		(pin "2"
+			(uuid "dc926c49-c915-470d-b2b5-00749f3505bb")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d2a28b21-08a4-472a-9f34-48db4deebb9f")
+		(property "Reference" "RC10-9"
+			(at 241.3 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e8b2d3fe-8c4b-40e0-b791-ed869e3b96f2")
+		)
+		(pin "2"
+			(uuid "b9d47461-c0d0-4606-9625-d5e52d2e1041")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d2e0ab87-3807-4a88-be47-f5c2586bfeb9")
+		(property "Reference" "RC1-9"
+			(at 58.42 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "905c7978-373b-43c6-894f-f9da59358409")
+		)
+		(pin "2"
+			(uuid "9dabc73f-860c-4bde-9950-7e2511b1e9b3")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 227.33 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d352da38-bdf9-428f-a8d9-8df6c9a36ec3")
+		(property "Reference" "D89"
+			(at 193.04 226.695 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 229.235 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 227.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4c3fc4a6-4570-4b34-b7cc-c9d681cef14a")
+		)
+		(pin "2"
+			(uuid "7d95533d-af2b-4a4c-b205-9385c93624cd")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D89")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d40b4fbb-e58c-433e-b2c5-236bb8aa92c5")
+		(property "Reference" "D1"
+			(at 30.48 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90049b07-ff34-407c-ad1c-bcb8b89b241c")
+		)
+		(pin "2"
+			(uuid "7bd5d68f-4902-47f7-bc35-be0973d0d904")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578")
+		(property "Reference" "RC5-0"
+			(at 139.7 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e5729530-792d-44f2-80ff-f6315aae335e")
+		)
+		(pin "2"
+			(uuid "01f42ec4-9037-47c0-8fc0-8f7345fd0a2b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d69b760e-d231-449e-ae78-5289569bfcf8")
+		(property "Reference" "RC4-8"
+			(at 119.38 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b2174dcf-3936-44c4-b9c9-8a8c2ffd5559")
+		)
+		(pin "2"
+			(uuid "553bf002-fd89-4554-b1c2-ed094fd5fe57")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d7b98385-4339-43e1-a83a-6daba8def1f8")
+		(property "Reference" "RC0-8"
+			(at 38.1 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c3a8852b-59c8-4849-9f9f-edc39c43f8e6")
+		)
+		(pin "2"
+			(uuid "f4bfef10-0157-4077-9c8b-8858eccf5c1a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69")
+		(property "Reference" "RC2-1"
+			(at 78.74 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba2015a3-c3ad-44cf-b530-b2a60bac2c12")
+		)
+		(pin "2"
+			(uuid "12bdf482-8bd0-4b7d-a511-fcaadc8ab54d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "daefbaa6-3e17-4eca-837b-024ccac5fc10")
+		(property "Reference" "D14"
+			(at 50.8 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12e5236e-b23d-4e38-9768-e28d1693b6eb")
+		)
+		(pin "2"
+			(uuid "1be4fe23-ac83-4b50-b43f-2e4b33c335d7")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dbb7c48e-1b69-4840-9f8a-f0ac68b4296d")
+		(property "Reference" "RC10-8"
+			(at 241.3 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0b11d916-53f3-4439-97e3-3f053db0d0f4")
+		)
+		(pin "2"
+			(uuid "26e77532-f2b2-4eab-89dc-7fae6951ac49")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 215.9 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "de9b7bb1-afa1-4e19-b963-4516a18a17bf")
+		(property "Reference" "D91"
+			(at 213.36 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 213.36 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 215.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6167a490-f64e-4925-8d8a-b4543a48c019")
+		)
+		(pin "2"
+			(uuid "b78fba3b-33a1-4c3a-941e-dc9814c91e24")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D91")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "df14ac0c-5b64-41d1-ac61-954e84a88f4b")
+		(property "Reference" "D47"
+			(at 111.76 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7284aa2f-4456-4e07-9251-a86b7acd95b1")
+		)
+		(pin "2"
+			(uuid "c06243a0-5a23-4af5-88df-f2a88bfb1da0")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D47")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e214b496-153e-40f8-93df-30f96574576d")
+		(property "Reference" "RC6-8"
+			(at 160.02 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "762c516c-df17-4ae0-8f7f-03315e74925e")
+		)
+		(pin "2"
+			(uuid "874fed4d-cc1d-47bf-b14e-533fedfc9875")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e255666b-19cd-45a4-b5c1-8997235eb1ad")
+		(property "Reference" "D72"
+			(at 172.72 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92803ca1-7814-4c2f-986c-c7a2afaea4b2")
+		)
+		(pin "2"
+			(uuid "f1e544c9-5e94-460f-960c-d30fdb857f44")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D72")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 203.2 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e345b77c-4943-4943-8fff-9d2c0a863651")
+		(property "Reference" "RC9-8"
+			(at 220.98 196.85 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 198.12 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 203.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3c5bbf7f-11d9-45e3-9492-3b3f4802883c")
+		)
+		(pin "2"
+			(uuid "8e4fc19e-5f68-43e8-b4a4-baf188b4cd3a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 195.58 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e433e872-70f0-4e5b-b473-1ebd1af79f33")
+		(property "Reference" "D84"
+			(at 193.04 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 193.04 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 195.58 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2c838395-b13b-44f3-9cda-ae0061827054")
+		)
+		(pin "2"
+			(uuid "b7abe52a-50b6-4b31-8da0-3b0e1433e922")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D84")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e4362acf-dcaf-47ae-b824-45cc81be26fd")
+		(property "Reference" "RC9-4"
+			(at 220.98 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "59031059-0660-4b8b-bc7c-d25dfdf99292")
+		)
+		(pin "2"
+			(uuid "8d191698-0ba8-4bfd-9183-392ad5be38af")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e490f25a-1360-4f95-aa79-5f1d93892bb3")
+		(property "Reference" "RC3-5"
+			(at 99.06 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "056973a8-92e3-49be-9b21-fe961241d12f")
+		)
+		(pin "2"
+			(uuid "01c4c06b-d45d-4ffb-ad72-57ca7686fd55")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 236.22 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e5c1c88e-f9c7-4c87-a0c4-3ca2d142293b")
+		(property "Reference" "D107"
+			(at 233.68 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 233.68 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 236.22 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 236.22 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 236.22 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 236.22 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 236.22 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4007740f-9871-42e9-bc5a-88a1bd3cb05c")
+		)
+		(pin "2"
+			(uuid "2d6b89ec-44b6-409d-98ce-d034565337e0")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D107")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e6262d19-9b35-41b6-845a-39c20b831416")
+		(property "Reference" "D76"
+			(at 172.72 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8324bd70-bd5e-4513-bc52-cc4e838003e8")
+		)
+		(pin "2"
+			(uuid "64285f25-2c5b-4231-8d94-7ba284d5a2d2")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D76")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e97aeea5-7475-4b9f-a312-6f51452496a5")
+		(property "Reference" "RC8-4"
+			(at 200.66 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b5d442a-c78e-4d0d-8f8c-3cc6c91bf307")
+		)
+		(pin "2"
+			(uuid "4b2eebd0-ccb3-482c-8c43-2690e285e66f")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 105.41 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b")
+		(property "Reference" "DS3"
+			(at 96.52 106.045 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 96.52 103.505 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "738869bf-f410-43b7-b7e7-4e927d69911a")
+		)
+		(pin "2"
+			(uuid "71649a24-87f4-49fb-9896-e50c64c03a31")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb153eb2-74b0-4cb9-b105-af356654d60d")
+		(property "Reference" "D24"
+			(at 71.12 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "77c4fd5e-5c79-4799-aab6-2f07a57c7df3")
+		)
+		(pin "2"
+			(uuid "a062346b-452b-46dc-a106-fab01848555d")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D24")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 262.89 231.14 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ec0ebda2-e0b5-4648-83ee-afd68a4093ad")
+		(property "Reference" "DI9"
+			(at 262.89 227.33 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 264.795 233.68 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 262.89 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 262.89 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 262.89 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 262.89 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 262.89 231.14 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "941790dd-6c84-4d17-8c86-cd053db9749e")
+		)
+		(pin "2"
+			(uuid "1cfb4960-1c24-46af-9168-505412fc1763")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ee3742e9-8e22-4413-88a6-b893a7cb3439")
+		(property "Reference" "RC8-6"
+			(at 200.66 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12157fba-1ac0-4b59-9ef4-f0b7f556fda2")
+		)
+		(pin "2"
+			(uuid "a6fa6d7f-615c-410e-9188-d1867808891a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eeca0e5b-e9f9-4790-9c32-e398887f1254")
+		(property "Reference" "RC8-9"
+			(at 200.66 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ee863615-0428-4134-aa77-1d7c4e3647ad")
+		)
+		(pin "2"
+			(uuid "7b155375-a70f-42ef-9309-987f1f53d011")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ef64a689-efe5-479a-a53a-19c9f4177765")
+		(property "Reference" "D74"
+			(at 172.72 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fc4be4a8-3bcc-4a9b-8dca-654b73020c91")
+		)
+		(pin "2"
+			(uuid "982449b6-25db-4afc-abf2-592e07b23449")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D74")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 241.3 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f122c030-5a9c-45f5-b8ba-c45e0254028c")
+		(property "Reference" "RC10-1"
+			(at 241.3 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 241.3 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 241.3 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 241.3 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a518542d-a321-474d-a528-b1ac405432fb")
+		)
+		(pin "2"
+			(uuid "8e1d9e00-0513-42d1-90ae-77a92818504e")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC10-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1920e34-64a4-41c9-8680-7fa42f5dfb9d")
+		(property "Reference" "RC2-0"
+			(at 78.74 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9242378-4df5-4b90-afbf-1098ccb8067f")
+		)
+		(pin "2"
+			(uuid "a135b9b9-316d-4cb2-a5a5-8d618a00a752")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1a5bcca-72b0-4fb1-9570-8abc0f731fb7")
+		(property "Reference" "RC1-7"
+			(at 58.42 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "058cb33f-3013-4884-ba52-2b175c6e6f25")
+		)
+		(pin "2"
+			(uuid "cb54004f-a1b9-489e-9cdf-00b812c2d5fa")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 243.84 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f2d1b442-f332-4cd5-8f37-082347d04ad7")
+		(property "Reference" "RC5-5"
+			(at 139.7 237.49 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 240.03 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 238.76 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 243.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b711bbbc-f96f-4962-a5e2-7b5cebc42152")
+		)
+		(pin "2"
+			(uuid "d05d308e-04e6-403d-8d5f-72c7cf2f105a")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f31d54be-89a7-479b-90a6-e9bcd6257412")
+		(property "Reference" "RC9-7"
+			(at 220.98 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 220.98 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 220.98 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 220.98 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f83ff9f6-7715-4e86-b4bf-0de9179fec70")
+		)
+		(pin "2"
+			(uuid "2a257b84-25fd-4cd2-9e3d-5ac106f662f8")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC9-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f735328c-2a24-4fb3-983d-b3e512d5a5cf")
+		(property "Reference" "RC8-5"
+			(at 200.66 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "af0d403b-f1be-40d9-bf46-12c29a8b07f1")
+		)
+		(pin "2"
+			(uuid "cf12207d-8835-4b4d-855b-207eb48891b5")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 223.52 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f93938b2-5ce6-4ad4-aef1-bcec2b0c3413")
+		(property "Reference" "RC4-9"
+			(at 119.38 217.17 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 219.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 218.44 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 223.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb557f65-fb80-44d7-9e25-f09389e948a7")
+		)
+		(pin "2"
+			(uuid "ef20bae4-a01f-4ba7-8d51-cad542d569ba")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 200.66 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f9c61822-7d54-487f-93d1-920e041f55a6")
+		(property "Reference" "RC8-2"
+			(at 200.66 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 200.66 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 200.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 200.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 200.66 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffd61ace-0250-4fd9-8d0c-c2c917d0d4b5")
+		)
+		(pin "2"
+			(uuid "d354ba15-00ca-4efb-954b-871f951259db")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC8-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc941f43-b642-4fef-8515-f8f851adced2")
+		(property "Reference" "D13"
+			(at 50.8 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c")
+		)
+		(pin "2"
+			(uuid "ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fcc35b13-8da5-4271-981a-5470b3add3e5")
+		(property "Reference" "D25"
+			(at 71.12 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0f0d662a-16b3-4c76-b4ee-49de18b57b47")
+		)
+		(pin "2"
+			(uuid "ba9a1f4c-173e-4b32-907f-fe9b31df718b")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fd13d6af-afdf-4367-a43b-1889348eabd8")
+		(property "Reference" "RC0-6"
+			(at 38.1 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "854af50a-a007-4ba3-a405-76f0f99e9817")
+		)
+		(pin "2"
+			(uuid "bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142")
+		)
+		(instances
+			(project "round-robin-12-110"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/round-robin-7-30.kicad_sch
+++ b/round-robin-7-30.kicad_sch
@@ -1,2841 +1,7645 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid cbac505e-77a6-4a00-a758-435de33cca16)
-
-  (paper "A3" portrait)
-
-  (lib_symbols
-    (symbol "Diode:1N4148" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "1N4148" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Device" "D" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Pins" "1=K 2=A" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "100V 0.15A standard switching diode, DO-35" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "D*DO?35*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "1N4148_0_1"
-        (polyline
-          (pts
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "1N4148_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 1.27 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "SW_Push" (at 0 -1.524 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "switch normally-open pushbutton push-button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Push button switch, generic, two pins" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SW_Push_0_1"
-        (circle (center -2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 3.048)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 0 180) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 104.14 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 06a6d1a8-0f12-4174-b63e-d35d8ca618bf)
-  )
-  (junction (at 63.5 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0a9113d4-8a8c-4abc-b886-f22c92ad18dc)
-  )
-  (junction (at 124.46 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29)
-  )
-  (junction (at 73.66 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0c7244ee-ddfb-470b-a70b-1cfc53f83773)
-  )
-  (junction (at 93.98 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5f3a7a-dc5d-4973-8743-eafaa1c1a462)
-  )
-  (junction (at 43.18 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 10cae212-bc64-40b9-b44f-13fd4a0406a6)
-  )
-  (junction (at 83.82 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1278b5e3-5eff-46d6-a162-44fde2066970)
-  )
-  (junction (at 104.14 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 17f3773a-2c02-426d-bcd6-7a35c59a710a)
-  )
-  (junction (at 73.66 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1c386ee6-5b9d-4eae-92b5-9440e81067f6)
-  )
-  (junction (at 93.98 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 21e320b6-a0c4-4d5d-babf-ee5274120507)
-  )
-  (junction (at 134.62 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 291db826-8863-42d6-a2e2-921b741b7753)
-  )
-  (junction (at 124.46 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 2b2b66bc-905d-4b48-89f5-1c62f6c27dbb)
-  )
-  (junction (at 93.98 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 31a1b16e-8174-4fea-bc42-9c75ed9182a0)
-  )
-  (junction (at 114.3 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 347306fc-87ef-43e1-a98f-ca29ac9473e6)
-  )
-  (junction (at 124.46 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 352af8be-9d08-4866-961e-b8632013179f)
-  )
-  (junction (at 104.14 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 356b49b0-20ac-4c33-8df8-9b27dee0b312)
-  )
-  (junction (at 165.1 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c)
-  )
-  (junction (at 114.3 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 490a89d7-a161-4f1a-9b45-a55729d9d59b)
-  )
-  (junction (at 124.46 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4c74baef-72cb-4cdf-b4eb-a3d28782257d)
-  )
-  (junction (at 53.34 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 4c7a50e9-7650-493b-b0a7-057b900a13a7)
-  )
-  (junction (at 63.5 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9)
-  )
-  (junction (at 43.18 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 4e641ba8-cbcf-42cf-89f0-ac977902bf98)
-  )
-  (junction (at 73.66 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 4fc826ad-ef7b-406a-9b89-76eb2c211523)
-  )
-  (junction (at 53.34 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 4fce0301-62b3-4ef1-9bae-8d55ea745d66)
-  )
-  (junction (at 53.34 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 53bb27f5-9b54-4704-b90e-33b3053be6c4)
-  )
-  (junction (at 63.5 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 670a793c-4c48-41d1-9f07-66b1d7d84b06)
-  )
-  (junction (at 83.82 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 672e2ce9-8f2c-43ff-9498-0e342bc1c65e)
-  )
-  (junction (at 43.18 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6bfc7531-8adc-4c87-bf8a-788404262765)
-  )
-  (junction (at 63.5 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 712da204-b8e1-4637-b967-521ccf7b108c)
-  )
-  (junction (at 73.66 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 71e77471-d824-448e-a6de-31cce05e17c2)
-  )
-  (junction (at 73.66 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 742ecb41-f257-40d3-a6f3-d155d6036628)
-  )
-  (junction (at 134.62 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 77ee3090-cccb-4e87-85da-203131141e39)
-  )
-  (junction (at 93.98 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 782ee96d-a257-4c78-ac0f-a3b5279bef37)
-  )
-  (junction (at 53.34 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 7943e9ed-5e22-49d3-a238-47d875f3e823)
-  )
-  (junction (at 134.62 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 7a10b798-0eae-48fa-874f-c983ca3ec677)
-  )
-  (junction (at 104.14 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 822096c9-a5b4-460b-8639-9bbf1bb1a2fa)
-  )
-  (junction (at 53.34 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 86d88f2b-6e5b-493a-b3a4-5436a8374fae)
-  )
-  (junction (at 83.82 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 8bf191a4-2dcd-4018-b67a-91aef9fad846)
-  )
-  (junction (at 144.78 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 8d88bb99-f0e4-4a81-b464-31814877675a)
-  )
-  (junction (at 165.1 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 95b0c111-7d27-49ee-a08f-b6f35d9d5b54)
-  )
-  (junction (at 93.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 96a12dd2-d02f-4a86-aa6d-3a7015c06462)
-  )
-  (junction (at 124.46 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9d2b0f02-b19d-4907-8835-9e7f8a8b9c34)
-  )
-  (junction (at 83.82 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b23bc3a0-3ebe-44a5-9126-8b5c4d648e08)
-  )
-  (junction (at 165.1 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b98759bc-77be-4dce-9aa2-cc5ce3889034)
-  )
-  (junction (at 53.34 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3)
-  )
-  (junction (at 144.78 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid befc6138-873b-4406-bc9e-e5a72f7f36fe)
-  )
-  (junction (at 83.82 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0)
-  )
-  (junction (at 63.5 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid c0959c68-283c-45f6-92d0-52fdc869aa4b)
-  )
-  (junction (at 93.98 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c41e97f8-87c8-4e82-92ed-e4644d6f526e)
-  )
-  (junction (at 165.1 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c56d20e0-377b-42bf-89fc-25b698ca10b4)
-  )
-  (junction (at 114.3 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c5afc93c-0846-4cf9-8f93-4c8f2232c9fa)
-  )
-  (junction (at 134.62 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid c63c6045-4445-429c-8181-d2e0331d798a)
-  )
-  (junction (at 43.18 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid c8f222f6-943e-4d7d-919b-3278ca0ede33)
-  )
-  (junction (at 144.78 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cc2d9922-84c9-42ce-883b-c028a251c101)
-  )
-  (junction (at 134.62 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid d1f99c7d-3b4a-46dc-8c9d-81678cfc55a8)
-  )
-  (junction (at 144.78 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d5b7ef4f-419a-421c-a02d-fd71016e6c97)
-  )
-  (junction (at 114.3 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid dcab5abe-0f5a-44d8-b554-722164ca6a23)
-  )
-  (junction (at 114.3 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid ee17efa1-5df9-47d0-aec2-a440d8b33e4c)
-  )
-  (junction (at 104.14 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid f24e6016-cf0c-4fe9-b584-ca06dfdbe767)
-  )
-  (junction (at 134.62 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid f529a69b-7ffc-4660-8266-ccda1735dd5f)
-  )
-  (junction (at 43.18 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid f6f817c6-438a-4497-93b1-8dc1f36a395c)
-  )
-  (junction (at 165.1 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fa2795fd-0138-4010-b310-3d5e73c1be1c)
-  )
-  (junction (at 73.66 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fbda2010-a213-45bb-958d-0c9446d51e42)
-  )
-  (junction (at 114.3 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid fc6abd7a-92c0-4b05-85ed-b3bd910676e1)
-  )
-  (junction (at 144.78 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid fdc0071f-cdad-424a-87db-7bd8a0569159)
-  )
-
-  (wire (pts (xy 83.82 60.96) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 022d84d0-7bcb-4024-8618-6f3a7f7b41aa)
-  )
-  (wire (pts (xy 144.78 25.4) (xy 144.78 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0406a358-3219-4537-99c7-cfb994e5303c)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0429bfe1-2992-4c6f-bb22-b2e8e5724910)
-  )
-  (wire (pts (xy 73.66 109.22) (xy 93.98 109.22))
-    (stroke (width 0) (type default))
-    (uuid 07ee4d30-e80a-41ae-829d-e3cecf87d77e)
-  )
-  (wire (pts (xy 165.1 68.58) (xy 165.1 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0aee33c0-3781-43dc-99cb-690f399192cd)
-  )
-  (wire (pts (xy 114.3 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid 0c3eb518-1186-4332-b1f4-de7d2ad8d296)
-  )
-  (wire (pts (xy 43.18 40.64) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0f76c070-bcf8-4924-a8c5-3abe13c36f41)
-  )
-  (wire (pts (xy 114.3 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid 10adf42c-d8c0-46d3-b51c-3ef7ac5d2e7d)
-  )
-  (wire (pts (xy 63.5 81.28) (xy 63.5 101.6))
-    (stroke (width 0) (type default))
-    (uuid 11ef6261-91ba-4d4c-99ef-8991b7c91dc8)
-  )
-  (wire (pts (xy 104.14 101.6) (xy 104.14 121.92))
-    (stroke (width 0) (type default))
-    (uuid 12080e73-a151-4804-ac9b-ac3ac13653e9)
-  )
-  (wire (pts (xy 73.66 48.26) (xy 93.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 12a939e2-2ab8-4d74-a5c9-6d61a9528b6e)
-  )
-  (wire (pts (xy 104.14 25.4) (xy 104.14 40.64))
-    (stroke (width 0) (type default))
-    (uuid 1af5b449-9a68-414b-a41f-d6f6cba715a8)
-  )
-  (wire (pts (xy 73.66 81.28) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 1c0140d1-6775-49db-9fd5-7ecf63ae1284)
-  )
-  (wire (pts (xy 114.3 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid 211f763f-7ef6-4fb5-98df-2e2ff37faa42)
-  )
-  (wire (pts (xy 63.5 40.64) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 23f46f84-f16d-4b0b-b463-c2c0244adcc0)
-  )
-  (wire (pts (xy 33.02 129.54) (xy 53.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid 24da3fea-844d-4666-b730-f8d7b708f242)
-  )
-  (wire (pts (xy 53.34 129.54) (xy 73.66 129.54))
-    (stroke (width 0) (type default))
-    (uuid 26f78b89-ba4b-4b48-90d1-1245694ead6f)
-  )
-  (wire (pts (xy 33.02 109.22) (xy 53.34 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2832f642-62e7-4a51-b112-f728658e7714)
-  )
-  (wire (pts (xy 53.34 68.58) (xy 73.66 68.58))
-    (stroke (width 0) (type default))
-    (uuid 29a0e612-9a4c-422c-a9b8-8a9fe3879b8a)
-  )
-  (wire (pts (xy 83.82 101.6) (xy 83.82 121.92))
-    (stroke (width 0) (type default))
-    (uuid 2a44e441-f6d5-4994-b7ba-34283a1facc7)
-  )
-  (wire (pts (xy 124.46 121.92) (xy 124.46 142.24))
-    (stroke (width 0) (type default))
-    (uuid 2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0)
-  )
-  (wire (pts (xy 114.3 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 2a65926a-d988-49f6-92e7-6e4d5936462f)
-  )
-  (wire (pts (xy 53.34 109.22) (xy 73.66 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd)
-  )
-  (wire (pts (xy 124.46 25.4) (xy 124.46 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3115f7a7-e786-49c1-9e4c-25c171cfeb33)
-  )
-  (wire (pts (xy 73.66 68.58) (xy 93.98 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3197b37c-ee5b-406a-ab67-08670d4b8c09)
-  )
-  (wire (pts (xy 63.5 121.92) (xy 63.5 142.24))
-    (stroke (width 0) (type default))
-    (uuid 3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5)
-  )
-  (wire (pts (xy 43.18 60.96) (xy 43.18 81.28))
-    (stroke (width 0) (type default))
-    (uuid 456f0365-d37d-43a2-afac-d06c44cc48af)
-  )
-  (wire (pts (xy 124.46 81.28) (xy 124.46 101.6))
-    (stroke (width 0) (type default))
-    (uuid 495f9334-ca7f-4aa5-8d75-09576f1afa2c)
-  )
-  (wire (pts (xy 53.34 60.96) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 4b4dc6d3-affe-4d76-b8dd-52454da5768e)
-  )
-  (wire (pts (xy 157.48 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 538c3775-786a-4f4b-bd72-a9f774f46aff)
-  )
-  (wire (pts (xy 157.48 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 578c2aed-3f9a-47b8-a9bb-6579be566144)
-  )
-  (wire (pts (xy 104.14 60.96) (xy 104.14 81.28))
-    (stroke (width 0) (type default))
-    (uuid 5837ecd4-cf70-4c14-9c7b-bb5f05f8274a)
-  )
-  (wire (pts (xy 104.14 81.28) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid 5b6ae0de-21c8-4433-a4e0-a3b552474fb0)
-  )
-  (wire (pts (xy 53.34 88.9) (xy 73.66 88.9))
-    (stroke (width 0) (type default))
-    (uuid 60b5d548-d07f-40b1-8e16-72d513f499f2)
-  )
-  (wire (pts (xy 93.98 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6414e19f-a27a-435d-a47f-a63cba9086f1)
-  )
-  (wire (pts (xy 33.02 68.58) (xy 53.34 68.58))
-    (stroke (width 0) (type default))
-    (uuid 68161b0c-a285-475d-a645-59648d12bc07)
-  )
-  (wire (pts (xy 63.5 60.96) (xy 63.5 81.28))
-    (stroke (width 0) (type default))
-    (uuid 69366ee1-72a9-4213-9ba6-cd9c3ed2fb92)
-  )
-  (wire (pts (xy 165.1 88.9) (xy 165.1 109.22))
-    (stroke (width 0) (type default))
-    (uuid 70c6e975-f457-4759-9791-1d1de45afbb3)
-  )
-  (wire (pts (xy 43.18 121.92) (xy 43.18 142.24))
-    (stroke (width 0) (type default))
-    (uuid 727cc522-ef34-45d4-b711-997054ff0b37)
-  )
-  (wire (pts (xy 33.02 48.26) (xy 53.34 48.26))
-    (stroke (width 0) (type default))
-    (uuid 737596e8-f579-4b1f-aa71-a489d8ba56da)
-  )
-  (wire (pts (xy 93.98 149.86) (xy 114.3 149.86))
-    (stroke (width 0) (type default))
-    (uuid 770cc50c-0085-42e2-b068-cd0ae3b59919)
-  )
-  (wire (pts (xy 165.1 25.4) (xy 165.1 48.26))
-    (stroke (width 0) (type default))
-    (uuid 794205f1-2f7e-4200-b59c-c02481b0416f)
-  )
-  (wire (pts (xy 73.66 88.9) (xy 93.98 88.9))
-    (stroke (width 0) (type default))
-    (uuid 79a42c80-d7a4-4e03-9070-f9fff835a239)
-  )
-  (wire (pts (xy 33.02 40.64) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid 7a4231d0-fb4b-4c65-9cc1-75d3ed714150)
-  )
-  (wire (pts (xy 93.98 48.26) (xy 114.3 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8d73bae8-988b-435b-a882-ae9668b41d7e)
-  )
-  (wire (pts (xy 165.1 48.26) (xy 165.1 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8f339462-56e0-4361-9d9b-983c75fb21ef)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 53.34 88.9))
-    (stroke (width 0) (type default))
-    (uuid 909384ab-bc1c-47d8-a34d-c3d137febfc2)
-  )
-  (wire (pts (xy 124.46 101.6) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91eea887-ea8a-4221-ba92-e5ec1caacc4f)
-  )
-  (wire (pts (xy 114.3 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 9c79c76c-a95b-401f-9edb-a06a0cceaa4b)
-  )
-  (wire (pts (xy 53.34 48.26) (xy 73.66 48.26))
-    (stroke (width 0) (type default))
-    (uuid 9d5ec847-5716-4125-b40b-fdbd3a1587a7)
-  )
-  (wire (pts (xy 93.98 101.6) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid a226d887-7662-4dbd-b58b-e683f5d85955)
-  )
-  (wire (pts (xy 157.48 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid a62d7a1d-7c0f-4aff-9baf-ee1394963045)
-  )
-  (wire (pts (xy 124.46 40.64) (xy 124.46 60.96))
-    (stroke (width 0) (type default))
-    (uuid a67c0815-f186-4f70-926f-1b264c84d8d8)
-  )
-  (wire (pts (xy 53.34 149.86) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid aac914ea-c9a3-4a8f-94e1-1f91cdd136a3)
-  )
-  (wire (pts (xy 93.98 129.54) (xy 114.3 129.54))
-    (stroke (width 0) (type default))
-    (uuid ab578e4e-a4bf-4ab4-80fc-d97d4aea6370)
-  )
-  (wire (pts (xy 83.82 121.92) (xy 83.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73)
-  )
-  (wire (pts (xy 93.98 68.58) (xy 114.3 68.58))
-    (stroke (width 0) (type default))
-    (uuid aea6a633-b213-403d-b447-42d91d3ab4da)
-  )
-  (wire (pts (xy 73.66 129.54) (xy 93.98 129.54))
-    (stroke (width 0) (type default))
-    (uuid b3f6f053-44f0-4391-9873-b6231b8014db)
-  )
-  (wire (pts (xy 157.48 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid b4182606-9fa5-4ac3-b420-412042ba2c24)
-  )
-  (wire (pts (xy 144.78 101.6) (xy 144.78 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7b2475f-30dc-4ea2-b799-96c21242154c)
-  )
-  (wire (pts (xy 83.82 81.28) (xy 83.82 101.6))
-    (stroke (width 0) (type default))
-    (uuid b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5)
-  )
-  (wire (pts (xy 43.18 101.6) (xy 43.18 121.92))
-    (stroke (width 0) (type default))
-    (uuid bb49a3de-620b-45ad-a54c-29dcceaf0796)
-  )
-  (wire (pts (xy 144.78 121.92) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid bf12198a-9e62-45c3-b466-f5d86de75219)
-  )
-  (wire (pts (xy 63.5 25.4) (xy 63.5 40.64))
-    (stroke (width 0) (type default))
-    (uuid c1a940de-fa49-4106-a8b9-697952eec2a2)
-  )
-  (wire (pts (xy 104.14 121.92) (xy 104.14 142.24))
-    (stroke (width 0) (type default))
-    (uuid c298ba49-6974-4340-859f-5d5a2b4132ff)
-  )
-  (wire (pts (xy 157.48 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid c88bac51-c8da-48ea-8fee-aba15e68bd91)
-  )
-  (wire (pts (xy 124.46 60.96) (xy 124.46 81.28))
-    (stroke (width 0) (type default))
-    (uuid c950d145-c024-47a8-ba57-97efd7bb658b)
-  )
-  (wire (pts (xy 157.48 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid c9ed0b8c-99dd-4d44-ba1a-de4a47fb79c7)
-  )
-  (wire (pts (xy 165.1 109.22) (xy 165.1 129.54))
-    (stroke (width 0) (type default))
-    (uuid cdde081d-7bdd-42e6-869e-3ff07b8b464b)
-  )
-  (wire (pts (xy 83.82 40.64) (xy 83.82 60.96))
-    (stroke (width 0) (type default))
-    (uuid cff15ec3-f29c-4d36-8776-64c5d29be534)
-  )
-  (wire (pts (xy 83.82 25.4) (xy 83.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid d1088709-a9b9-4e05-8ea2-f87942ee2796)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 93.98 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1347903-ae03-46a2-a707-154093060583)
-  )
-  (wire (pts (xy 144.78 40.64) (xy 144.78 60.96))
-    (stroke (width 0) (type default))
-    (uuid d2183fb3-afd3-46ca-955e-993ea31aa5d3)
-  )
-  (wire (pts (xy 114.3 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid d52cbeed-b4ba-405a-8237-2ba7c961038d)
-  )
-  (wire (pts (xy 33.02 149.86) (xy 53.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid da80b027-904b-4ca2-99c6-5937c80c825c)
-  )
-  (wire (pts (xy 43.18 81.28) (xy 43.18 101.6))
-    (stroke (width 0) (type default))
-    (uuid df5c3763-e66c-46c4-9070-0f73d8115bc4)
-  )
-  (wire (pts (xy 165.1 129.54) (xy 165.1 149.86))
-    (stroke (width 0) (type default))
-    (uuid dfb5a082-e4d5-46ea-8dc8-c65064cd598b)
-  )
-  (wire (pts (xy 144.78 81.28) (xy 144.78 101.6))
-    (stroke (width 0) (type default))
-    (uuid e444742a-24b1-4bbf-b7ee-438e6dffc9cc)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid e6d06035-ccb7-4d3e-ae70-d73150e65bbb)
-  )
-  (wire (pts (xy 63.5 101.6) (xy 63.5 121.92))
-    (stroke (width 0) (type default))
-    (uuid edeeb0d9-51cc-411d-aac4-77f10b619702)
-  )
-  (wire (pts (xy 104.14 40.64) (xy 104.14 60.96))
-    (stroke (width 0) (type default))
-    (uuid ef5c9f05-d71b-4562-9939-852432c066c5)
-  )
-  (wire (pts (xy 144.78 60.96) (xy 144.78 81.28))
-    (stroke (width 0) (type default))
-    (uuid f0ce7c2b-d80c-49f2-bf63-62b750f7ca47)
-  )
-  (wire (pts (xy 134.62 142.24) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid f781a362-e0d4-48be-9d13-5686e05b406f)
-  )
-  (wire (pts (xy 43.18 25.4) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid fa765e67-a220-4a00-944c-7663298f0ead)
-  )
-
-  (global_label "IO 3" (shape bidirectional) (at 104.14 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 24ec698b-5cae-4571-b9c4-c0e35d64a64d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 104.14 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 1" (shape bidirectional) (at 63.5 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2d4b15a5-8b6c-4ca3-a7bb-7848c8036590)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 63.5 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 0" (shape bidirectional) (at 43.18 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 465a517d-f0e1-4825-8675-1cce54bfa7a5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 43.18 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "INTR" (shape bidirectional) (at 165.1 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4e12b932-2346-4e84-b5a4-80468334f3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 173.29 25.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "IO 2" (shape bidirectional) (at 83.82 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 70d42e66-a74c-4de2-af96-d1860851d3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 83.82 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 144.78 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d44cceb0-f409-4e5f-a98a-9feead2e845d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 4" (shape bidirectional) (at 124.46 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f36f49e4-227f-479f-b914-786aa44dd568)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 124.46 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 64.77 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 04430572-8314-4d21-974c-22350cead1a6)
-    (property "Reference" "DS1" (at 55.88 65.405 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 55.88 62.865 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e433df4-9fec-4cfb-b60f-eebca7c574cf))
-    (pin "2" (uuid 9bcc1487-0612-4bdb-a2de-a8b2f590b28f))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 44.45 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080aaa87-0974-4a77-bf63-185495f411a0)
-    (property "Reference" "DS0" (at 35.56 45.085 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 35.56 42.545 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bfacad1-28fd-4f2e-93dc-68f478b8a6ba))
-    (pin "2" (uuid 376f73f9-79fa-4153-ae38-31ed5446db52))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09d14922-c46a-4bf1-bb2c-1d224060568c)
-    (property "Reference" "D40" (at 111.76 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2f1a1d2-df3d-4680-9706-2ca411fa6890))
-    (pin "2" (uuid f58fd788-6016-46e7-b903-3606dd2ec21d))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D40") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 161.29 149.86 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0d18473f-e37a-4136-b721-5a2e40e4f8ed)
-    (property "Reference" "DI5" (at 161.29 146.05 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 163.195 152.4 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 161.29 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 161.29 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 161.29 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 161.29 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d5a885ca-5076-44e6-9a84-d07474947dde))
-    (pin "2" (uuid 047b5b54-de8b-4afc-abc2-c6d1f2d17bd2))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0fadd319-be81-4c25-8d23-e7495a114aa7)
-    (property "Reference" "RC4-0" (at 119.38 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid efb1c47f-fe25-4bea-8081-43d3c19de5cd))
-    (pin "2" (uuid 9138c970-6e3d-46df-9354-5174df2a4e52))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ff76361-9578-4f9f-a20c-f042e24a7755)
-    (property "Reference" "D5" (at 30.48 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06))
-    (pin "2" (uuid cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 11f01cd8-f751-497f-9599-50fe1fc0a618)
-    (property "Reference" "RC5-4" (at 139.7 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc28293-fab9-4f93-b3d5-ca9ee69110c4))
-    (pin "2" (uuid 088ac770-af1e-4c4f-ad11-5b44a20594d8))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1e5f084d-4db5-48ad-a2a3-76f186559614)
-    (property "Reference" "RC3-1" (at 99.06 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa))
-    (pin "2" (uuid 40b7f115-b5d7-4fa0-b12b-c1c7b6866feb))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 244b7f9d-3923-4908-be6d-02c49eb4663c)
-    (property "Reference" "RC2-3" (at 78.74 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d79440a-2f90-4c0b-8d60-528615b0bd65))
-    (pin "2" (uuid 7f1d0566-f385-4126-b190-2379308ed05b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 28137b00-0d76-493b-92b8-23037474163f)
-    (property "Reference" "RC1-3" (at 58.42 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3))
-    (pin "2" (uuid 41d35b0f-21b5-4da8-92df-229c816b63c5))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c50947a-4bb9-43c2-b65c-4726e224b6b0)
-    (property "Reference" "RC3-0" (at 99.06 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b))
-    (pin "2" (uuid 30241adf-a2e7-4976-a53a-5c267616618e))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30340eba-9ed0-42ff-b11f-98a864f7223e)
-    (property "Reference" "RC1-4" (at 58.42 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aa956a67-c26e-4a57-9ddb-59688a6476ad))
-    (pin "2" (uuid 23cd0d93-5050-40ea-9d49-879bbcbb8bcd))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30b60f6a-8d20-44dd-b832-1906a957c513)
-    (property "Reference" "D54" (at 132.08 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c2ad1a4-b254-49a0-8435-d3a374353ffc))
-    (pin "2" (uuid 27a3cb64-baf1-430a-b797-bd52c0e46cbe))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D54") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35827986-7004-4f70-a10a-6ceb42f33d9f)
-    (property "Reference" "RC1-2" (at 58.42 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 879d3b07-b41e-4233-b196-e223f635bdf3))
-    (pin "2" (uuid 641f8ea7-6306-4550-92c8-e3cc0ed3e5a5))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976)
-    (property "Reference" "D43" (at 111.76 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7d6fb6c4-b36c-4ff1-879b-43826c273a72))
-    (pin "2" (uuid 198c65f6-b3df-4780-9f6d-1c910e870a1b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D43") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef0222e-2eac-4930-ac36-0f395f4593b6)
-    (property "Reference" "RC1-0" (at 58.42 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f0b9b8-9322-4d89-a423-dd3d807d99ff))
-    (pin "2" (uuid ce54609e-9d1d-4a3b-81a2-5a384dbe41c8))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef86e49-a152-4515-afb0-4098f497c742)
-    (property "Reference" "D31" (at 91.44 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a))
-    (pin "2" (uuid b917ad78-96a8-428f-ad4f-d49149b5b97b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D31") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 402f0f46-5eb8-421b-9b9f-01a54b5cfa87)
-    (property "Reference" "RC4-1" (at 119.38 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cb206c0-1fab-4ac5-b301-f9678369525b))
-    (pin "2" (uuid b99c2ecc-04a5-4c54-a491-d99fe2562dcc))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 433f3f09-0867-41a3-8ac6-5f00bd3314fc)
-    (property "Reference" "D32" (at 91.44 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 11a29637-fd50-4473-bb70-d4116312a4f5))
-    (pin "2" (uuid 53f6307d-8380-45e9-b3fa-4d05a2bd575d))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44de9323-bd5d-49cd-bf0a-70392801309d)
-    (property "Reference" "D45" (at 111.76 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb2b185b-5d98-46b8-8516-9e5c980291cf))
-    (pin "2" (uuid f730da3b-5ef9-4abc-8c8d-0794fe3feb87))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D45") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 454ad926-1c6a-4aa4-b6f8-25297463de18)
-    (property "Reference" "RC3-2" (at 99.06 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f0aebfce-7e76-40f1-83ef-5914b8ebbcc7))
-    (pin "2" (uuid 744fce2b-a15c-45a6-92b0-e880efafb5f6))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 161.29 48.26 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46348ccc-126c-461a-8e39-f93f389ddaa7)
-    (property "Reference" "DI0" (at 161.29 44.45 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 163.195 50.8 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 161.29 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 161.29 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 161.29 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 161.29 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c86bf5fa-c113-44c1-b93d-7a5d4ac11904))
-    (pin "2" (uuid dbd8322f-50c7-4271-821c-b0005fd066b2))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4a7f7b3d-918b-431a-b79d-c66494b3ec50)
-    (property "Reference" "D52" (at 132.08 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd114d76-87b2-4089-b211-b7b541ac42b3))
-    (pin "2" (uuid a360aa38-116c-4dd0-a569-f6a7a5a88a05))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D52") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 553a576d-44a1-4bad-9211-394526206f63)
-    (property "Reference" "D41" (at 111.76 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4a035e61-91c9-41ba-9328-bc9b284e86c2))
-    (pin "2" (uuid 8628539f-d3cd-4957-a6bb-5c605649e715))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D41") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 161.29 68.58 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5692cd7d-67c7-4fe7-8b4d-c8bc86968b31)
-    (property "Reference" "DI1" (at 161.29 64.77 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 163.195 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 161.29 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 161.29 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 161.29 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 161.29 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9abe1fc5-b3c1-424f-8519-d12916c57a11))
-    (pin "2" (uuid 168b1203-c5fc-4b69-b8e5-94d0bdc27e41))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59263e5e-1eeb-458b-9b02-ca162d4a65d7)
-    (property "Reference" "D21" (at 71.12 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2372f523-257f-414c-92f4-8d433cfbee15))
-    (pin "2" (uuid 21891727-1d09-4cab-bd90-75c57b141f7c))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D21") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59fdee43-9b65-471d-9ea8-5dc40dc65f6e)
-    (property "Reference" "D35" (at 91.44 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5834d436-0e26-481b-a20d-40fa6346502e))
-    (pin "2" (uuid 59af1ddc-701f-49c0-b6cd-778072695c5c))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D35") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5f21a75c-b9ee-47bf-adcf-39a03e42660f)
-    (property "Reference" "D15" (at 50.8 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1))
-    (pin "2" (uuid 7a8a84c2-38d2-473b-955d-81dd816a398e))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D15") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5fa8cce4-fbbf-4784-a459-71364b77e1a7)
-    (property "Reference" "RC0-2" (at 38.1 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cb7750fa-a378-43a3-a1c6-638c32a1c79e))
-    (pin "2" (uuid 67dfe958-6bd5-4618-98a3-d513db4ad5c0))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5ff7733c-a36f-4b29-a8e7-bdf79fabdf72)
-    (property "Reference" "D4" (at 30.48 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ed6062e9-f00a-474a-840f-39685bd66d70))
-    (pin "2" (uuid c0e85db4-b88d-4383-8de6-9f7370be62a6))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6aa79de9-555a-4ed1-93d3-b801685ebd28)
-    (property "Reference" "D53" (at 132.08 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2031fe-ef72-48a9-afa6-c06144a31b2c))
-    (pin "2" (uuid 7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D53") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 72047ccc-8813-4e13-ae4a-04618a9ab771)
-    (property "Reference" "D23" (at 71.12 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84))
-    (pin "2" (uuid 6dee3493-b1eb-401e-abb4-cbdef0ef3867))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D23") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7322809e-8332-47c6-af41-fcf3bbcec7d0)
-    (property "Reference" "D34" (at 91.44 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e3b096d1-dbd9-4fb8-8775-725a7aed0bc4))
-    (pin "2" (uuid 63756bb0-b693-4bbc-82da-e89a6b927e71))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D34") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 76054860-648b-474e-9b4d-cc9d83653495)
-    (property "Reference" "D10" (at 50.8 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d7e8bc-1ac3-4327-ab17-369de6ee755c))
-    (pin "2" (uuid c8283bba-c907-48e0-9745-e0818ca7ab04))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 77aa25a5-82c7-42c3-9d55-8606dd65ffa8)
-    (property "Reference" "RC5-1" (at 139.7 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51db5d58-5004-4c9c-b8d1-c184bfb493da))
-    (pin "2" (uuid 16d6f605-4627-49bd-9180-8203902febfd))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8010e136-1dd3-496f-b7ef-81fb0c8b419e)
-    (property "Reference" "D20" (at 71.12 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5aa5bf69-e040-48d4-81fc-332aff45c2f9))
-    (pin "2" (uuid f5458189-75e2-45c3-bf32-0320ebe63391))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D20") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80c46ab4-724f-418d-bb6f-e89792097e1a)
-    (property "Reference" "RC2-4" (at 78.74 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc0fd3d-897b-4e06-ac65-16066b68709e))
-    (pin "2" (uuid b7b98128-d37a-4ac7-b049-5cf9bdd5aadb))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 84146f81-04f3-4efb-b753-bdc596c8e7a9)
-    (property "Reference" "RC4-3" (at 119.38 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 774ced50-3b17-48fe-b2d7-22681b1dd1f7))
-    (pin "2" (uuid bad310c0-ca25-47d0-b27e-42438b959c7b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 86602dfb-ea19-4060-ad39-496c613a47cb)
-    (property "Reference" "D30" (at 91.44 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 02958e5d-18b7-48f3-9883-661ceaa75da5))
-    (pin "2" (uuid abed4b13-9431-40c7-848f-b30c05e39dfd))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D30") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8c168cda-0a39-478d-9d71-1073400c7ed7)
-    (property "Reference" "RC1-5" (at 58.42 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d2851af-db15-44cf-8e07-da339bdc18b2))
-    (pin "2" (uuid 94b381a2-7c19-4916-9f9a-ee00221d04d3))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 161.29 129.54 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7)
-    (property "Reference" "DI4" (at 161.29 125.73 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 163.195 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 161.29 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 161.29 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 161.29 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 161.29 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c02807d6-1705-4325-bcb0-203f4e9a5baa))
-    (pin "2" (uuid d6c46059-bf9c-4959-836e-e4d33dcc5edd))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 161.29 109.22 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 957e7a82-ca9c-46a8-bca9-099b05fe7e8f)
-    (property "Reference" "DI3" (at 161.29 105.41 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 163.195 111.76 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 161.29 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 161.29 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 161.29 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 161.29 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc53fac9-006c-4101-8113-949ab8e05afb))
-    (pin "2" (uuid f6122429-5885-4b7a-b72a-162ca49c70c2))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 161.29 88.9 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd)
-    (property "Reference" "DI2" (at 161.29 85.09 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 163.195 91.44 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 161.29 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 161.29 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 161.29 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 161.29 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a))
-    (pin "2" (uuid 81e4b9c6-9b09-4e38-94e9-cebdeae457ee))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9e96ab02-44ee-4ac7-8251-0d309b7409ad)
-    (property "Reference" "RC5-3" (at 139.7 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd85b120-1be2-4f17-a3d7-505a734afc72))
-    (pin "2" (uuid 666e03ce-bf1c-4b58-ac4e-f01557ca11fd))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a400377f-e146-4099-97e7-db21e16d5759)
-    (property "Reference" "D3" (at 30.48 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bfc71c1-6349-4b3f-bf89-22c83277904e))
-    (pin "2" (uuid dafd4b6c-6c2f-41e0-95ab-05ead276d86d))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a71b771b-4e14-4d95-98e7-86a6250f569e)
-    (property "Reference" "RC0-4" (at 38.1 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 95049e61-b78e-490f-86e1-aba711db5c19))
-    (pin "2" (uuid 6e474ba8-5b88-41c8-9259-b0ebfb6012f0))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid abf3c9d9-a279-4546-abcf-5e4f6862bc48)
-    (property "Reference" "D2" (at 30.48 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3499f31-3593-4cd9-977b-3b6479091d7b))
-    (pin "2" (uuid 17f09d49-1093-4838-8e5c-8fc4c42e5d05))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac10b530-144b-4dfc-ab37-ad7a8ced8612)
-    (property "Reference" "RC4-5" (at 119.38 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6c95156-54b9-4f54-a278-f808b4871687))
-    (pin "2" (uuid c3dc8d92-1759-4195-a3c9-81260bc6d8b1))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 85.09 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid accba515-4e8d-4804-afea-f36f436141c3)
-    (property "Reference" "DS2" (at 76.2 85.725 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 76.2 83.185 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 034e4344-7cda-43bc-a12a-f56b6e8f68f5))
-    (pin "2" (uuid 6f0bef00-c613-46da-9667-752b92174ad1))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 146.05 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3573dc3-ef18-4f4c-817b-c984ae7cfae9)
-    (property "Reference" "DS5" (at 137.16 146.685 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 137.16 144.145 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 813e7cf6-f821-4e03-95cc-308010bed54e))
-    (pin "2" (uuid 9669a028-42d7-436f-8ec5-bc3423db62d6))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b39d56f9-3079-43e4-bb1b-80277fdae425)
-    (property "Reference" "RC4-2" (at 119.38 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b205d044-9ffa-4dce-82fd-f51ba622a818))
-    (pin "2" (uuid 29ce7588-4a17-4be4-9207-ea3ed2669aa1))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3c497a9-b81f-4161-88cf-2e58ddb4cdd8)
-    (property "Reference" "RC3-4" (at 99.06 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ae78f0d3-f75a-49c8-ab9b-8a9831e434d7))
-    (pin "2" (uuid a59e897c-0784-437d-9243-baf91d40a453))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba927934-b2e1-4953-b21b-54ef02be8935)
-    (property "Reference" "RC0-5" (at 38.1 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cadba0a-3bb3-40cd-acea-644da4b3e05f))
-    (pin "2" (uuid 1368ebac-096c-415f-acaf-9afb071e729f))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bb2c72f0-a908-44e7-b7d5-67df52eed516)
-    (property "Reference" "DS4" (at 116.84 126.365 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 116.84 123.825 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5ab0b348-3e2a-4517-90b3-fad111de6205))
-    (pin "2" (uuid 6e7351bb-5d09-464f-9e8d-535ba0f5c6f3))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be02506a-2bb1-4713-b046-f0327dae72de)
-    (property "Reference" "RC0-1" (at 38.1 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 97a92abd-708c-465e-baf7-79fa35370a7c))
-    (pin "2" (uuid c9056b1e-419e-478d-9fc4-be1e95902d28))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d)
-    (property "Reference" "RC5-2" (at 139.7 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f22c39d-012a-4297-b61c-1ff841801333))
-    (pin "2" (uuid adbe8c88-ad34-405b-866a-efb64899002f))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c164cb58-7d29-400c-b219-f07036f5e8c9)
-    (property "Reference" "RC0-3" (at 38.1 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92164ea1-76d0-4223-80cc-32c093c14fcd))
-    (pin "2" (uuid e615b2e5-6986-47ac-8f35-da60c20b811c))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c43b92c2-4283-44f7-8cb3-665623564383)
-    (property "Reference" "D42" (at 111.76 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0929e13-ab77-4737-9d55-142bd9901b1c))
-    (pin "2" (uuid 0f45988c-1752-479c-97d5-fbada14f9a42))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D42") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c72dd108-be98-47d5-b809-561778aa3212)
-    (property "Reference" "RC2-5" (at 78.74 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d2f0fd-ce69-4d4e-a4ab-163c1691ef24))
-    (pin "2" (uuid 03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe)
-    (property "Reference" "D50" (at 132.08 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a606860e-126b-4f3e-bcfe-a2dfa8adc9c8))
-    (pin "2" (uuid 59120505-a333-4c63-8904-aa379cfb043b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D50") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e)
-    (property "Reference" "D51" (at 132.08 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48596e1c-4629-46bb-98c1-de11cd41e539))
-    (pin "2" (uuid f7decfb7-c4ef-4861-ba8a-043f44f3b09e))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D51") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cf81ef85-b58f-422a-b88a-7b7914aa3581)
-    (property "Reference" "D12" (at 50.8 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e34c154b-a3cb-467d-891b-2f2891056190))
-    (pin "2" (uuid dc926c49-c915-470d-b2b5-00749f3505bb))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D12") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d40b4fbb-e58c-433e-b2c5-236bb8aa92c5)
-    (property "Reference" "D1" (at 30.48 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90049b07-ff34-407c-ad1c-bcb8b89b241c))
-    (pin "2" (uuid 7bd5d68f-4902-47f7-bc35-be0973d0d904))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578)
-    (property "Reference" "RC5-0" (at 139.7 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5729530-792d-44f2-80ff-f6315aae335e))
-    (pin "2" (uuid 01f42ec4-9037-47c0-8fc0-8f7345fd0a2b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69)
-    (property "Reference" "RC2-1" (at 78.74 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ba2015a3-c3ad-44cf-b530-b2a60bac2c12))
-    (pin "2" (uuid 12bdf482-8bd0-4b7d-a511-fcaadc8ab54d))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid daefbaa6-3e17-4eca-837b-024ccac5fc10)
-    (property "Reference" "D14" (at 50.8 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12e5236e-b23d-4e38-9768-e28d1693b6eb))
-    (pin "2" (uuid 1be4fe23-ac83-4b50-b43f-2e4b33c335d7))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D14") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e490f25a-1360-4f95-aa79-5f1d93892bb3)
-    (property "Reference" "RC3-5" (at 99.06 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 056973a8-92e3-49be-9b21-fe961241d12f))
-    (pin "2" (uuid 01c4c06b-d45d-4ffb-ad72-57ca7686fd55))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 105.41 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b)
-    (property "Reference" "DS3" (at 96.52 106.045 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 96.52 103.505 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 738869bf-f410-43b7-b7e7-4e927d69911a))
-    (pin "2" (uuid 71649a24-87f4-49fb-9896-e50c64c03a31))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb153eb2-74b0-4cb9-b105-af356654d60d)
-    (property "Reference" "D24" (at 71.12 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77c4fd5e-5c79-4799-aab6-2f07a57c7df3))
-    (pin "2" (uuid a062346b-452b-46dc-a106-fab01848555d))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D24") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1920e34-64a4-41c9-8680-7fa42f5dfb9d)
-    (property "Reference" "RC2-0" (at 78.74 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9242378-4df5-4b90-afbf-1098ccb8067f))
-    (pin "2" (uuid a135b9b9-316d-4cb2-a5a5-8d618a00a752))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fc941f43-b642-4fef-8515-f8f851adced2)
-    (property "Reference" "D13" (at 50.8 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c))
-    (pin "2" (uuid ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D13") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fcc35b13-8da5-4271-981a-5470b3add3e5)
-    (property "Reference" "D25" (at 71.12 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0d662a-16b3-4c76-b4ee-49de18b57b47))
-    (pin "2" (uuid ba9a1f4c-173e-4b32-907f-fe9b31df718b))
-    (instances
-      (project "round-robin-7-30"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D25") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "cbac505e-77a6-4a00-a758-435de33cca16")
+	(paper "A3" portrait)
+	(lib_symbols
+		(symbol "Diode:1N4148"
+			(pin_numbers hide)
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "1N4148"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "100V 0.15A standard switching diode, DO-35"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Device" "D"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "D*DO?35*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "1N4148_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "1N4148_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 104.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06a6d1a8-0f12-4174-b63e-d35d8ca618bf")
+	)
+	(junction
+		(at 63.5 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a9113d4-8a8c-4abc-b886-f22c92ad18dc")
+	)
+	(junction
+		(at 124.46 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29")
+	)
+	(junction
+		(at 73.66 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c7244ee-ddfb-470b-a70b-1cfc53f83773")
+	)
+	(junction
+		(at 93.98 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5f3a7a-dc5d-4973-8743-eafaa1c1a462")
+	)
+	(junction
+		(at 43.18 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "10cae212-bc64-40b9-b44f-13fd4a0406a6")
+	)
+	(junction
+		(at 83.82 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1278b5e3-5eff-46d6-a162-44fde2066970")
+	)
+	(junction
+		(at 104.14 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17f3773a-2c02-426d-bcd6-7a35c59a710a")
+	)
+	(junction
+		(at 73.66 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c386ee6-5b9d-4eae-92b5-9440e81067f6")
+	)
+	(junction
+		(at 93.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21e320b6-a0c4-4d5d-babf-ee5274120507")
+	)
+	(junction
+		(at 134.62 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "291db826-8863-42d6-a2e2-921b741b7753")
+	)
+	(junction
+		(at 124.46 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2b2b66bc-905d-4b48-89f5-1c62f6c27dbb")
+	)
+	(junction
+		(at 93.98 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "31a1b16e-8174-4fea-bc42-9c75ed9182a0")
+	)
+	(junction
+		(at 114.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "347306fc-87ef-43e1-a98f-ca29ac9473e6")
+	)
+	(junction
+		(at 124.46 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "352af8be-9d08-4866-961e-b8632013179f")
+	)
+	(junction
+		(at 104.14 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "356b49b0-20ac-4c33-8df8-9b27dee0b312")
+	)
+	(junction
+		(at 165.1 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c")
+	)
+	(junction
+		(at 114.3 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "490a89d7-a161-4f1a-9b45-a55729d9d59b")
+	)
+	(junction
+		(at 124.46 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c74baef-72cb-4cdf-b4eb-a3d28782257d")
+	)
+	(junction
+		(at 53.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c7a50e9-7650-493b-b0a7-057b900a13a7")
+	)
+	(junction
+		(at 63.5 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9")
+	)
+	(junction
+		(at 43.18 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e641ba8-cbcf-42cf-89f0-ac977902bf98")
+	)
+	(junction
+		(at 73.66 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fc826ad-ef7b-406a-9b89-76eb2c211523")
+	)
+	(junction
+		(at 53.34 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fce0301-62b3-4ef1-9bae-8d55ea745d66")
+	)
+	(junction
+		(at 53.34 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53bb27f5-9b54-4704-b90e-33b3053be6c4")
+	)
+	(junction
+		(at 63.5 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "670a793c-4c48-41d1-9f07-66b1d7d84b06")
+	)
+	(junction
+		(at 83.82 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "672e2ce9-8f2c-43ff-9498-0e342bc1c65e")
+	)
+	(junction
+		(at 43.18 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6bfc7531-8adc-4c87-bf8a-788404262765")
+	)
+	(junction
+		(at 63.5 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "712da204-b8e1-4637-b967-521ccf7b108c")
+	)
+	(junction
+		(at 73.66 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71e77471-d824-448e-a6de-31cce05e17c2")
+	)
+	(junction
+		(at 73.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "742ecb41-f257-40d3-a6f3-d155d6036628")
+	)
+	(junction
+		(at 134.62 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "77ee3090-cccb-4e87-85da-203131141e39")
+	)
+	(junction
+		(at 93.98 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "782ee96d-a257-4c78-ac0f-a3b5279bef37")
+	)
+	(junction
+		(at 53.34 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7943e9ed-5e22-49d3-a238-47d875f3e823")
+	)
+	(junction
+		(at 134.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7a10b798-0eae-48fa-874f-c983ca3ec677")
+	)
+	(junction
+		(at 104.14 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "822096c9-a5b4-460b-8639-9bbf1bb1a2fa")
+	)
+	(junction
+		(at 53.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "86d88f2b-6e5b-493a-b3a4-5436a8374fae")
+	)
+	(junction
+		(at 83.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bf191a4-2dcd-4018-b67a-91aef9fad846")
+	)
+	(junction
+		(at 144.78 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d88bb99-f0e4-4a81-b464-31814877675a")
+	)
+	(junction
+		(at 165.1 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95b0c111-7d27-49ee-a08f-b6f35d9d5b54")
+	)
+	(junction
+		(at 93.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96a12dd2-d02f-4a86-aa6d-3a7015c06462")
+	)
+	(junction
+		(at 124.46 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9d2b0f02-b19d-4907-8835-9e7f8a8b9c34")
+	)
+	(junction
+		(at 83.82 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b23bc3a0-3ebe-44a5-9126-8b5c4d648e08")
+	)
+	(junction
+		(at 165.1 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b98759bc-77be-4dce-9aa2-cc5ce3889034")
+	)
+	(junction
+		(at 53.34 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3")
+	)
+	(junction
+		(at 144.78 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "befc6138-873b-4406-bc9e-e5a72f7f36fe")
+	)
+	(junction
+		(at 83.82 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0")
+	)
+	(junction
+		(at 63.5 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c0959c68-283c-45f6-92d0-52fdc869aa4b")
+	)
+	(junction
+		(at 93.98 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c41e97f8-87c8-4e82-92ed-e4644d6f526e")
+	)
+	(junction
+		(at 165.1 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c56d20e0-377b-42bf-89fc-25b698ca10b4")
+	)
+	(junction
+		(at 114.3 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c5afc93c-0846-4cf9-8f93-4c8f2232c9fa")
+	)
+	(junction
+		(at 134.62 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c63c6045-4445-429c-8181-d2e0331d798a")
+	)
+	(junction
+		(at 43.18 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8f222f6-943e-4d7d-919b-3278ca0ede33")
+	)
+	(junction
+		(at 144.78 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc2d9922-84c9-42ce-883b-c028a251c101")
+	)
+	(junction
+		(at 134.62 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d1f99c7d-3b4a-46dc-8c9d-81678cfc55a8")
+	)
+	(junction
+		(at 144.78 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b7ef4f-419a-421c-a02d-fd71016e6c97")
+	)
+	(junction
+		(at 114.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcab5abe-0f5a-44d8-b554-722164ca6a23")
+	)
+	(junction
+		(at 114.3 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee17efa1-5df9-47d0-aec2-a440d8b33e4c")
+	)
+	(junction
+		(at 104.14 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f24e6016-cf0c-4fe9-b584-ca06dfdbe767")
+	)
+	(junction
+		(at 134.62 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f529a69b-7ffc-4660-8266-ccda1735dd5f")
+	)
+	(junction
+		(at 43.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6f817c6-438a-4497-93b1-8dc1f36a395c")
+	)
+	(junction
+		(at 165.1 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa2795fd-0138-4010-b310-3d5e73c1be1c")
+	)
+	(junction
+		(at 73.66 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbda2010-a213-45bb-958d-0c9446d51e42")
+	)
+	(junction
+		(at 114.3 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc6abd7a-92c0-4b05-85ed-b3bd910676e1")
+	)
+	(junction
+		(at 144.78 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdc0071f-cdad-424a-87db-7bd8a0569159")
+	)
+	(wire
+		(pts
+			(xy 83.82 60.96) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022d84d0-7bcb-4024-8618-6f3a7f7b41aa")
+	)
+	(wire
+		(pts
+			(xy 144.78 25.4) (xy 144.78 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0406a358-3219-4537-99c7-cfb994e5303c")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0429bfe1-2992-4c6f-bb22-b2e8e5724910")
+	)
+	(wire
+		(pts
+			(xy 73.66 109.22) (xy 93.98 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07ee4d30-e80a-41ae-829d-e3cecf87d77e")
+	)
+	(wire
+		(pts
+			(xy 165.1 68.58) (xy 165.1 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aee33c0-3781-43dc-99cb-690f399192cd")
+	)
+	(wire
+		(pts
+			(xy 114.3 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0c3eb518-1186-4332-b1f4-de7d2ad8d296")
+	)
+	(wire
+		(pts
+			(xy 43.18 40.64) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f76c070-bcf8-4924-a8c5-3abe13c36f41")
+	)
+	(wire
+		(pts
+			(xy 114.3 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10adf42c-d8c0-46d3-b51c-3ef7ac5d2e7d")
+	)
+	(wire
+		(pts
+			(xy 63.5 81.28) (xy 63.5 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ef6261-91ba-4d4c-99ef-8991b7c91dc8")
+	)
+	(wire
+		(pts
+			(xy 104.14 101.6) (xy 104.14 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12080e73-a151-4804-ac9b-ac3ac13653e9")
+	)
+	(wire
+		(pts
+			(xy 73.66 48.26) (xy 93.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12a939e2-2ab8-4d74-a5c9-6d61a9528b6e")
+	)
+	(wire
+		(pts
+			(xy 104.14 25.4) (xy 104.14 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af5b449-9a68-414b-a41f-d6f6cba715a8")
+	)
+	(wire
+		(pts
+			(xy 73.66 81.28) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0140d1-6775-49db-9fd5-7ecf63ae1284")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "211f763f-7ef6-4fb5-98df-2e2ff37faa42")
+	)
+	(wire
+		(pts
+			(xy 63.5 40.64) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23f46f84-f16d-4b0b-b463-c2c0244adcc0")
+	)
+	(wire
+		(pts
+			(xy 33.02 129.54) (xy 53.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24da3fea-844d-4666-b730-f8d7b708f242")
+	)
+	(wire
+		(pts
+			(xy 53.34 129.54) (xy 73.66 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26f78b89-ba4b-4b48-90d1-1245694ead6f")
+	)
+	(wire
+		(pts
+			(xy 33.02 109.22) (xy 53.34 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2832f642-62e7-4a51-b112-f728658e7714")
+	)
+	(wire
+		(pts
+			(xy 53.34 68.58) (xy 73.66 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29a0e612-9a4c-422c-a9b8-8a9fe3879b8a")
+	)
+	(wire
+		(pts
+			(xy 83.82 101.6) (xy 83.82 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a44e441-f6d5-4994-b7ba-34283a1facc7")
+	)
+	(wire
+		(pts
+			(xy 124.46 121.92) (xy 124.46 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0")
+	)
+	(wire
+		(pts
+			(xy 114.3 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a65926a-d988-49f6-92e7-6e4d5936462f")
+	)
+	(wire
+		(pts
+			(xy 53.34 109.22) (xy 73.66 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd")
+	)
+	(wire
+		(pts
+			(xy 124.46 25.4) (xy 124.46 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3115f7a7-e786-49c1-9e4c-25c171cfeb33")
+	)
+	(wire
+		(pts
+			(xy 73.66 68.58) (xy 93.98 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3197b37c-ee5b-406a-ab67-08670d4b8c09")
+	)
+	(wire
+		(pts
+			(xy 63.5 121.92) (xy 63.5 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5")
+	)
+	(wire
+		(pts
+			(xy 43.18 60.96) (xy 43.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456f0365-d37d-43a2-afac-d06c44cc48af")
+	)
+	(wire
+		(pts
+			(xy 124.46 81.28) (xy 124.46 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "495f9334-ca7f-4aa5-8d75-09576f1afa2c")
+	)
+	(wire
+		(pts
+			(xy 53.34 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4b4dc6d3-affe-4d76-b8dd-52454da5768e")
+	)
+	(wire
+		(pts
+			(xy 157.48 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "538c3775-786a-4f4b-bd72-a9f774f46aff")
+	)
+	(wire
+		(pts
+			(xy 157.48 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "578c2aed-3f9a-47b8-a9bb-6579be566144")
+	)
+	(wire
+		(pts
+			(xy 104.14 60.96) (xy 104.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5837ecd4-cf70-4c14-9c7b-bb5f05f8274a")
+	)
+	(wire
+		(pts
+			(xy 104.14 81.28) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6ae0de-21c8-4433-a4e0-a3b552474fb0")
+	)
+	(wire
+		(pts
+			(xy 53.34 88.9) (xy 73.66 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b5d548-d07f-40b1-8e16-72d513f499f2")
+	)
+	(wire
+		(pts
+			(xy 93.98 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6414e19f-a27a-435d-a47f-a63cba9086f1")
+	)
+	(wire
+		(pts
+			(xy 33.02 68.58) (xy 53.34 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68161b0c-a285-475d-a645-59648d12bc07")
+	)
+	(wire
+		(pts
+			(xy 63.5 60.96) (xy 63.5 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "69366ee1-72a9-4213-9ba6-cd9c3ed2fb92")
+	)
+	(wire
+		(pts
+			(xy 165.1 88.9) (xy 165.1 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70c6e975-f457-4759-9791-1d1de45afbb3")
+	)
+	(wire
+		(pts
+			(xy 43.18 121.92) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "727cc522-ef34-45d4-b711-997054ff0b37")
+	)
+	(wire
+		(pts
+			(xy 33.02 48.26) (xy 53.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "737596e8-f579-4b1f-aa71-a489d8ba56da")
+	)
+	(wire
+		(pts
+			(xy 93.98 149.86) (xy 114.3 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "770cc50c-0085-42e2-b068-cd0ae3b59919")
+	)
+	(wire
+		(pts
+			(xy 165.1 25.4) (xy 165.1 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "794205f1-2f7e-4200-b59c-c02481b0416f")
+	)
+	(wire
+		(pts
+			(xy 73.66 88.9) (xy 93.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79a42c80-d7a4-4e03-9070-f9fff835a239")
+	)
+	(wire
+		(pts
+			(xy 33.02 40.64) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a4231d0-fb4b-4c65-9cc1-75d3ed714150")
+	)
+	(wire
+		(pts
+			(xy 93.98 48.26) (xy 114.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d73bae8-988b-435b-a882-ae9668b41d7e")
+	)
+	(wire
+		(pts
+			(xy 165.1 48.26) (xy 165.1 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f339462-56e0-4361-9d9b-983c75fb21ef")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "909384ab-bc1c-47d8-a34d-c3d137febfc2")
+	)
+	(wire
+		(pts
+			(xy 124.46 101.6) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91eea887-ea8a-4221-ba92-e5ec1caacc4f")
+	)
+	(wire
+		(pts
+			(xy 114.3 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c79c76c-a95b-401f-9edb-a06a0cceaa4b")
+	)
+	(wire
+		(pts
+			(xy 53.34 48.26) (xy 73.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ec847-5716-4125-b40b-fdbd3a1587a7")
+	)
+	(wire
+		(pts
+			(xy 93.98 101.6) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a226d887-7662-4dbd-b58b-e683f5d85955")
+	)
+	(wire
+		(pts
+			(xy 157.48 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a62d7a1d-7c0f-4aff-9baf-ee1394963045")
+	)
+	(wire
+		(pts
+			(xy 124.46 40.64) (xy 124.46 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a67c0815-f186-4f70-926f-1b264c84d8d8")
+	)
+	(wire
+		(pts
+			(xy 53.34 149.86) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aac914ea-c9a3-4a8f-94e1-1f91cdd136a3")
+	)
+	(wire
+		(pts
+			(xy 93.98 129.54) (xy 114.3 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab578e4e-a4bf-4ab4-80fc-d97d4aea6370")
+	)
+	(wire
+		(pts
+			(xy 83.82 121.92) (xy 83.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73")
+	)
+	(wire
+		(pts
+			(xy 93.98 68.58) (xy 114.3 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aea6a633-b213-403d-b447-42d91d3ab4da")
+	)
+	(wire
+		(pts
+			(xy 73.66 129.54) (xy 93.98 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f6f053-44f0-4391-9873-b6231b8014db")
+	)
+	(wire
+		(pts
+			(xy 157.48 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b4182606-9fa5-4ac3-b420-412042ba2c24")
+	)
+	(wire
+		(pts
+			(xy 144.78 101.6) (xy 144.78 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7b2475f-30dc-4ea2-b799-96c21242154c")
+	)
+	(wire
+		(pts
+			(xy 83.82 81.28) (xy 83.82 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5")
+	)
+	(wire
+		(pts
+			(xy 43.18 101.6) (xy 43.18 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb49a3de-620b-45ad-a54c-29dcceaf0796")
+	)
+	(wire
+		(pts
+			(xy 144.78 121.92) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf12198a-9e62-45c3-b466-f5d86de75219")
+	)
+	(wire
+		(pts
+			(xy 63.5 25.4) (xy 63.5 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1a940de-fa49-4106-a8b9-697952eec2a2")
+	)
+	(wire
+		(pts
+			(xy 104.14 121.92) (xy 104.14 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c298ba49-6974-4340-859f-5d5a2b4132ff")
+	)
+	(wire
+		(pts
+			(xy 157.48 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c88bac51-c8da-48ea-8fee-aba15e68bd91")
+	)
+	(wire
+		(pts
+			(xy 124.46 60.96) (xy 124.46 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c950d145-c024-47a8-ba57-97efd7bb658b")
+	)
+	(wire
+		(pts
+			(xy 157.48 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9ed0b8c-99dd-4d44-ba1a-de4a47fb79c7")
+	)
+	(wire
+		(pts
+			(xy 165.1 109.22) (xy 165.1 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdde081d-7bdd-42e6-869e-3ff07b8b464b")
+	)
+	(wire
+		(pts
+			(xy 83.82 40.64) (xy 83.82 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cff15ec3-f29c-4d36-8776-64c5d29be534")
+	)
+	(wire
+		(pts
+			(xy 83.82 25.4) (xy 83.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1088709-a9b9-4e05-8ea2-f87942ee2796")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 93.98 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1347903-ae03-46a2-a707-154093060583")
+	)
+	(wire
+		(pts
+			(xy 144.78 40.64) (xy 144.78 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2183fb3-afd3-46ca-955e-993ea31aa5d3")
+	)
+	(wire
+		(pts
+			(xy 114.3 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d52cbeed-b4ba-405a-8237-2ba7c961038d")
+	)
+	(wire
+		(pts
+			(xy 33.02 149.86) (xy 53.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da80b027-904b-4ca2-99c6-5937c80c825c")
+	)
+	(wire
+		(pts
+			(xy 43.18 81.28) (xy 43.18 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df5c3763-e66c-46c4-9070-0f73d8115bc4")
+	)
+	(wire
+		(pts
+			(xy 165.1 129.54) (xy 165.1 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfb5a082-e4d5-46ea-8dc8-c65064cd598b")
+	)
+	(wire
+		(pts
+			(xy 144.78 81.28) (xy 144.78 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e444742a-24b1-4bbf-b7ee-438e6dffc9cc")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6d06035-ccb7-4d3e-ae70-d73150e65bbb")
+	)
+	(wire
+		(pts
+			(xy 63.5 101.6) (xy 63.5 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edeeb0d9-51cc-411d-aac4-77f10b619702")
+	)
+	(wire
+		(pts
+			(xy 104.14 40.64) (xy 104.14 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5c9f05-d71b-4562-9939-852432c066c5")
+	)
+	(wire
+		(pts
+			(xy 144.78 60.96) (xy 144.78 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0ce7c2b-d80c-49f2-bf63-62b750f7ca47")
+	)
+	(wire
+		(pts
+			(xy 134.62 142.24) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f781a362-e0d4-48be-9d13-5686e05b406f")
+	)
+	(wire
+		(pts
+			(xy 43.18 25.4) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa765e67-a220-4a00-944c-7663298f0ead")
+	)
+	(global_label "IO 3"
+		(shape bidirectional)
+		(at 104.14 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "24ec698b-5cae-4571-b9c4-c0e35d64a64d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 104.14 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 1"
+		(shape bidirectional)
+		(at 63.5 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d4b15a5-8b6c-4ca3-a7bb-7848c8036590")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 63.5 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 0"
+		(shape bidirectional)
+		(at 43.18 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "465a517d-f0e1-4825-8675-1cce54bfa7a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 43.18 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "INTR"
+		(shape bidirectional)
+		(at 165.1 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4e12b932-2346-4e84-b5a4-80468334f3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 173.29 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 2"
+		(shape bidirectional)
+		(at 83.82 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70d42e66-a74c-4de2-af96-d1860851d3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 83.82 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 144.78 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d44cceb0-f409-4e5f-a98a-9feead2e845d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 4"
+		(shape bidirectional)
+		(at 124.46 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f36f49e4-227f-479f-b914-786aa44dd568")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04430572-8314-4d21-974c-22350cead1a6")
+		(property "Reference" "DS1"
+			(at 55.88 65.405 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 55.88 62.865 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3e433df4-9fec-4cfb-b60f-eebca7c574cf")
+		)
+		(pin "2"
+			(uuid "9bcc1487-0612-4bdb-a2de-a8b2f590b28f")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 44.45 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080aaa87-0974-4a77-bf63-185495f411a0")
+		(property "Reference" "DS0"
+			(at 35.56 45.085 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 35.56 42.545 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bfacad1-28fd-4f2e-93dc-68f478b8a6ba")
+		)
+		(pin "2"
+			(uuid "376f73f9-79fa-4153-ae38-31ed5446db52")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09d14922-c46a-4bf1-bb2c-1d224060568c")
+		(property "Reference" "D40"
+			(at 111.76 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c2f1a1d2-df3d-4680-9706-2ca411fa6890")
+		)
+		(pin "2"
+			(uuid "f58fd788-6016-46e7-b903-3606dd2ec21d")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D40")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 161.29 149.86 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d18473f-e37a-4136-b721-5a2e40e4f8ed")
+		(property "Reference" "DI5"
+			(at 161.29 146.05 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 163.195 152.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 161.29 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 161.29 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 161.29 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 161.29 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5a885ca-5076-44e6-9a84-d07474947dde")
+		)
+		(pin "2"
+			(uuid "047b5b54-de8b-4afc-abc2-c6d1f2d17bd2")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0fadd319-be81-4c25-8d23-e7495a114aa7")
+		(property "Reference" "RC4-0"
+			(at 119.38 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "efb1c47f-fe25-4bea-8081-43d3c19de5cd")
+		)
+		(pin "2"
+			(uuid "9138c970-6e3d-46df-9354-5174df2a4e52")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ff76361-9578-4f9f-a20c-f042e24a7755")
+		(property "Reference" "D5"
+			(at 30.48 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06")
+		)
+		(pin "2"
+			(uuid "cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "11f01cd8-f751-497f-9599-50fe1fc0a618")
+		(property "Reference" "RC5-4"
+			(at 139.7 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc28293-fab9-4f93-b3d5-ca9ee69110c4")
+		)
+		(pin "2"
+			(uuid "088ac770-af1e-4c4f-ad11-5b44a20594d8")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1e5f084d-4db5-48ad-a2a3-76f186559614")
+		(property "Reference" "RC3-1"
+			(at 99.06 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa")
+		)
+		(pin "2"
+			(uuid "40b7f115-b5d7-4fa0-b12b-c1c7b6866feb")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "244b7f9d-3923-4908-be6d-02c49eb4663c")
+		(property "Reference" "RC2-3"
+			(at 78.74 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1d79440a-2f90-4c0b-8d60-528615b0bd65")
+		)
+		(pin "2"
+			(uuid "7f1d0566-f385-4126-b190-2379308ed05b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "28137b00-0d76-493b-92b8-23037474163f")
+		(property "Reference" "RC1-3"
+			(at 58.42 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3")
+		)
+		(pin "2"
+			(uuid "41d35b0f-21b5-4da8-92df-229c816b63c5")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c50947a-4bb9-43c2-b65c-4726e224b6b0")
+		(property "Reference" "RC3-0"
+			(at 99.06 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b")
+		)
+		(pin "2"
+			(uuid "30241adf-a2e7-4976-a53a-5c267616618e")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30340eba-9ed0-42ff-b11f-98a864f7223e")
+		(property "Reference" "RC1-4"
+			(at 58.42 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aa956a67-c26e-4a57-9ddb-59688a6476ad")
+		)
+		(pin "2"
+			(uuid "23cd0d93-5050-40ea-9d49-879bbcbb8bcd")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30b60f6a-8d20-44dd-b832-1906a957c513")
+		(property "Reference" "D54"
+			(at 132.08 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2ad1a4-b254-49a0-8435-d3a374353ffc")
+		)
+		(pin "2"
+			(uuid "27a3cb64-baf1-430a-b797-bd52c0e46cbe")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D54")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35827986-7004-4f70-a10a-6ceb42f33d9f")
+		(property "Reference" "RC1-2"
+			(at 58.42 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "879d3b07-b41e-4233-b196-e223f635bdf3")
+		)
+		(pin "2"
+			(uuid "641f8ea7-6306-4550-92c8-e3cc0ed3e5a5")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976")
+		(property "Reference" "D43"
+			(at 111.76 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6fb6c4-b36c-4ff1-879b-43826c273a72")
+		)
+		(pin "2"
+			(uuid "198c65f6-b3df-4780-9f6d-1c910e870a1b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D43")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef0222e-2eac-4930-ac36-0f395f4593b6")
+		(property "Reference" "RC1-0"
+			(at 58.42 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20f0b9b8-9322-4d89-a423-dd3d807d99ff")
+		)
+		(pin "2"
+			(uuid "ce54609e-9d1d-4a3b-81a2-5a384dbe41c8")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef86e49-a152-4515-afb0-4098f497c742")
+		(property "Reference" "D31"
+			(at 91.44 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a")
+		)
+		(pin "2"
+			(uuid "b917ad78-96a8-428f-ad4f-d49149b5b97b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "402f0f46-5eb8-421b-9b9f-01a54b5cfa87")
+		(property "Reference" "RC4-1"
+			(at 119.38 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cb206c0-1fab-4ac5-b301-f9678369525b")
+		)
+		(pin "2"
+			(uuid "b99c2ecc-04a5-4c54-a491-d99fe2562dcc")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "433f3f09-0867-41a3-8ac6-5f00bd3314fc")
+		(property "Reference" "D32"
+			(at 91.44 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11a29637-fd50-4473-bb70-d4116312a4f5")
+		)
+		(pin "2"
+			(uuid "53f6307d-8380-45e9-b3fa-4d05a2bd575d")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44de9323-bd5d-49cd-bf0a-70392801309d")
+		(property "Reference" "D45"
+			(at 111.76 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb2b185b-5d98-46b8-8516-9e5c980291cf")
+		)
+		(pin "2"
+			(uuid "f730da3b-5ef9-4abc-8c8d-0794fe3feb87")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D45")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "454ad926-1c6a-4aa4-b6f8-25297463de18")
+		(property "Reference" "RC3-2"
+			(at 99.06 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0aebfce-7e76-40f1-83ef-5914b8ebbcc7")
+		)
+		(pin "2"
+			(uuid "744fce2b-a15c-45a6-92b0-e880efafb5f6")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 161.29 48.26 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46348ccc-126c-461a-8e39-f93f389ddaa7")
+		(property "Reference" "DI0"
+			(at 161.29 44.45 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 163.195 50.8 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 161.29 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 161.29 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 161.29 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 161.29 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c86bf5fa-c113-44c1-b93d-7a5d4ac11904")
+		)
+		(pin "2"
+			(uuid "dbd8322f-50c7-4271-821c-b0005fd066b2")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a7f7b3d-918b-431a-b79d-c66494b3ec50")
+		(property "Reference" "D52"
+			(at 132.08 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd114d76-87b2-4089-b211-b7b541ac42b3")
+		)
+		(pin "2"
+			(uuid "a360aa38-116c-4dd0-a569-f6a7a5a88a05")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D52")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "553a576d-44a1-4bad-9211-394526206f63")
+		(property "Reference" "D41"
+			(at 111.76 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4a035e61-91c9-41ba-9328-bc9b284e86c2")
+		)
+		(pin "2"
+			(uuid "8628539f-d3cd-4957-a6bb-5c605649e715")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 161.29 68.58 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5692cd7d-67c7-4fe7-8b4d-c8bc86968b31")
+		(property "Reference" "DI1"
+			(at 161.29 64.77 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 163.195 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 161.29 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 161.29 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 161.29 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 161.29 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9abe1fc5-b3c1-424f-8519-d12916c57a11")
+		)
+		(pin "2"
+			(uuid "168b1203-c5fc-4b69-b8e5-94d0bdc27e41")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59263e5e-1eeb-458b-9b02-ca162d4a65d7")
+		(property "Reference" "D21"
+			(at 71.12 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2372f523-257f-414c-92f4-8d433cfbee15")
+		)
+		(pin "2"
+			(uuid "21891727-1d09-4cab-bd90-75c57b141f7c")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59fdee43-9b65-471d-9ea8-5dc40dc65f6e")
+		(property "Reference" "D35"
+			(at 91.44 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5834d436-0e26-481b-a20d-40fa6346502e")
+		)
+		(pin "2"
+			(uuid "59af1ddc-701f-49c0-b6cd-778072695c5c")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D35")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f21a75c-b9ee-47bf-adcf-39a03e42660f")
+		(property "Reference" "D15"
+			(at 50.8 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1")
+		)
+		(pin "2"
+			(uuid "7a8a84c2-38d2-473b-955d-81dd816a398e")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fa8cce4-fbbf-4784-a459-71364b77e1a7")
+		(property "Reference" "RC0-2"
+			(at 38.1 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cb7750fa-a378-43a3-a1c6-638c32a1c79e")
+		)
+		(pin "2"
+			(uuid "67dfe958-6bd5-4618-98a3-d513db4ad5c0")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5ff7733c-a36f-4b29-a8e7-bdf79fabdf72")
+		(property "Reference" "D4"
+			(at 30.48 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed6062e9-f00a-474a-840f-39685bd66d70")
+		)
+		(pin "2"
+			(uuid "c0e85db4-b88d-4383-8de6-9f7370be62a6")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6aa79de9-555a-4ed1-93d3-b801685ebd28")
+		(property "Reference" "D53"
+			(at 132.08 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b2031fe-ef72-48a9-afa6-c06144a31b2c")
+		)
+		(pin "2"
+			(uuid "7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D53")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "72047ccc-8813-4e13-ae4a-04618a9ab771")
+		(property "Reference" "D23"
+			(at 71.12 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84")
+		)
+		(pin "2"
+			(uuid "6dee3493-b1eb-401e-abb4-cbdef0ef3867")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7322809e-8332-47c6-af41-fcf3bbcec7d0")
+		(property "Reference" "D34"
+			(at 91.44 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e3b096d1-dbd9-4fb8-8775-725a7aed0bc4")
+		)
+		(pin "2"
+			(uuid "63756bb0-b693-4bbc-82da-e89a6b927e71")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D34")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "76054860-648b-474e-9b4d-cc9d83653495")
+		(property "Reference" "D10"
+			(at 50.8 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d7e8bc-1ac3-4327-ab17-369de6ee755c")
+		)
+		(pin "2"
+			(uuid "c8283bba-c907-48e0-9745-e0818ca7ab04")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "77aa25a5-82c7-42c3-9d55-8606dd65ffa8")
+		(property "Reference" "RC5-1"
+			(at 139.7 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51db5d58-5004-4c9c-b8d1-c184bfb493da")
+		)
+		(pin "2"
+			(uuid "16d6f605-4627-49bd-9180-8203902febfd")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8010e136-1dd3-496f-b7ef-81fb0c8b419e")
+		(property "Reference" "D20"
+			(at 71.12 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5aa5bf69-e040-48d4-81fc-332aff45c2f9")
+		)
+		(pin "2"
+			(uuid "f5458189-75e2-45c3-bf32-0320ebe63391")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80c46ab4-724f-418d-bb6f-e89792097e1a")
+		(property "Reference" "RC2-4"
+			(at 78.74 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc0fd3d-897b-4e06-ac65-16066b68709e")
+		)
+		(pin "2"
+			(uuid "b7b98128-d37a-4ac7-b049-5cf9bdd5aadb")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "84146f81-04f3-4efb-b753-bdc596c8e7a9")
+		(property "Reference" "RC4-3"
+			(at 119.38 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "774ced50-3b17-48fe-b2d7-22681b1dd1f7")
+		)
+		(pin "2"
+			(uuid "bad310c0-ca25-47d0-b27e-42438b959c7b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86602dfb-ea19-4060-ad39-496c613a47cb")
+		(property "Reference" "D30"
+			(at 91.44 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "02958e5d-18b7-48f3-9883-661ceaa75da5")
+		)
+		(pin "2"
+			(uuid "abed4b13-9431-40c7-848f-b30c05e39dfd")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D30")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c168cda-0a39-478d-9d71-1073400c7ed7")
+		(property "Reference" "RC1-5"
+			(at 58.42 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d2851af-db15-44cf-8e07-da339bdc18b2")
+		)
+		(pin "2"
+			(uuid "94b381a2-7c19-4916-9f9a-ee00221d04d3")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 161.29 129.54 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7")
+		(property "Reference" "DI4"
+			(at 161.29 125.73 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 163.195 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 161.29 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 161.29 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 161.29 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 161.29 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c02807d6-1705-4325-bcb0-203f4e9a5baa")
+		)
+		(pin "2"
+			(uuid "d6c46059-bf9c-4959-836e-e4d33dcc5edd")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 161.29 109.22 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "957e7a82-ca9c-46a8-bca9-099b05fe7e8f")
+		(property "Reference" "DI3"
+			(at 161.29 105.41 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 163.195 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 161.29 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 161.29 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 161.29 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 161.29 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc53fac9-006c-4101-8113-949ab8e05afb")
+		)
+		(pin "2"
+			(uuid "f6122429-5885-4b7a-b72a-162ca49c70c2")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 161.29 88.9 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd")
+		(property "Reference" "DI2"
+			(at 161.29 85.09 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 163.195 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 161.29 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 161.29 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 161.29 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 161.29 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 161.29 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a")
+		)
+		(pin "2"
+			(uuid "81e4b9c6-9b09-4e38-94e9-cebdeae457ee")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e96ab02-44ee-4ac7-8251-0d309b7409ad")
+		(property "Reference" "RC5-3"
+			(at 139.7 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd85b120-1be2-4f17-a3d7-505a734afc72")
+		)
+		(pin "2"
+			(uuid "666e03ce-bf1c-4b58-ac4e-f01557ca11fd")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a400377f-e146-4099-97e7-db21e16d5759")
+		(property "Reference" "D3"
+			(at 30.48 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bfc71c1-6349-4b3f-bf89-22c83277904e")
+		)
+		(pin "2"
+			(uuid "dafd4b6c-6c2f-41e0-95ab-05ead276d86d")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a71b771b-4e14-4d95-98e7-86a6250f569e")
+		(property "Reference" "RC0-4"
+			(at 38.1 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "95049e61-b78e-490f-86e1-aba711db5c19")
+		)
+		(pin "2"
+			(uuid "6e474ba8-5b88-41c8-9259-b0ebfb6012f0")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "abf3c9d9-a279-4546-abcf-5e4f6862bc48")
+		(property "Reference" "D2"
+			(at 30.48 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a3499f31-3593-4cd9-977b-3b6479091d7b")
+		)
+		(pin "2"
+			(uuid "17f09d49-1093-4838-8e5c-8fc4c42e5d05")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac10b530-144b-4dfc-ab37-ad7a8ced8612")
+		(property "Reference" "RC4-5"
+			(at 119.38 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d6c95156-54b9-4f54-a278-f808b4871687")
+		)
+		(pin "2"
+			(uuid "c3dc8d92-1759-4195-a3c9-81260bc6d8b1")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 85.09 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "accba515-4e8d-4804-afea-f36f436141c3")
+		(property "Reference" "DS2"
+			(at 76.2 85.725 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 76.2 83.185 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "034e4344-7cda-43bc-a12a-f56b6e8f68f5")
+		)
+		(pin "2"
+			(uuid "6f0bef00-c613-46da-9667-752b92174ad1")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 146.05 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3573dc3-ef18-4f4c-817b-c984ae7cfae9")
+		(property "Reference" "DS5"
+			(at 137.16 146.685 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 137.16 144.145 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "813e7cf6-f821-4e03-95cc-308010bed54e")
+		)
+		(pin "2"
+			(uuid "9669a028-42d7-436f-8ec5-bc3423db62d6")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b39d56f9-3079-43e4-bb1b-80277fdae425")
+		(property "Reference" "RC4-2"
+			(at 119.38 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b205d044-9ffa-4dce-82fd-f51ba622a818")
+		)
+		(pin "2"
+			(uuid "29ce7588-4a17-4be4-9207-ea3ed2669aa1")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c497a9-b81f-4161-88cf-2e58ddb4cdd8")
+		(property "Reference" "RC3-4"
+			(at 99.06 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae78f0d3-f75a-49c8-ab9b-8a9831e434d7")
+		)
+		(pin "2"
+			(uuid "a59e897c-0784-437d-9243-baf91d40a453")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba927934-b2e1-4953-b21b-54ef02be8935")
+		(property "Reference" "RC0-5"
+			(at 38.1 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cadba0a-3bb3-40cd-acea-644da4b3e05f")
+		)
+		(pin "2"
+			(uuid "1368ebac-096c-415f-acaf-9afb071e729f")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bb2c72f0-a908-44e7-b7d5-67df52eed516")
+		(property "Reference" "DS4"
+			(at 116.84 126.365 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 116.84 123.825 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5ab0b348-3e2a-4517-90b3-fad111de6205")
+		)
+		(pin "2"
+			(uuid "6e7351bb-5d09-464f-9e8d-535ba0f5c6f3")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be02506a-2bb1-4713-b046-f0327dae72de")
+		(property "Reference" "RC0-1"
+			(at 38.1 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97a92abd-708c-465e-baf7-79fa35370a7c")
+		)
+		(pin "2"
+			(uuid "c9056b1e-419e-478d-9fc4-be1e95902d28")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d")
+		(property "Reference" "RC5-2"
+			(at 139.7 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f22c39d-012a-4297-b61c-1ff841801333")
+		)
+		(pin "2"
+			(uuid "adbe8c88-ad34-405b-866a-efb64899002f")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c164cb58-7d29-400c-b219-f07036f5e8c9")
+		(property "Reference" "RC0-3"
+			(at 38.1 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92164ea1-76d0-4223-80cc-32c093c14fcd")
+		)
+		(pin "2"
+			(uuid "e615b2e5-6986-47ac-8f35-da60c20b811c")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c43b92c2-4283-44f7-8cb3-665623564383")
+		(property "Reference" "D42"
+			(at 111.76 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0929e13-ab77-4737-9d55-142bd9901b1c")
+		)
+		(pin "2"
+			(uuid "0f45988c-1752-479c-97d5-fbada14f9a42")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D42")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c72dd108-be98-47d5-b809-561778aa3212")
+		(property "Reference" "RC2-5"
+			(at 78.74 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d2f0fd-ce69-4d4e-a4ab-163c1691ef24")
+		)
+		(pin "2"
+			(uuid "03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe")
+		(property "Reference" "D50"
+			(at 132.08 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a606860e-126b-4f3e-bcfe-a2dfa8adc9c8")
+		)
+		(pin "2"
+			(uuid "59120505-a333-4c63-8904-aa379cfb043b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D50")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e")
+		(property "Reference" "D51"
+			(at 132.08 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48596e1c-4629-46bb-98c1-de11cd41e539")
+		)
+		(pin "2"
+			(uuid "f7decfb7-c4ef-4861-ba8a-043f44f3b09e")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D51")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf81ef85-b58f-422a-b88a-7b7914aa3581")
+		(property "Reference" "D12"
+			(at 50.8 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e34c154b-a3cb-467d-891b-2f2891056190")
+		)
+		(pin "2"
+			(uuid "dc926c49-c915-470d-b2b5-00749f3505bb")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d40b4fbb-e58c-433e-b2c5-236bb8aa92c5")
+		(property "Reference" "D1"
+			(at 30.48 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90049b07-ff34-407c-ad1c-bcb8b89b241c")
+		)
+		(pin "2"
+			(uuid "7bd5d68f-4902-47f7-bc35-be0973d0d904")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578")
+		(property "Reference" "RC5-0"
+			(at 139.7 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e5729530-792d-44f2-80ff-f6315aae335e")
+		)
+		(pin "2"
+			(uuid "01f42ec4-9037-47c0-8fc0-8f7345fd0a2b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69")
+		(property "Reference" "RC2-1"
+			(at 78.74 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba2015a3-c3ad-44cf-b530-b2a60bac2c12")
+		)
+		(pin "2"
+			(uuid "12bdf482-8bd0-4b7d-a511-fcaadc8ab54d")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "daefbaa6-3e17-4eca-837b-024ccac5fc10")
+		(property "Reference" "D14"
+			(at 50.8 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12e5236e-b23d-4e38-9768-e28d1693b6eb")
+		)
+		(pin "2"
+			(uuid "1be4fe23-ac83-4b50-b43f-2e4b33c335d7")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e490f25a-1360-4f95-aa79-5f1d93892bb3")
+		(property "Reference" "RC3-5"
+			(at 99.06 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "056973a8-92e3-49be-9b21-fe961241d12f")
+		)
+		(pin "2"
+			(uuid "01c4c06b-d45d-4ffb-ad72-57ca7686fd55")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 105.41 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b")
+		(property "Reference" "DS3"
+			(at 96.52 106.045 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 96.52 103.505 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "738869bf-f410-43b7-b7e7-4e927d69911a")
+		)
+		(pin "2"
+			(uuid "71649a24-87f4-49fb-9896-e50c64c03a31")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb153eb2-74b0-4cb9-b105-af356654d60d")
+		(property "Reference" "D24"
+			(at 71.12 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "77c4fd5e-5c79-4799-aab6-2f07a57c7df3")
+		)
+		(pin "2"
+			(uuid "a062346b-452b-46dc-a106-fab01848555d")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D24")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1920e34-64a4-41c9-8680-7fa42f5dfb9d")
+		(property "Reference" "RC2-0"
+			(at 78.74 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9242378-4df5-4b90-afbf-1098ccb8067f")
+		)
+		(pin "2"
+			(uuid "a135b9b9-316d-4cb2-a5a5-8d618a00a752")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc941f43-b642-4fef-8515-f8f851adced2")
+		(property "Reference" "D13"
+			(at 50.8 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c")
+		)
+		(pin "2"
+			(uuid "ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fcc35b13-8da5-4271-981a-5470b3add3e5")
+		(property "Reference" "D25"
+			(at 71.12 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0f0d662a-16b3-4c76-b4ee-49de18b57b47")
+		)
+		(pin "2"
+			(uuid "ba9a1f4c-173e-4b32-907f-fe9b31df718b")
+		)
+		(instances
+			(project "round-robin-7-30"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/round-robin-8-42.kicad_sch
+++ b/round-robin-8-42.kicad_sch
@@ -2083,7 +2083,7 @@
 			)
 		)
 	)
-	(global_label "IO 5"
+	(global_label "IO 6"
 		(shape bidirectional)
 		(at 165.1 25.4 90)
 		(fields_autoplaced yes)
@@ -2095,12 +2095,12 @@
 		)
 		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 165.1 17.2705 90)
+			(at 165.1 17.1911 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 				(hide yes)
 			)
 		)

--- a/round-robin-8-42.kicad_sch
+++ b/round-robin-8-42.kicad_sch
@@ -1,3795 +1,10221 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid cbac505e-77a6-4a00-a758-435de33cca16)
-
-  (paper "A3" portrait)
-
-  (lib_symbols
-    (symbol "Diode:1N4148" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "1N4148" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Device" "D" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Pins" "1=K 2=A" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "100V 0.15A standard switching diode, DO-35" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "D*DO?35*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "1N4148_0_1"
-        (polyline
-          (pts
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "1N4148_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 1.27 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "SW_Push" (at 0 -1.524 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "switch normally-open pushbutton push-button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Push button switch, generic, two pins" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SW_Push_0_1"
-        (circle (center -2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 3.048)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 0 180) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 165.1 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 00d75863-bb9f-4d4c-ae8f-f64498ed1533)
-  )
-  (junction (at 154.94 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 00d7cd9a-ef35-47e5-9c5b-fc78b3d5db54)
-  )
-  (junction (at 154.94 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 031341d5-0985-401c-b571-184ae9c80cc7)
-  )
-  (junction (at 104.14 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 06a6d1a8-0f12-4174-b63e-d35d8ca618bf)
-  )
-  (junction (at 165.1 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 09e82fd3-a43f-4071-83d2-fb0a65931c0e)
-  )
-  (junction (at 63.5 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0a9113d4-8a8c-4abc-b886-f22c92ad18dc)
-  )
-  (junction (at 124.46 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29)
-  )
-  (junction (at 73.66 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0c7244ee-ddfb-470b-a70b-1cfc53f83773)
-  )
-  (junction (at 134.62 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 0c73479c-4e07-428a-85f3-93341c42ca57)
-  )
-  (junction (at 93.98 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5f3a7a-dc5d-4973-8743-eafaa1c1a462)
-  )
-  (junction (at 43.18 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 10cae212-bc64-40b9-b44f-13fd4a0406a6)
-  )
-  (junction (at 83.82 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1278b5e3-5eff-46d6-a162-44fde2066970)
-  )
-  (junction (at 53.34 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 14bb4fc2-d7df-49aa-b10e-882abdd2aa5f)
-  )
-  (junction (at 104.14 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 17f3773a-2c02-426d-bcd6-7a35c59a710a)
-  )
-  (junction (at 114.3 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 1a11ada5-19c8-45ac-810c-daedbb80ad5b)
-  )
-  (junction (at 73.66 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1c386ee6-5b9d-4eae-92b5-9440e81067f6)
-  )
-  (junction (at 154.94 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1f991325-c039-4256-a53a-b28fb9b7dd9e)
-  )
-  (junction (at 93.98 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 21e320b6-a0c4-4d5d-babf-ee5274120507)
-  )
-  (junction (at 165.1 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 2501dc30-a271-4271-9ca6-b085328a23ec)
-  )
-  (junction (at 124.46 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 2b2b66bc-905d-4b48-89f5-1c62f6c27dbb)
-  )
-  (junction (at 134.62 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 2c5878fe-fb0a-42a4-a883-ea4209708ea5)
-  )
-  (junction (at 63.5 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 2d808057-faeb-478c-a005-dbbbe2bf98c1)
-  )
-  (junction (at 73.66 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 30c9eca3-7c32-4704-8819-3599d7b84f53)
-  )
-  (junction (at 93.98 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 31a1b16e-8174-4fea-bc42-9c75ed9182a0)
-  )
-  (junction (at 114.3 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 347306fc-87ef-43e1-a98f-ca29ac9473e6)
-  )
-  (junction (at 124.46 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 352af8be-9d08-4866-961e-b8632013179f)
-  )
-  (junction (at 104.14 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 356b49b0-20ac-4c33-8df8-9b27dee0b312)
-  )
-  (junction (at 185.42 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c)
-  )
-  (junction (at 114.3 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 490a89d7-a161-4f1a-9b45-a55729d9d59b)
-  )
-  (junction (at 124.46 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4c74baef-72cb-4cdf-b4eb-a3d28782257d)
-  )
-  (junction (at 53.34 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 4c7a50e9-7650-493b-b0a7-057b900a13a7)
-  )
-  (junction (at 63.5 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9)
-  )
-  (junction (at 165.1 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 4df4e0a7-6e46-4c32-959d-094f3457d75b)
-  )
-  (junction (at 43.18 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 4e641ba8-cbcf-42cf-89f0-ac977902bf98)
-  )
-  (junction (at 73.66 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 4fc826ad-ef7b-406a-9b89-76eb2c211523)
-  )
-  (junction (at 53.34 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 4fce0301-62b3-4ef1-9bae-8d55ea745d66)
-  )
-  (junction (at 53.34 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 53bb27f5-9b54-4704-b90e-33b3053be6c4)
-  )
-  (junction (at 154.94 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 65b6b203-33fb-4648-98da-5ff0cc1246cc)
-  )
-  (junction (at 63.5 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 670a793c-4c48-41d1-9f07-66b1d7d84b06)
-  )
-  (junction (at 83.82 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 672e2ce9-8f2c-43ff-9498-0e342bc1c65e)
-  )
-  (junction (at 43.18 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6bfc7531-8adc-4c87-bf8a-788404262765)
-  )
-  (junction (at 134.62 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1)
-  )
-  (junction (at 63.5 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 712da204-b8e1-4637-b967-521ccf7b108c)
-  )
-  (junction (at 73.66 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 71e77471-d824-448e-a6de-31cce05e17c2)
-  )
-  (junction (at 73.66 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 742ecb41-f257-40d3-a6f3-d155d6036628)
-  )
-  (junction (at 93.98 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 782ee96d-a257-4c78-ac0f-a3b5279bef37)
-  )
-  (junction (at 53.34 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 7943e9ed-5e22-49d3-a238-47d875f3e823)
-  )
-  (junction (at 43.18 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 7dbcae2f-e000-4aff-92b3-5518ea113182)
-  )
-  (junction (at 104.14 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 822096c9-a5b4-460b-8639-9bbf1bb1a2fa)
-  )
-  (junction (at 93.98 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 84442e81-a253-49f6-ab0f-8ece0b39f637)
-  )
-  (junction (at 53.34 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 86d88f2b-6e5b-493a-b3a4-5436a8374fae)
-  )
-  (junction (at 104.14 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 88441b0d-9a40-4e18-8fc9-814cc1cb4d3e)
-  )
-  (junction (at 83.82 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 8bf191a4-2dcd-4018-b67a-91aef9fad846)
-  )
-  (junction (at 144.78 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 8d88bb99-f0e4-4a81-b464-31814877675a)
-  )
-  (junction (at 154.94 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 950e9d22-abb7-4d11-b3ab-59cc90a5e7b5)
-  )
-  (junction (at 185.42 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 95b0c111-7d27-49ee-a08f-b6f35d9d5b54)
-  )
-  (junction (at 93.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 96a12dd2-d02f-4a86-aa6d-3a7015c06462)
-  )
-  (junction (at 134.62 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 99c67f58-7bde-4417-a08c-823e6af847f2)
-  )
-  (junction (at 124.46 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9d2b0f02-b19d-4907-8835-9e7f8a8b9c34)
-  )
-  (junction (at 154.94 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 9ecc2321-002b-408d-8858-0987adb7df1e)
-  )
-  (junction (at 165.1 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid a7400bf6-86c3-4d41-886e-57235a457a4c)
-  )
-  (junction (at 185.42 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid a9ece8f4-f868-428b-b7ff-a3dc07b47d6c)
-  )
-  (junction (at 144.78 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid aa4f9edb-d8b6-45e2-8d16-270f3c9fc990)
-  )
-  (junction (at 83.82 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b23bc3a0-3ebe-44a5-9126-8b5c4d648e08)
-  )
-  (junction (at 185.42 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b98759bc-77be-4dce-9aa2-cc5ce3889034)
-  )
-  (junction (at 53.34 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3)
-  )
-  (junction (at 144.78 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid befc6138-873b-4406-bc9e-e5a72f7f36fe)
-  )
-  (junction (at 83.82 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0)
-  )
-  (junction (at 134.62 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid c29c26fc-c285-45ba-9e88-4c2a02375307)
-  )
-  (junction (at 165.1 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid c331d35d-23c9-43ea-b243-b660cb5f4bdb)
-  )
-  (junction (at 134.62 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid c3f1775c-0d63-41d3-b7d8-a4c96d241ce3)
-  )
-  (junction (at 93.98 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c41e97f8-87c8-4e82-92ed-e4644d6f526e)
-  )
-  (junction (at 185.42 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c56d20e0-377b-42bf-89fc-25b698ca10b4)
-  )
-  (junction (at 114.3 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c5afc93c-0846-4cf9-8f93-4c8f2232c9fa)
-  )
-  (junction (at 154.94 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid c8075164-3db2-4fce-aefd-057a5a32f582)
-  )
-  (junction (at 43.18 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid c8f222f6-943e-4d7d-919b-3278ca0ede33)
-  )
-  (junction (at 144.78 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cc2d9922-84c9-42ce-883b-c028a251c101)
-  )
-  (junction (at 63.5 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid cfd86ddc-0810-4057-8a79-4468ec7b2424)
-  )
-  (junction (at 83.82 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid d5a179bd-82b1-4661-aebc-4c4d4801bdff)
-  )
-  (junction (at 144.78 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d5b7ef4f-419a-421c-a02d-fd71016e6c97)
-  )
-  (junction (at 114.3 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid dcab5abe-0f5a-44d8-b554-722164ca6a23)
-  )
-  (junction (at 114.3 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid ee17efa1-5df9-47d0-aec2-a440d8b33e4c)
-  )
-  (junction (at 134.62 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid f1379b2f-59c4-4b61-a98f-3645b6e5fe6b)
-  )
-  (junction (at 104.14 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid f24e6016-cf0c-4fe9-b584-ca06dfdbe767)
-  )
-  (junction (at 43.18 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid f6f817c6-438a-4497-93b1-8dc1f36a395c)
-  )
-  (junction (at 124.46 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd)
-  )
-  (junction (at 185.42 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fa2795fd-0138-4010-b310-3d5e73c1be1c)
-  )
-  (junction (at 73.66 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fbda2010-a213-45bb-958d-0c9446d51e42)
-  )
-  (junction (at 114.3 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid fc6abd7a-92c0-4b05-85ed-b3bd910676e1)
-  )
-  (junction (at 144.78 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid fdc0071f-cdad-424a-87db-7bd8a0569159)
-  )
-
-  (wire (pts (xy 83.82 60.96) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 022d84d0-7bcb-4024-8618-6f3a7f7b41aa)
-  )
-  (wire (pts (xy 144.78 25.4) (xy 144.78 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0406a358-3219-4537-99c7-cfb994e5303c)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0429bfe1-2992-4c6f-bb22-b2e8e5724910)
-  )
-  (wire (pts (xy 73.66 109.22) (xy 93.98 109.22))
-    (stroke (width 0) (type default))
-    (uuid 07ee4d30-e80a-41ae-829d-e3cecf87d77e)
-  )
-  (wire (pts (xy 114.3 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0897e94f-d1e3-47ff-89f6-5de7a1349783)
-  )
-  (wire (pts (xy 185.42 68.58) (xy 185.42 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0aee33c0-3781-43dc-99cb-690f399192cd)
-  )
-  (wire (pts (xy 43.18 40.64) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0f76c070-bcf8-4924-a8c5-3abe13c36f41)
-  )
-  (wire (pts (xy 63.5 81.28) (xy 63.5 101.6))
-    (stroke (width 0) (type default))
-    (uuid 11ef6261-91ba-4d4c-99ef-8991b7c91dc8)
-  )
-  (wire (pts (xy 104.14 101.6) (xy 104.14 121.92))
-    (stroke (width 0) (type default))
-    (uuid 12080e73-a151-4804-ac9b-ac3ac13653e9)
-  )
-  (wire (pts (xy 73.66 48.26) (xy 93.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 12a939e2-2ab8-4d74-a5c9-6d61a9528b6e)
-  )
-  (wire (pts (xy 104.14 25.4) (xy 104.14 40.64))
-    (stroke (width 0) (type default))
-    (uuid 1af5b449-9a68-414b-a41f-d6f6cba715a8)
-  )
-  (wire (pts (xy 73.66 81.28) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 1c0140d1-6775-49db-9fd5-7ecf63ae1284)
-  )
-  (wire (pts (xy 177.8 149.86) (xy 154.94 149.86))
-    (stroke (width 0) (type default))
-    (uuid 20f13b47-7825-4cae-9d6b-163d56b184aa)
-  )
-  (wire (pts (xy 114.3 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid 211f763f-7ef6-4fb5-98df-2e2ff37faa42)
-  )
-  (wire (pts (xy 63.5 40.64) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 23f46f84-f16d-4b0b-b463-c2c0244adcc0)
-  )
-  (wire (pts (xy 33.02 129.54) (xy 53.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid 24da3fea-844d-4666-b730-f8d7b708f242)
-  )
-  (wire (pts (xy 53.34 129.54) (xy 73.66 129.54))
-    (stroke (width 0) (type default))
-    (uuid 26f78b89-ba4b-4b48-90d1-1245694ead6f)
-  )
-  (wire (pts (xy 33.02 109.22) (xy 53.34 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2832f642-62e7-4a51-b112-f728658e7714)
-  )
-  (wire (pts (xy 53.34 68.58) (xy 73.66 68.58))
-    (stroke (width 0) (type default))
-    (uuid 29a0e612-9a4c-422c-a9b8-8a9fe3879b8a)
-  )
-  (wire (pts (xy 83.82 101.6) (xy 83.82 121.92))
-    (stroke (width 0) (type default))
-    (uuid 2a44e441-f6d5-4994-b7ba-34283a1facc7)
-  )
-  (wire (pts (xy 124.46 121.92) (xy 124.46 142.24))
-    (stroke (width 0) (type default))
-    (uuid 2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0)
-  )
-  (wire (pts (xy 114.3 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 2a65926a-d988-49f6-92e7-6e4d5936462f)
-  )
-  (wire (pts (xy 165.1 60.96) (xy 165.1 81.28))
-    (stroke (width 0) (type default))
-    (uuid 2b8c9def-eaec-4abd-b08a-c3613e6389df)
-  )
-  (wire (pts (xy 53.34 109.22) (xy 73.66 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd)
-  )
-  (wire (pts (xy 124.46 25.4) (xy 124.46 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3115f7a7-e786-49c1-9e4c-25c171cfeb33)
-  )
-  (wire (pts (xy 73.66 68.58) (xy 93.98 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3197b37c-ee5b-406a-ab67-08670d4b8c09)
-  )
-  (wire (pts (xy 177.8 109.22) (xy 154.94 109.22))
-    (stroke (width 0) (type default))
-    (uuid 3ab82e35-1d5e-4aa0-b90b-a7ac5fa0104b)
-  )
-  (wire (pts (xy 63.5 121.92) (xy 63.5 142.24))
-    (stroke (width 0) (type default))
-    (uuid 3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5)
-  )
-  (wire (pts (xy 73.66 170.18) (xy 93.98 170.18))
-    (stroke (width 0) (type default))
-    (uuid 40ad23e4-b284-4d51-a92e-26a2272af251)
-  )
-  (wire (pts (xy 165.1 121.92) (xy 165.1 142.24))
-    (stroke (width 0) (type default))
-    (uuid 411efa8a-c2b6-469e-b517-3b3f24ffe025)
-  )
-  (wire (pts (xy 53.34 170.18) (xy 73.66 170.18))
-    (stroke (width 0) (type default))
-    (uuid 4554fe48-1b8d-466c-b3f4-c87fb3d79947)
-  )
-  (wire (pts (xy 43.18 60.96) (xy 43.18 81.28))
-    (stroke (width 0) (type default))
-    (uuid 456f0365-d37d-43a2-afac-d06c44cc48af)
-  )
-  (wire (pts (xy 114.3 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid 473d672b-6459-459b-93fc-780e5d8f9818)
-  )
-  (wire (pts (xy 124.46 81.28) (xy 124.46 101.6))
-    (stroke (width 0) (type default))
-    (uuid 495f9334-ca7f-4aa5-8d75-09576f1afa2c)
-  )
-  (wire (pts (xy 165.1 81.28) (xy 165.1 101.6))
-    (stroke (width 0) (type default))
-    (uuid 50f7b113-f5f8-43e0-9da7-2a02dc224210)
-  )
-  (wire (pts (xy 104.14 60.96) (xy 104.14 81.28))
-    (stroke (width 0) (type default))
-    (uuid 5837ecd4-cf70-4c14-9c7b-bb5f05f8274a)
-  )
-  (wire (pts (xy 177.8 48.26) (xy 154.94 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5a1019c3-a65a-4850-acf9-d96f4de0e3ce)
-  )
-  (wire (pts (xy 104.14 81.28) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid 5b6ae0de-21c8-4433-a4e0-a3b552474fb0)
-  )
-  (wire (pts (xy 53.34 88.9) (xy 73.66 88.9))
-    (stroke (width 0) (type default))
-    (uuid 60b5d548-d07f-40b1-8e16-72d513f499f2)
-  )
-  (wire (pts (xy 93.98 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6414e19f-a27a-435d-a47f-a63cba9086f1)
-  )
-  (wire (pts (xy 134.62 109.22) (xy 154.94 109.22))
-    (stroke (width 0) (type default))
-    (uuid 64344100-c91d-4b5c-a8eb-9406d47360dd)
-  )
-  (wire (pts (xy 33.02 68.58) (xy 53.34 68.58))
-    (stroke (width 0) (type default))
-    (uuid 68161b0c-a285-475d-a645-59648d12bc07)
-  )
-  (wire (pts (xy 134.62 149.86) (xy 154.94 149.86))
-    (stroke (width 0) (type default))
-    (uuid 690a405c-1ac3-4b57-a93b-778dda168d2c)
-  )
-  (wire (pts (xy 165.1 40.64) (xy 165.1 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc)
-  )
-  (wire (pts (xy 185.42 149.86) (xy 185.42 170.18))
-    (stroke (width 0) (type default))
-    (uuid 6f77a68c-1e32-433a-820e-9683e6fd5e12)
-  )
-  (wire (pts (xy 185.42 88.9) (xy 185.42 109.22))
-    (stroke (width 0) (type default))
-    (uuid 70c6e975-f457-4759-9791-1d1de45afbb3)
-  )
-  (wire (pts (xy 43.18 121.92) (xy 43.18 142.24))
-    (stroke (width 0) (type default))
-    (uuid 727cc522-ef34-45d4-b711-997054ff0b37)
-  )
-  (wire (pts (xy 33.02 48.26) (xy 53.34 48.26))
-    (stroke (width 0) (type default))
-    (uuid 737596e8-f579-4b1f-aa71-a489d8ba56da)
-  )
-  (wire (pts (xy 93.98 149.86) (xy 114.3 149.86))
-    (stroke (width 0) (type default))
-    (uuid 770cc50c-0085-42e2-b068-cd0ae3b59919)
-  )
-  (wire (pts (xy 185.42 25.4) (xy 185.42 48.26))
-    (stroke (width 0) (type default))
-    (uuid 794205f1-2f7e-4200-b59c-c02481b0416f)
-  )
-  (wire (pts (xy 73.66 88.9) (xy 93.98 88.9))
-    (stroke (width 0) (type default))
-    (uuid 79a42c80-d7a4-4e03-9070-f9fff835a239)
-  )
-  (wire (pts (xy 33.02 40.64) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid 7a4231d0-fb4b-4c65-9cc1-75d3ed714150)
-  )
-  (wire (pts (xy 165.1 25.4) (xy 165.1 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8506f273-12d6-426d-910b-0c9eecbe3765)
-  )
-  (wire (pts (xy 177.8 88.9) (xy 154.94 88.9))
-    (stroke (width 0) (type default))
-    (uuid 8af11afc-5332-4a82-a8bc-ab0167ac423c)
-  )
-  (wire (pts (xy 134.62 68.58) (xy 154.94 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8b5d907e-943a-431c-bc72-2abe781e3a29)
-  )
-  (wire (pts (xy 177.8 129.54) (xy 154.94 129.54))
-    (stroke (width 0) (type default))
-    (uuid 8c0fc5fb-7e6f-4660-88bb-9988ebc48535)
-  )
-  (wire (pts (xy 93.98 48.26) (xy 114.3 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8d73bae8-988b-435b-a882-ae9668b41d7e)
-  )
-  (wire (pts (xy 104.14 142.24) (xy 104.14 162.56))
-    (stroke (width 0) (type default))
-    (uuid 8dd624a1-3da3-42c1-929d-9366cd043e3d)
-  )
-  (wire (pts (xy 185.42 48.26) (xy 185.42 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8f339462-56e0-4361-9d9b-983c75fb21ef)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 53.34 88.9))
-    (stroke (width 0) (type default))
-    (uuid 909384ab-bc1c-47d8-a34d-c3d137febfc2)
-  )
-  (wire (pts (xy 124.46 101.6) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91eea887-ea8a-4221-ba92-e5ec1caacc4f)
-  )
-  (wire (pts (xy 124.46 142.24) (xy 124.46 162.56))
-    (stroke (width 0) (type default))
-    (uuid 94397688-ce0e-48d4-a59c-7257120bf834)
-  )
-  (wire (pts (xy 114.3 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 9c79c76c-a95b-401f-9edb-a06a0cceaa4b)
-  )
-  (wire (pts (xy 53.34 48.26) (xy 73.66 48.26))
-    (stroke (width 0) (type default))
-    (uuid 9d5ec847-5716-4125-b40b-fdbd3a1587a7)
-  )
-  (wire (pts (xy 165.1 101.6) (xy 165.1 121.92))
-    (stroke (width 0) (type default))
-    (uuid 9f711890-a6d6-4440-8bc1-ed469cb6acc4)
-  )
-  (wire (pts (xy 93.98 101.6) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid a226d887-7662-4dbd-b58b-e683f5d85955)
-  )
-  (wire (pts (xy 134.62 48.26) (xy 154.94 48.26))
-    (stroke (width 0) (type default))
-    (uuid a2736023-3b9d-49fd-b999-28b7c4f9ccda)
-  )
-  (wire (pts (xy 124.46 40.64) (xy 124.46 60.96))
-    (stroke (width 0) (type default))
-    (uuid a67c0815-f186-4f70-926f-1b264c84d8d8)
-  )
-  (wire (pts (xy 63.5 60.96) (xy 63.5 81.28))
-    (stroke (width 0) (type default))
-    (uuid a6a1d300-b392-4504-80e5-ef4849e747ad)
-  )
-  (wire (pts (xy 154.94 162.56) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid a803bbba-64cc-448d-a04f-7f03127ebddd)
-  )
-  (wire (pts (xy 53.34 149.86) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid aac914ea-c9a3-4a8f-94e1-1f91cdd136a3)
-  )
-  (wire (pts (xy 93.98 129.54) (xy 114.3 129.54))
-    (stroke (width 0) (type default))
-    (uuid ab578e4e-a4bf-4ab4-80fc-d97d4aea6370)
-  )
-  (wire (pts (xy 53.34 60.96) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid abbb9177-3783-4c3c-a4ad-361c4048cd21)
-  )
-  (wire (pts (xy 83.82 121.92) (xy 83.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73)
-  )
-  (wire (pts (xy 93.98 68.58) (xy 114.3 68.58))
-    (stroke (width 0) (type default))
-    (uuid aea6a633-b213-403d-b447-42d91d3ab4da)
-  )
-  (wire (pts (xy 114.3 170.18) (xy 134.62 170.18))
-    (stroke (width 0) (type default))
-    (uuid b3e14390-7dc6-416b-bbd5-cdf868192ca4)
-  )
-  (wire (pts (xy 73.66 129.54) (xy 93.98 129.54))
-    (stroke (width 0) (type default))
-    (uuid b3f6f053-44f0-4391-9873-b6231b8014db)
-  )
-  (wire (pts (xy 144.78 101.6) (xy 144.78 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7b2475f-30dc-4ea2-b799-96c21242154c)
-  )
-  (wire (pts (xy 83.82 81.28) (xy 83.82 101.6))
-    (stroke (width 0) (type default))
-    (uuid b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5)
-  )
-  (wire (pts (xy 43.18 101.6) (xy 43.18 121.92))
-    (stroke (width 0) (type default))
-    (uuid bb49a3de-620b-45ad-a54c-29dcceaf0796)
-  )
-  (wire (pts (xy 134.62 129.54) (xy 154.94 129.54))
-    (stroke (width 0) (type default))
-    (uuid be9d25ae-f4eb-4b8a-906a-25cd5eb33eee)
-  )
-  (wire (pts (xy 144.78 121.92) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid bf12198a-9e62-45c3-b466-f5d86de75219)
-  )
-  (wire (pts (xy 63.5 25.4) (xy 63.5 40.64))
-    (stroke (width 0) (type default))
-    (uuid c1a940de-fa49-4106-a8b9-697952eec2a2)
-  )
-  (wire (pts (xy 104.14 121.92) (xy 104.14 142.24))
-    (stroke (width 0) (type default))
-    (uuid c298ba49-6974-4340-859f-5d5a2b4132ff)
-  )
-  (wire (pts (xy 124.46 60.96) (xy 124.46 81.28))
-    (stroke (width 0) (type default))
-    (uuid c950d145-c024-47a8-ba57-97efd7bb658b)
-  )
-  (wire (pts (xy 144.78 142.24) (xy 144.78 162.56))
-    (stroke (width 0) (type default))
-    (uuid ca92ed7f-ae97-4c0c-81e4-820de1c001c1)
-  )
-  (wire (pts (xy 185.42 109.22) (xy 185.42 129.54))
-    (stroke (width 0) (type default))
-    (uuid cdde081d-7bdd-42e6-869e-3ff07b8b464b)
-  )
-  (wire (pts (xy 83.82 40.64) (xy 83.82 60.96))
-    (stroke (width 0) (type default))
-    (uuid cff15ec3-f29c-4d36-8776-64c5d29be534)
-  )
-  (wire (pts (xy 83.82 25.4) (xy 83.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid d1088709-a9b9-4e05-8ea2-f87942ee2796)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 93.98 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1347903-ae03-46a2-a707-154093060583)
-  )
-  (wire (pts (xy 134.62 170.18) (xy 154.94 170.18))
-    (stroke (width 0) (type default))
-    (uuid d187208d-eec6-46ce-8efb-063c47534382)
-  )
-  (wire (pts (xy 144.78 40.64) (xy 144.78 60.96))
-    (stroke (width 0) (type default))
-    (uuid d2183fb3-afd3-46ca-955e-993ea31aa5d3)
-  )
-  (wire (pts (xy 43.18 142.24) (xy 43.18 162.56))
-    (stroke (width 0) (type default))
-    (uuid d76ad758-0ae0-4ce6-9f67-c689c066c744)
-  )
-  (wire (pts (xy 33.02 149.86) (xy 53.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid da80b027-904b-4ca2-99c6-5937c80c825c)
-  )
-  (wire (pts (xy 63.5 142.24) (xy 63.5 162.56))
-    (stroke (width 0) (type default))
-    (uuid db492971-48ff-4667-996c-f5d540a20741)
-  )
-  (wire (pts (xy 177.8 68.58) (xy 154.94 68.58))
-    (stroke (width 0) (type default))
-    (uuid db5976d9-d358-409b-8c22-c774449a4749)
-  )
-  (wire (pts (xy 165.1 142.24) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid dccfde3a-ff1d-42ec-97d5-a8f6cccea832)
-  )
-  (wire (pts (xy 33.02 170.18) (xy 53.34 170.18))
-    (stroke (width 0) (type default))
-    (uuid de8e54c6-84d9-47e5-8f08-dc3e96b8afdb)
-  )
-  (wire (pts (xy 43.18 81.28) (xy 43.18 101.6))
-    (stroke (width 0) (type default))
-    (uuid df5c3763-e66c-46c4-9070-0f73d8115bc4)
-  )
-  (wire (pts (xy 185.42 129.54) (xy 185.42 149.86))
-    (stroke (width 0) (type default))
-    (uuid dfb5a082-e4d5-46ea-8dc8-c65064cd598b)
-  )
-  (wire (pts (xy 93.98 170.18) (xy 114.3 170.18))
-    (stroke (width 0) (type default))
-    (uuid e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb)
-  )
-  (wire (pts (xy 144.78 81.28) (xy 144.78 101.6))
-    (stroke (width 0) (type default))
-    (uuid e444742a-24b1-4bbf-b7ee-438e6dffc9cc)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid e6d06035-ccb7-4d3e-ae70-d73150e65bbb)
-  )
-  (wire (pts (xy 114.3 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa)
-  )
-  (wire (pts (xy 63.5 101.6) (xy 63.5 121.92))
-    (stroke (width 0) (type default))
-    (uuid edeeb0d9-51cc-411d-aac4-77f10b619702)
-  )
-  (wire (pts (xy 177.8 170.18) (xy 154.94 170.18))
-    (stroke (width 0) (type default))
-    (uuid eeafc558-c991-4da4-9667-7ee142f1f3fc)
-  )
-  (wire (pts (xy 104.14 40.64) (xy 104.14 60.96))
-    (stroke (width 0) (type default))
-    (uuid ef5c9f05-d71b-4562-9939-852432c066c5)
-  )
-  (wire (pts (xy 144.78 60.96) (xy 144.78 81.28))
-    (stroke (width 0) (type default))
-    (uuid f0ce7c2b-d80c-49f2-bf63-62b750f7ca47)
-  )
-  (wire (pts (xy 134.62 142.24) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid f781a362-e0d4-48be-9d13-5686e05b406f)
-  )
-  (wire (pts (xy 43.18 25.4) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid fa765e67-a220-4a00-944c-7663298f0ead)
-  )
-  (wire (pts (xy 83.82 142.24) (xy 83.82 162.56))
-    (stroke (width 0) (type default))
-    (uuid fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b)
-  )
-  (wire (pts (xy 134.62 88.9) (xy 154.94 88.9))
-    (stroke (width 0) (type default))
-    (uuid fe9aa3a8-9e6f-4970-a032-3a3fd676df11)
-  )
-
-  (global_label "IO 3" (shape bidirectional) (at 104.14 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 24ec698b-5cae-4571-b9c4-c0e35d64a64d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 104.14 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 1" (shape bidirectional) (at 63.5 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2d4b15a5-8b6c-4ca3-a7bb-7848c8036590)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 63.5 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 0" (shape bidirectional) (at 43.18 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 465a517d-f0e1-4825-8675-1cce54bfa7a5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 43.18 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "INTR" (shape bidirectional) (at 185.42 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4e12b932-2346-4e84-b5a4-80468334f3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 193.61 25.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "IO 2" (shape bidirectional) (at 83.82 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 70d42e66-a74c-4de2-af96-d1860851d3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 83.82 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 165.1 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 89461221-a936-49a3-bf5d-18ec120f3e0c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 165.1 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 144.78 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d44cceb0-f409-4e5f-a98a-9feead2e845d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 4" (shape bidirectional) (at 124.46 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f36f49e4-227f-479f-b914-786aa44dd568)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 124.46 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0263b847-a932-4a31-9f35-35bb23f7000d)
-    (property "Reference" "D62" (at 152.4 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc2e60ca-c74f-4e4b-a0a0-9705327e9578))
-    (pin "2" (uuid d12efbfe-85ac-442f-8c0f-ddbe5646c7d5))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D62") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 64.77 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 04430572-8314-4d21-974c-22350cead1a6)
-    (property "Reference" "DS1" (at 55.88 65.405 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 55.88 62.865 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e433df4-9fec-4cfb-b60f-eebca7c574cf))
-    (pin "2" (uuid 9bcc1487-0612-4bdb-a2de-a8b2f590b28f))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 44.45 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080aaa87-0974-4a77-bf63-185495f411a0)
-    (property "Reference" "DS0" (at 35.56 45.085 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 35.56 42.545 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bfacad1-28fd-4f2e-93dc-68f478b8a6ba))
-    (pin "2" (uuid 376f73f9-79fa-4153-ae38-31ed5446db52))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09d14922-c46a-4bf1-bb2c-1d224060568c)
-    (property "Reference" "D40" (at 111.76 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2f1a1d2-df3d-4680-9706-2ca411fa6890))
-    (pin "2" (uuid f58fd788-6016-46e7-b903-3606dd2ec21d))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D40") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 149.86 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0d18473f-e37a-4136-b721-5a2e40e4f8ed)
-    (property "Reference" "DI5" (at 181.61 146.05 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 152.4 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d5a885ca-5076-44e6-9a84-d07474947dde))
-    (pin "2" (uuid 047b5b54-de8b-4afc-abc2-c6d1f2d17bd2))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 170.18 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0ef17723-f7f8-4fdb-8913-5a4ceefbc065)
-    (property "Reference" "DI6" (at 181.61 166.37 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 172.72 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df5a6b10-ba48-4f34-96ce-3832d480a7ee))
-    (pin "2" (uuid 59f34a55-6ac4-496d-8c40-1b8f1eafbcb5))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0fadd319-be81-4c25-8d23-e7495a114aa7)
-    (property "Reference" "RC4-0" (at 119.38 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid efb1c47f-fe25-4bea-8081-43d3c19de5cd))
-    (pin "2" (uuid 9138c970-6e3d-46df-9354-5174df2a4e52))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ff76361-9578-4f9f-a20c-f042e24a7755)
-    (property "Reference" "D5" (at 30.48 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06))
-    (pin "2" (uuid cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 11f01cd8-f751-497f-9599-50fe1fc0a618)
-    (property "Reference" "RC5-4" (at 139.7 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc28293-fab9-4f93-b3d5-ca9ee69110c4))
-    (pin "2" (uuid 088ac770-af1e-4c4f-ad11-5b44a20594d8))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 13ddd48d-7d2b-415d-b8fa-15c71e245acc)
-    (property "Reference" "D61" (at 152.4 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 745d89b9-e75a-40ae-97bc-d1eadf220f02))
-    (pin "2" (uuid 7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D61") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1b13866a-6fbf-441b-9c64-56258379f43a)
-    (property "Reference" "D65" (at 152.4 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c70f4670-9685-4aab-ac4f-4ebaf44d5847))
-    (pin "2" (uuid 8b9c860d-59e1-424e-a148-1aa2c0db4056))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D65") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a)
-    (property "Reference" "RC6-4" (at 160.02 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3427b432-e194-40af-9dcb-04dccafe2b0f))
-    (pin "2" (uuid 8af48a1b-2c49-47d9-959c-ee33cdd6f977))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1e5f084d-4db5-48ad-a2a3-76f186559614)
-    (property "Reference" "RC3-1" (at 99.06 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa))
-    (pin "2" (uuid 40b7f115-b5d7-4fa0-b12b-c1c7b6866feb))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 244b7f9d-3923-4908-be6d-02c49eb4663c)
-    (property "Reference" "RC2-3" (at 78.74 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d79440a-2f90-4c0b-8d60-528615b0bd65))
-    (pin "2" (uuid 7f1d0566-f385-4126-b190-2379308ed05b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 166.37 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2518146c-59f4-45b7-a4fa-f618686ab064)
-    (property "Reference" "DS6" (at 157.48 167.005 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 157.48 164.465 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cee2f461-8f62-48d8-ac7b-1698deb984c1))
-    (pin "2" (uuid 460b9088-619c-4166-a615-45e17ecf1f0d))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2519cd5e-8ecf-41a4-a9d0-5b856882cb05)
-    (property "Reference" "D63" (at 152.4 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ea1c9827-ebfa-43f1-b2c6-5a572466713e))
-    (pin "2" (uuid 0496ba9c-818c-4d39-979a-e8785e06d12a))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D63") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 28137b00-0d76-493b-92b8-23037474163f)
-    (property "Reference" "RC1-3" (at 58.42 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3))
-    (pin "2" (uuid 41d35b0f-21b5-4da8-92df-229c816b63c5))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c50947a-4bb9-43c2-b65c-4726e224b6b0)
-    (property "Reference" "RC3-0" (at 99.06 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b))
-    (pin "2" (uuid 30241adf-a2e7-4976-a53a-5c267616618e))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30340eba-9ed0-42ff-b11f-98a864f7223e)
-    (property "Reference" "RC1-4" (at 58.42 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aa956a67-c26e-4a57-9ddb-59688a6476ad))
-    (pin "2" (uuid 23cd0d93-5050-40ea-9d49-879bbcbb8bcd))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30b60f6a-8d20-44dd-b832-1906a957c513)
-    (property "Reference" "D54" (at 132.08 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c2ad1a4-b254-49a0-8435-d3a374353ffc))
-    (pin "2" (uuid 27a3cb64-baf1-430a-b797-bd52c0e46cbe))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D54") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 310fec10-f10c-41d7-9446-87c12744e146)
-    (property "Reference" "D26" (at 71.12 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e1d524d3-5d24-4c87-b480-74c57a74b567))
-    (pin "2" (uuid c0e9aa05-6318-4fdc-abee-cb43875c8e46))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D26") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35827986-7004-4f70-a10a-6ceb42f33d9f)
-    (property "Reference" "RC1-2" (at 58.42 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 879d3b07-b41e-4233-b196-e223f635bdf3))
-    (pin "2" (uuid 641f8ea7-6306-4550-92c8-e3cc0ed3e5a5))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976)
-    (property "Reference" "D43" (at 111.76 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7d6fb6c4-b36c-4ff1-879b-43826c273a72))
-    (pin "2" (uuid 198c65f6-b3df-4780-9f6d-1c910e870a1b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D43") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef0222e-2eac-4930-ac36-0f395f4593b6)
-    (property "Reference" "RC1-0" (at 58.42 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f0b9b8-9322-4d89-a423-dd3d807d99ff))
-    (pin "2" (uuid ce54609e-9d1d-4a3b-81a2-5a384dbe41c8))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef86e49-a152-4515-afb0-4098f497c742)
-    (property "Reference" "D31" (at 91.44 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a))
-    (pin "2" (uuid b917ad78-96a8-428f-ad4f-d49149b5b97b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D31") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 402f0f46-5eb8-421b-9b9f-01a54b5cfa87)
-    (property "Reference" "RC4-1" (at 119.38 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cb206c0-1fab-4ac5-b301-f9678369525b))
-    (pin "2" (uuid b99c2ecc-04a5-4c54-a491-d99fe2562dcc))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 40d8058d-714e-4f99-a508-f64f9c8b575b)
-    (property "Reference" "D60" (at 152.4 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 66710233-d2ab-4921-aa86-488ee87fbb3a))
-    (pin "2" (uuid a9636da9-222c-478f-bc5b-71d3f0473300))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D60") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 433f3f09-0867-41a3-8ac6-5f00bd3314fc)
-    (property "Reference" "D32" (at 91.44 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 11a29637-fd50-4473-bb70-d4116312a4f5))
-    (pin "2" (uuid 53f6307d-8380-45e9-b3fa-4d05a2bd575d))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44de9323-bd5d-49cd-bf0a-70392801309d)
-    (property "Reference" "D45" (at 111.76 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb2b185b-5d98-46b8-8516-9e5c980291cf))
-    (pin "2" (uuid f730da3b-5ef9-4abc-8c8d-0794fe3feb87))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D45") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 454ad926-1c6a-4aa4-b6f8-25297463de18)
-    (property "Reference" "RC3-2" (at 99.06 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f0aebfce-7e76-40f1-83ef-5914b8ebbcc7))
-    (pin "2" (uuid 744fce2b-a15c-45a6-92b0-e880efafb5f6))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 48.26 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46348ccc-126c-461a-8e39-f93f389ddaa7)
-    (property "Reference" "DI0" (at 181.61 44.45 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 50.8 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c86bf5fa-c113-44c1-b93d-7a5d4ac11904))
-    (pin "2" (uuid dbd8322f-50c7-4271-821c-b0005fd066b2))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4a7f7b3d-918b-431a-b79d-c66494b3ec50)
-    (property "Reference" "D52" (at 132.08 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd114d76-87b2-4089-b211-b7b541ac42b3))
-    (pin "2" (uuid a360aa38-116c-4dd0-a569-f6a7a5a88a05))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D52") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4d978207-10b9-4a43-a474-2e66421925a0)
-    (property "Reference" "D64" (at 152.4 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 27529674-e97c-460d-9de8-89cd61c8a6eb))
-    (pin "2" (uuid 57e77ee6-e62d-402e-a614-a833da3fbafb))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D64") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5466fd2d-f22f-409b-b7da-f8d297aeb7a2)
-    (property "Reference" "RC6-5" (at 160.02 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffdd8419-9afa-4f38-bfbf-7dc4e869b438))
-    (pin "2" (uuid 0db27643-51f5-4634-a791-2c4813885195))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 553a576d-44a1-4bad-9211-394526206f63)
-    (property "Reference" "D41" (at 111.76 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4a035e61-91c9-41ba-9328-bc9b284e86c2))
-    (pin "2" (uuid 8628539f-d3cd-4957-a6bb-5c605649e715))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D41") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 68.58 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5692cd7d-67c7-4fe7-8b4d-c8bc86968b31)
-    (property "Reference" "DI1" (at 181.61 64.77 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9abe1fc5-b3c1-424f-8519-d12916c57a11))
-    (pin "2" (uuid 168b1203-c5fc-4b69-b8e5-94d0bdc27e41))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59263e5e-1eeb-458b-9b02-ca162d4a65d7)
-    (property "Reference" "D21" (at 71.12 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2372f523-257f-414c-92f4-8d433cfbee15))
-    (pin "2" (uuid 21891727-1d09-4cab-bd90-75c57b141f7c))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D21") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59fdee43-9b65-471d-9ea8-5dc40dc65f6e)
-    (property "Reference" "D35" (at 91.44 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5834d436-0e26-481b-a20d-40fa6346502e))
-    (pin "2" (uuid 59af1ddc-701f-49c0-b6cd-778072695c5c))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D35") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5aeb247f-6f79-4df2-b767-9ca89069182c)
-    (property "Reference" "D56" (at 132.08 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d46c0cdd-d9c1-44c1-ba6c-034fc547ff01))
-    (pin "2" (uuid 53f3e198-3ef2-40c4-a8f7-298435eddd0b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D56") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5c60f960-fb0a-46f6-9aff-5d8144586231)
-    (property "Reference" "RC4-6" (at 119.38 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 990f1ee1-d6da-4ae8-809a-1911d8099a4c))
-    (pin "2" (uuid a8276c00-b61f-4db4-8f4f-e51e512de654))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5f21a75c-b9ee-47bf-adcf-39a03e42660f)
-    (property "Reference" "D15" (at 50.8 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1))
-    (pin "2" (uuid 7a8a84c2-38d2-473b-955d-81dd816a398e))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D15") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5fa8cce4-fbbf-4784-a459-71364b77e1a7)
-    (property "Reference" "RC0-2" (at 38.1 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cb7750fa-a378-43a3-a1c6-638c32a1c79e))
-    (pin "2" (uuid 67dfe958-6bd5-4618-98a3-d513db4ad5c0))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5ff7733c-a36f-4b29-a8e7-bdf79fabdf72)
-    (property "Reference" "D4" (at 30.48 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ed6062e9-f00a-474a-840f-39685bd66d70))
-    (pin "2" (uuid c0e85db4-b88d-4383-8de6-9f7370be62a6))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61b2e3fc-583b-407b-beff-dd8441f2f403)
-    (property "Reference" "RC2-6" (at 78.74 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 752f308d-4723-4468-9745-81de18307ba3))
-    (pin "2" (uuid 3267c09c-2818-42d7-96a9-6aaa2d6c4a92))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6368f5d6-df20-4a23-a72c-e29e990ea131)
-    (property "Reference" "D36" (at 91.44 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cd72461-15a2-466d-828d-9560639fb78b))
-    (pin "2" (uuid e26d27e6-f81a-4557-bc98-f3f953d25d26))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D36") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 67aba0e0-2c92-4816-99a5-9091230a7899)
-    (property "Reference" "RC3-6" (at 99.06 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9c252319-dc79-4365-afaa-77dcde3e6c4e))
-    (pin "2" (uuid a5f35312-d094-4f22-9eb9-0edc1f8fb9c4))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6aa79de9-555a-4ed1-93d3-b801685ebd28)
-    (property "Reference" "D53" (at 132.08 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2031fe-ef72-48a9-afa6-c06144a31b2c))
-    (pin "2" (uuid 7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D53") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 70d661b8-51f1-49b8-ad84-9ce8d120c0fc)
-    (property "Reference" "RC6-2" (at 160.02 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2175ea2-22e6-4720-ab54-24959d43a616))
-    (pin "2" (uuid 63a1bf12-3f2f-4dc8-8a86-7932361b8306))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 72047ccc-8813-4e13-ae4a-04618a9ab771)
-    (property "Reference" "D23" (at 71.12 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84))
-    (pin "2" (uuid 6dee3493-b1eb-401e-abb4-cbdef0ef3867))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D23") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7322809e-8332-47c6-af41-fcf3bbcec7d0)
-    (property "Reference" "D34" (at 91.44 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e3b096d1-dbd9-4fb8-8775-725a7aed0bc4))
-    (pin "2" (uuid 63756bb0-b693-4bbc-82da-e89a6b927e71))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D34") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 76054860-648b-474e-9b4d-cc9d83653495)
-    (property "Reference" "D10" (at 50.8 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d7e8bc-1ac3-4327-ab17-369de6ee755c))
-    (pin "2" (uuid c8283bba-c907-48e0-9745-e0818ca7ab04))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 77aa25a5-82c7-42c3-9d55-8606dd65ffa8)
-    (property "Reference" "RC5-1" (at 139.7 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51db5d58-5004-4c9c-b8d1-c184bfb493da))
-    (pin "2" (uuid 16d6f605-4627-49bd-9180-8203902febfd))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7876e2e4-9d5a-416f-b97a-e958a989e5b8)
-    (property "Reference" "D16" (at 50.8 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8bd5710-8f18-4748-9b3c-a975f78342a1))
-    (pin "2" (uuid da0aa924-203b-4985-9bff-4185f3555d43))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D16") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8010e136-1dd3-496f-b7ef-81fb0c8b419e)
-    (property "Reference" "D20" (at 71.12 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5aa5bf69-e040-48d4-81fc-332aff45c2f9))
-    (pin "2" (uuid f5458189-75e2-45c3-bf32-0320ebe63391))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D20") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80c46ab4-724f-418d-bb6f-e89792097e1a)
-    (property "Reference" "RC2-4" (at 78.74 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc0fd3d-897b-4e06-ac65-16066b68709e))
-    (pin "2" (uuid b7b98128-d37a-4ac7-b049-5cf9bdd5aadb))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 81912d5a-1def-44e9-a6ef-abaf3ecd517d)
-    (property "Reference" "RC6-1" (at 160.02 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fa9aca31-bd8b-4e2e-8b86-05d191575df9))
-    (pin "2" (uuid fce38bd6-fb8f-42a6-8d68-ecda7f1a588f))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83fb734e-dbcd-4939-9bb9-d97efd05ec97)
-    (property "Reference" "RC5-6" (at 139.7 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7315a9fc-fd63-46c2-90db-bee656dc7568))
-    (pin "2" (uuid f2997912-9551-49e9-aab8-387875819f56))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 84146f81-04f3-4efb-b753-bdc596c8e7a9)
-    (property "Reference" "RC4-3" (at 119.38 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 774ced50-3b17-48fe-b2d7-22681b1dd1f7))
-    (pin "2" (uuid bad310c0-ca25-47d0-b27e-42438b959c7b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 86602dfb-ea19-4060-ad39-496c613a47cb)
-    (property "Reference" "D30" (at 91.44 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 02958e5d-18b7-48f3-9883-661ceaa75da5))
-    (pin "2" (uuid abed4b13-9431-40c7-848f-b30c05e39dfd))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D30") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8c168cda-0a39-478d-9d71-1073400c7ed7)
-    (property "Reference" "RC1-5" (at 58.42 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d2851af-db15-44cf-8e07-da339bdc18b2))
-    (pin "2" (uuid 94b381a2-7c19-4916-9f9a-ee00221d04d3))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 129.54 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7)
-    (property "Reference" "DI4" (at 181.61 125.73 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c02807d6-1705-4325-bcb0-203f4e9a5baa))
-    (pin "2" (uuid d6c46059-bf9c-4959-836e-e4d33dcc5edd))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9578a4b6-1a56-40b7-be8d-56404ef59fdf)
-    (property "Reference" "RC1-6" (at 58.42 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0b899b44-3ae3-40be-a452-1f16eaa5f4af))
-    (pin "2" (uuid 11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 109.22 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 957e7a82-ca9c-46a8-bca9-099b05fe7e8f)
-    (property "Reference" "DI3" (at 181.61 105.41 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 111.76 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc53fac9-006c-4101-8113-949ab8e05afb))
-    (pin "2" (uuid f6122429-5885-4b7a-b72a-162ca49c70c2))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9af5b930-d274-4b05-b0bf-e2c27b7e71dd)
-    (property "Reference" "D6" (at 30.48 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bdad3d4-58ec-438c-beb8-3eea36a29d95))
-    (pin "2" (uuid 5ff4e8af-dd18-4010-b183-21b8178cd684))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 181.61 88.9 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd)
-    (property "Reference" "DI2" (at 181.61 85.09 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 183.515 91.44 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 181.61 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 181.61 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 181.61 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 181.61 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a))
-    (pin "2" (uuid 81e4b9c6-9b09-4e38-94e9-cebdeae457ee))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9e96ab02-44ee-4ac7-8251-0d309b7409ad)
-    (property "Reference" "RC5-3" (at 139.7 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd85b120-1be2-4f17-a3d7-505a734afc72))
-    (pin "2" (uuid 666e03ce-bf1c-4b58-ac4e-f01557ca11fd))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a3969e5a-abe0-44e9-adf1-6255946e3f4c)
-    (property "Reference" "RC6-0" (at 160.02 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bc4d6aea-ec1e-45c7-842c-68cd7e21336f))
-    (pin "2" (uuid f785fa77-0ac2-41ff-9704-1acbb4a72c84))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a400377f-e146-4099-97e7-db21e16d5759)
-    (property "Reference" "D3" (at 30.48 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bfc71c1-6349-4b3f-bf89-22c83277904e))
-    (pin "2" (uuid dafd4b6c-6c2f-41e0-95ab-05ead276d86d))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a71b771b-4e14-4d95-98e7-86a6250f569e)
-    (property "Reference" "RC0-4" (at 38.1 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 95049e61-b78e-490f-86e1-aba711db5c19))
-    (pin "2" (uuid 6e474ba8-5b88-41c8-9259-b0ebfb6012f0))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid abf3c9d9-a279-4546-abcf-5e4f6862bc48)
-    (property "Reference" "D2" (at 30.48 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3499f31-3593-4cd9-977b-3b6479091d7b))
-    (pin "2" (uuid 17f09d49-1093-4838-8e5c-8fc4c42e5d05))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac10b530-144b-4dfc-ab37-ad7a8ced8612)
-    (property "Reference" "RC4-5" (at 119.38 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6c95156-54b9-4f54-a278-f808b4871687))
-    (pin "2" (uuid c3dc8d92-1759-4195-a3c9-81260bc6d8b1))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 85.09 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid accba515-4e8d-4804-afea-f36f436141c3)
-    (property "Reference" "DS2" (at 76.2 85.725 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 76.2 83.185 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 034e4344-7cda-43bc-a12a-f56b6e8f68f5))
-    (pin "2" (uuid 6f0bef00-c613-46da-9667-752b92174ad1))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b2cc8c06-500a-41ac-a412-7baf61e0f24c)
-    (property "Reference" "RC6-3" (at 160.02 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0a77d5cb-df53-4102-99ed-4829fa686656))
-    (pin "2" (uuid 22df81c2-2a06-44e2-bed1-a6d6c14df76a))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 146.05 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3573dc3-ef18-4f4c-817b-c984ae7cfae9)
-    (property "Reference" "DS5" (at 137.16 146.685 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 137.16 144.145 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 813e7cf6-f821-4e03-95cc-308010bed54e))
-    (pin "2" (uuid 9669a028-42d7-436f-8ec5-bc3423db62d6))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b39d56f9-3079-43e4-bb1b-80277fdae425)
-    (property "Reference" "RC4-2" (at 119.38 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b205d044-9ffa-4dce-82fd-f51ba622a818))
-    (pin "2" (uuid 29ce7588-4a17-4be4-9207-ea3ed2669aa1))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3c497a9-b81f-4161-88cf-2e58ddb4cdd8)
-    (property "Reference" "RC3-4" (at 99.06 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ae78f0d3-f75a-49c8-ab9b-8a9831e434d7))
-    (pin "2" (uuid a59e897c-0784-437d-9243-baf91d40a453))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba927934-b2e1-4953-b21b-54ef02be8935)
-    (property "Reference" "RC0-5" (at 38.1 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cadba0a-3bb3-40cd-acea-644da4b3e05f))
-    (pin "2" (uuid 1368ebac-096c-415f-acaf-9afb071e729f))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bb2c72f0-a908-44e7-b7d5-67df52eed516)
-    (property "Reference" "DS4" (at 116.84 126.365 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 116.84 123.825 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5ab0b348-3e2a-4517-90b3-fad111de6205))
-    (pin "2" (uuid 6e7351bb-5d09-464f-9e8d-535ba0f5c6f3))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be02506a-2bb1-4713-b046-f0327dae72de)
-    (property "Reference" "RC0-1" (at 38.1 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 97a92abd-708c-465e-baf7-79fa35370a7c))
-    (pin "2" (uuid c9056b1e-419e-478d-9fc4-be1e95902d28))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d)
-    (property "Reference" "RC5-2" (at 139.7 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f22c39d-012a-4297-b61c-1ff841801333))
-    (pin "2" (uuid adbe8c88-ad34-405b-866a-efb64899002f))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c11b6807-83e7-46af-9d7e-9d56aab4109c)
-    (property "Reference" "D46" (at 111.76 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46))
-    (pin "2" (uuid 6764bae9-067c-4178-897e-2c25048ade8b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D46") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c164cb58-7d29-400c-b219-f07036f5e8c9)
-    (property "Reference" "RC0-3" (at 38.1 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92164ea1-76d0-4223-80cc-32c093c14fcd))
-    (pin "2" (uuid e615b2e5-6986-47ac-8f35-da60c20b811c))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c43b92c2-4283-44f7-8cb3-665623564383)
-    (property "Reference" "D42" (at 111.76 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0929e13-ab77-4737-9d55-142bd9901b1c))
-    (pin "2" (uuid 0f45988c-1752-479c-97d5-fbada14f9a42))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D42") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c72dd108-be98-47d5-b809-561778aa3212)
-    (property "Reference" "RC2-5" (at 78.74 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d2f0fd-ce69-4d4e-a4ab-163c1691ef24))
-    (pin "2" (uuid 03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe)
-    (property "Reference" "D50" (at 132.08 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a606860e-126b-4f3e-bcfe-a2dfa8adc9c8))
-    (pin "2" (uuid 59120505-a333-4c63-8904-aa379cfb043b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D50") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e)
-    (property "Reference" "D51" (at 132.08 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48596e1c-4629-46bb-98c1-de11cd41e539))
-    (pin "2" (uuid f7decfb7-c4ef-4861-ba8a-043f44f3b09e))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D51") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cf81ef85-b58f-422a-b88a-7b7914aa3581)
-    (property "Reference" "D12" (at 50.8 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e34c154b-a3cb-467d-891b-2f2891056190))
-    (pin "2" (uuid dc926c49-c915-470d-b2b5-00749f3505bb))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D12") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d40b4fbb-e58c-433e-b2c5-236bb8aa92c5)
-    (property "Reference" "D1" (at 30.48 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90049b07-ff34-407c-ad1c-bcb8b89b241c))
-    (pin "2" (uuid 7bd5d68f-4902-47f7-bc35-be0973d0d904))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578)
-    (property "Reference" "RC5-0" (at 139.7 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5729530-792d-44f2-80ff-f6315aae335e))
-    (pin "2" (uuid 01f42ec4-9037-47c0-8fc0-8f7345fd0a2b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69)
-    (property "Reference" "RC2-1" (at 78.74 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ba2015a3-c3ad-44cf-b530-b2a60bac2c12))
-    (pin "2" (uuid 12bdf482-8bd0-4b7d-a511-fcaadc8ab54d))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid daefbaa6-3e17-4eca-837b-024ccac5fc10)
-    (property "Reference" "D14" (at 50.8 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12e5236e-b23d-4e38-9768-e28d1693b6eb))
-    (pin "2" (uuid 1be4fe23-ac83-4b50-b43f-2e4b33c335d7))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D14") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e490f25a-1360-4f95-aa79-5f1d93892bb3)
-    (property "Reference" "RC3-5" (at 99.06 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 056973a8-92e3-49be-9b21-fe961241d12f))
-    (pin "2" (uuid 01c4c06b-d45d-4ffb-ad72-57ca7686fd55))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 105.41 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b)
-    (property "Reference" "DS3" (at 96.52 106.045 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 96.52 103.505 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 738869bf-f410-43b7-b7e7-4e927d69911a))
-    (pin "2" (uuid 71649a24-87f4-49fb-9896-e50c64c03a31))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb153eb2-74b0-4cb9-b105-af356654d60d)
-    (property "Reference" "D24" (at 71.12 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77c4fd5e-5c79-4799-aab6-2f07a57c7df3))
-    (pin "2" (uuid a062346b-452b-46dc-a106-fab01848555d))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D24") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1920e34-64a4-41c9-8680-7fa42f5dfb9d)
-    (property "Reference" "RC2-0" (at 78.74 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9242378-4df5-4b90-afbf-1098ccb8067f))
-    (pin "2" (uuid a135b9b9-316d-4cb2-a5a5-8d618a00a752))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fc941f43-b642-4fef-8515-f8f851adced2)
-    (property "Reference" "D13" (at 50.8 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c))
-    (pin "2" (uuid ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D13") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fcc35b13-8da5-4271-981a-5470b3add3e5)
-    (property "Reference" "D25" (at 71.12 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0d662a-16b3-4c76-b4ee-49de18b57b47))
-    (pin "2" (uuid ba9a1f4c-173e-4b32-907f-fe9b31df718b))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D25") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fd13d6af-afdf-4367-a43b-1889348eabd8)
-    (property "Reference" "RC0-6" (at 38.1 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 854af50a-a007-4ba3-a405-76f0f99e9817))
-    (pin "2" (uuid bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142))
-    (instances
-      (project "round-robin-8-42"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "cbac505e-77a6-4a00-a758-435de33cca16")
+	(paper "A3" portrait)
+	(lib_symbols
+		(symbol "Diode:1N4148"
+			(pin_numbers hide)
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "1N4148"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "100V 0.15A standard switching diode, DO-35"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Device" "D"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "D*DO?35*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "1N4148_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "1N4148_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 165.1 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "00d75863-bb9f-4d4c-ae8f-f64498ed1533")
+	)
+	(junction
+		(at 154.94 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "00d7cd9a-ef35-47e5-9c5b-fc78b3d5db54")
+	)
+	(junction
+		(at 154.94 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "031341d5-0985-401c-b571-184ae9c80cc7")
+	)
+	(junction
+		(at 104.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06a6d1a8-0f12-4174-b63e-d35d8ca618bf")
+	)
+	(junction
+		(at 165.1 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "09e82fd3-a43f-4071-83d2-fb0a65931c0e")
+	)
+	(junction
+		(at 63.5 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a9113d4-8a8c-4abc-b886-f22c92ad18dc")
+	)
+	(junction
+		(at 124.46 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29")
+	)
+	(junction
+		(at 73.66 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c7244ee-ddfb-470b-a70b-1cfc53f83773")
+	)
+	(junction
+		(at 134.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c73479c-4e07-428a-85f3-93341c42ca57")
+	)
+	(junction
+		(at 93.98 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5f3a7a-dc5d-4973-8743-eafaa1c1a462")
+	)
+	(junction
+		(at 43.18 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "10cae212-bc64-40b9-b44f-13fd4a0406a6")
+	)
+	(junction
+		(at 83.82 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1278b5e3-5eff-46d6-a162-44fde2066970")
+	)
+	(junction
+		(at 53.34 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14bb4fc2-d7df-49aa-b10e-882abdd2aa5f")
+	)
+	(junction
+		(at 104.14 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17f3773a-2c02-426d-bcd6-7a35c59a710a")
+	)
+	(junction
+		(at 114.3 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a11ada5-19c8-45ac-810c-daedbb80ad5b")
+	)
+	(junction
+		(at 73.66 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c386ee6-5b9d-4eae-92b5-9440e81067f6")
+	)
+	(junction
+		(at 154.94 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1f991325-c039-4256-a53a-b28fb9b7dd9e")
+	)
+	(junction
+		(at 93.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21e320b6-a0c4-4d5d-babf-ee5274120507")
+	)
+	(junction
+		(at 165.1 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2501dc30-a271-4271-9ca6-b085328a23ec")
+	)
+	(junction
+		(at 124.46 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2b2b66bc-905d-4b48-89f5-1c62f6c27dbb")
+	)
+	(junction
+		(at 134.62 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c5878fe-fb0a-42a4-a883-ea4209708ea5")
+	)
+	(junction
+		(at 63.5 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2d808057-faeb-478c-a005-dbbbe2bf98c1")
+	)
+	(junction
+		(at 73.66 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30c9eca3-7c32-4704-8819-3599d7b84f53")
+	)
+	(junction
+		(at 93.98 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "31a1b16e-8174-4fea-bc42-9c75ed9182a0")
+	)
+	(junction
+		(at 114.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "347306fc-87ef-43e1-a98f-ca29ac9473e6")
+	)
+	(junction
+		(at 124.46 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "352af8be-9d08-4866-961e-b8632013179f")
+	)
+	(junction
+		(at 104.14 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "356b49b0-20ac-4c33-8df8-9b27dee0b312")
+	)
+	(junction
+		(at 185.42 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c")
+	)
+	(junction
+		(at 114.3 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "490a89d7-a161-4f1a-9b45-a55729d9d59b")
+	)
+	(junction
+		(at 124.46 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c74baef-72cb-4cdf-b4eb-a3d28782257d")
+	)
+	(junction
+		(at 53.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c7a50e9-7650-493b-b0a7-057b900a13a7")
+	)
+	(junction
+		(at 63.5 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9")
+	)
+	(junction
+		(at 165.1 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4df4e0a7-6e46-4c32-959d-094f3457d75b")
+	)
+	(junction
+		(at 43.18 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e641ba8-cbcf-42cf-89f0-ac977902bf98")
+	)
+	(junction
+		(at 73.66 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fc826ad-ef7b-406a-9b89-76eb2c211523")
+	)
+	(junction
+		(at 53.34 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fce0301-62b3-4ef1-9bae-8d55ea745d66")
+	)
+	(junction
+		(at 53.34 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53bb27f5-9b54-4704-b90e-33b3053be6c4")
+	)
+	(junction
+		(at 154.94 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "65b6b203-33fb-4648-98da-5ff0cc1246cc")
+	)
+	(junction
+		(at 63.5 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "670a793c-4c48-41d1-9f07-66b1d7d84b06")
+	)
+	(junction
+		(at 83.82 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "672e2ce9-8f2c-43ff-9498-0e342bc1c65e")
+	)
+	(junction
+		(at 43.18 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6bfc7531-8adc-4c87-bf8a-788404262765")
+	)
+	(junction
+		(at 134.62 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1")
+	)
+	(junction
+		(at 63.5 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "712da204-b8e1-4637-b967-521ccf7b108c")
+	)
+	(junction
+		(at 73.66 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71e77471-d824-448e-a6de-31cce05e17c2")
+	)
+	(junction
+		(at 73.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "742ecb41-f257-40d3-a6f3-d155d6036628")
+	)
+	(junction
+		(at 93.98 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "782ee96d-a257-4c78-ac0f-a3b5279bef37")
+	)
+	(junction
+		(at 53.34 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7943e9ed-5e22-49d3-a238-47d875f3e823")
+	)
+	(junction
+		(at 43.18 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7dbcae2f-e000-4aff-92b3-5518ea113182")
+	)
+	(junction
+		(at 104.14 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "822096c9-a5b4-460b-8639-9bbf1bb1a2fa")
+	)
+	(junction
+		(at 93.98 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84442e81-a253-49f6-ab0f-8ece0b39f637")
+	)
+	(junction
+		(at 53.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "86d88f2b-6e5b-493a-b3a4-5436a8374fae")
+	)
+	(junction
+		(at 104.14 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "88441b0d-9a40-4e18-8fc9-814cc1cb4d3e")
+	)
+	(junction
+		(at 83.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bf191a4-2dcd-4018-b67a-91aef9fad846")
+	)
+	(junction
+		(at 144.78 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d88bb99-f0e4-4a81-b464-31814877675a")
+	)
+	(junction
+		(at 154.94 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "950e9d22-abb7-4d11-b3ab-59cc90a5e7b5")
+	)
+	(junction
+		(at 185.42 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95b0c111-7d27-49ee-a08f-b6f35d9d5b54")
+	)
+	(junction
+		(at 93.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96a12dd2-d02f-4a86-aa6d-3a7015c06462")
+	)
+	(junction
+		(at 134.62 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99c67f58-7bde-4417-a08c-823e6af847f2")
+	)
+	(junction
+		(at 124.46 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9d2b0f02-b19d-4907-8835-9e7f8a8b9c34")
+	)
+	(junction
+		(at 154.94 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9ecc2321-002b-408d-8858-0987adb7df1e")
+	)
+	(junction
+		(at 165.1 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a7400bf6-86c3-4d41-886e-57235a457a4c")
+	)
+	(junction
+		(at 185.42 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9ece8f4-f868-428b-b7ff-a3dc07b47d6c")
+	)
+	(junction
+		(at 144.78 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aa4f9edb-d8b6-45e2-8d16-270f3c9fc990")
+	)
+	(junction
+		(at 83.82 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b23bc3a0-3ebe-44a5-9126-8b5c4d648e08")
+	)
+	(junction
+		(at 185.42 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b98759bc-77be-4dce-9aa2-cc5ce3889034")
+	)
+	(junction
+		(at 53.34 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3")
+	)
+	(junction
+		(at 144.78 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "befc6138-873b-4406-bc9e-e5a72f7f36fe")
+	)
+	(junction
+		(at 83.82 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0")
+	)
+	(junction
+		(at 134.62 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c29c26fc-c285-45ba-9e88-4c2a02375307")
+	)
+	(junction
+		(at 165.1 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c331d35d-23c9-43ea-b243-b660cb5f4bdb")
+	)
+	(junction
+		(at 134.62 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c3f1775c-0d63-41d3-b7d8-a4c96d241ce3")
+	)
+	(junction
+		(at 93.98 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c41e97f8-87c8-4e82-92ed-e4644d6f526e")
+	)
+	(junction
+		(at 185.42 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c56d20e0-377b-42bf-89fc-25b698ca10b4")
+	)
+	(junction
+		(at 114.3 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c5afc93c-0846-4cf9-8f93-4c8f2232c9fa")
+	)
+	(junction
+		(at 154.94 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8075164-3db2-4fce-aefd-057a5a32f582")
+	)
+	(junction
+		(at 43.18 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8f222f6-943e-4d7d-919b-3278ca0ede33")
+	)
+	(junction
+		(at 144.78 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc2d9922-84c9-42ce-883b-c028a251c101")
+	)
+	(junction
+		(at 63.5 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cfd86ddc-0810-4057-8a79-4468ec7b2424")
+	)
+	(junction
+		(at 83.82 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5a179bd-82b1-4661-aebc-4c4d4801bdff")
+	)
+	(junction
+		(at 144.78 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b7ef4f-419a-421c-a02d-fd71016e6c97")
+	)
+	(junction
+		(at 114.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcab5abe-0f5a-44d8-b554-722164ca6a23")
+	)
+	(junction
+		(at 114.3 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee17efa1-5df9-47d0-aec2-a440d8b33e4c")
+	)
+	(junction
+		(at 134.62 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f1379b2f-59c4-4b61-a98f-3645b6e5fe6b")
+	)
+	(junction
+		(at 104.14 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f24e6016-cf0c-4fe9-b584-ca06dfdbe767")
+	)
+	(junction
+		(at 43.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6f817c6-438a-4497-93b1-8dc1f36a395c")
+	)
+	(junction
+		(at 124.46 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd")
+	)
+	(junction
+		(at 185.42 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa2795fd-0138-4010-b310-3d5e73c1be1c")
+	)
+	(junction
+		(at 73.66 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbda2010-a213-45bb-958d-0c9446d51e42")
+	)
+	(junction
+		(at 114.3 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc6abd7a-92c0-4b05-85ed-b3bd910676e1")
+	)
+	(junction
+		(at 144.78 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdc0071f-cdad-424a-87db-7bd8a0569159")
+	)
+	(wire
+		(pts
+			(xy 83.82 60.96) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022d84d0-7bcb-4024-8618-6f3a7f7b41aa")
+	)
+	(wire
+		(pts
+			(xy 144.78 25.4) (xy 144.78 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0406a358-3219-4537-99c7-cfb994e5303c")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0429bfe1-2992-4c6f-bb22-b2e8e5724910")
+	)
+	(wire
+		(pts
+			(xy 73.66 109.22) (xy 93.98 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07ee4d30-e80a-41ae-829d-e3cecf87d77e")
+	)
+	(wire
+		(pts
+			(xy 114.3 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0897e94f-d1e3-47ff-89f6-5de7a1349783")
+	)
+	(wire
+		(pts
+			(xy 185.42 68.58) (xy 185.42 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aee33c0-3781-43dc-99cb-690f399192cd")
+	)
+	(wire
+		(pts
+			(xy 43.18 40.64) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f76c070-bcf8-4924-a8c5-3abe13c36f41")
+	)
+	(wire
+		(pts
+			(xy 63.5 81.28) (xy 63.5 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ef6261-91ba-4d4c-99ef-8991b7c91dc8")
+	)
+	(wire
+		(pts
+			(xy 104.14 101.6) (xy 104.14 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12080e73-a151-4804-ac9b-ac3ac13653e9")
+	)
+	(wire
+		(pts
+			(xy 73.66 48.26) (xy 93.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12a939e2-2ab8-4d74-a5c9-6d61a9528b6e")
+	)
+	(wire
+		(pts
+			(xy 104.14 25.4) (xy 104.14 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af5b449-9a68-414b-a41f-d6f6cba715a8")
+	)
+	(wire
+		(pts
+			(xy 73.66 81.28) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0140d1-6775-49db-9fd5-7ecf63ae1284")
+	)
+	(wire
+		(pts
+			(xy 177.8 149.86) (xy 154.94 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "20f13b47-7825-4cae-9d6b-163d56b184aa")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "211f763f-7ef6-4fb5-98df-2e2ff37faa42")
+	)
+	(wire
+		(pts
+			(xy 63.5 40.64) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23f46f84-f16d-4b0b-b463-c2c0244adcc0")
+	)
+	(wire
+		(pts
+			(xy 33.02 129.54) (xy 53.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24da3fea-844d-4666-b730-f8d7b708f242")
+	)
+	(wire
+		(pts
+			(xy 53.34 129.54) (xy 73.66 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26f78b89-ba4b-4b48-90d1-1245694ead6f")
+	)
+	(wire
+		(pts
+			(xy 33.02 109.22) (xy 53.34 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2832f642-62e7-4a51-b112-f728658e7714")
+	)
+	(wire
+		(pts
+			(xy 53.34 68.58) (xy 73.66 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29a0e612-9a4c-422c-a9b8-8a9fe3879b8a")
+	)
+	(wire
+		(pts
+			(xy 83.82 101.6) (xy 83.82 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a44e441-f6d5-4994-b7ba-34283a1facc7")
+	)
+	(wire
+		(pts
+			(xy 124.46 121.92) (xy 124.46 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0")
+	)
+	(wire
+		(pts
+			(xy 114.3 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a65926a-d988-49f6-92e7-6e4d5936462f")
+	)
+	(wire
+		(pts
+			(xy 165.1 60.96) (xy 165.1 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b8c9def-eaec-4abd-b08a-c3613e6389df")
+	)
+	(wire
+		(pts
+			(xy 53.34 109.22) (xy 73.66 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd")
+	)
+	(wire
+		(pts
+			(xy 124.46 25.4) (xy 124.46 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3115f7a7-e786-49c1-9e4c-25c171cfeb33")
+	)
+	(wire
+		(pts
+			(xy 73.66 68.58) (xy 93.98 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3197b37c-ee5b-406a-ab67-08670d4b8c09")
+	)
+	(wire
+		(pts
+			(xy 177.8 109.22) (xy 154.94 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ab82e35-1d5e-4aa0-b90b-a7ac5fa0104b")
+	)
+	(wire
+		(pts
+			(xy 63.5 121.92) (xy 63.5 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5")
+	)
+	(wire
+		(pts
+			(xy 73.66 170.18) (xy 93.98 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40ad23e4-b284-4d51-a92e-26a2272af251")
+	)
+	(wire
+		(pts
+			(xy 165.1 121.92) (xy 165.1 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "411efa8a-c2b6-469e-b517-3b3f24ffe025")
+	)
+	(wire
+		(pts
+			(xy 53.34 170.18) (xy 73.66 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4554fe48-1b8d-466c-b3f4-c87fb3d79947")
+	)
+	(wire
+		(pts
+			(xy 43.18 60.96) (xy 43.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456f0365-d37d-43a2-afac-d06c44cc48af")
+	)
+	(wire
+		(pts
+			(xy 114.3 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "473d672b-6459-459b-93fc-780e5d8f9818")
+	)
+	(wire
+		(pts
+			(xy 124.46 81.28) (xy 124.46 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "495f9334-ca7f-4aa5-8d75-09576f1afa2c")
+	)
+	(wire
+		(pts
+			(xy 165.1 81.28) (xy 165.1 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f7b113-f5f8-43e0-9da7-2a02dc224210")
+	)
+	(wire
+		(pts
+			(xy 104.14 60.96) (xy 104.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5837ecd4-cf70-4c14-9c7b-bb5f05f8274a")
+	)
+	(wire
+		(pts
+			(xy 177.8 48.26) (xy 154.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5a1019c3-a65a-4850-acf9-d96f4de0e3ce")
+	)
+	(wire
+		(pts
+			(xy 104.14 81.28) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6ae0de-21c8-4433-a4e0-a3b552474fb0")
+	)
+	(wire
+		(pts
+			(xy 53.34 88.9) (xy 73.66 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b5d548-d07f-40b1-8e16-72d513f499f2")
+	)
+	(wire
+		(pts
+			(xy 93.98 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6414e19f-a27a-435d-a47f-a63cba9086f1")
+	)
+	(wire
+		(pts
+			(xy 134.62 109.22) (xy 154.94 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64344100-c91d-4b5c-a8eb-9406d47360dd")
+	)
+	(wire
+		(pts
+			(xy 33.02 68.58) (xy 53.34 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68161b0c-a285-475d-a645-59648d12bc07")
+	)
+	(wire
+		(pts
+			(xy 134.62 149.86) (xy 154.94 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690a405c-1ac3-4b57-a93b-778dda168d2c")
+	)
+	(wire
+		(pts
+			(xy 165.1 40.64) (xy 165.1 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc")
+	)
+	(wire
+		(pts
+			(xy 185.42 149.86) (xy 185.42 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f77a68c-1e32-433a-820e-9683e6fd5e12")
+	)
+	(wire
+		(pts
+			(xy 185.42 88.9) (xy 185.42 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70c6e975-f457-4759-9791-1d1de45afbb3")
+	)
+	(wire
+		(pts
+			(xy 43.18 121.92) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "727cc522-ef34-45d4-b711-997054ff0b37")
+	)
+	(wire
+		(pts
+			(xy 33.02 48.26) (xy 53.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "737596e8-f579-4b1f-aa71-a489d8ba56da")
+	)
+	(wire
+		(pts
+			(xy 93.98 149.86) (xy 114.3 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "770cc50c-0085-42e2-b068-cd0ae3b59919")
+	)
+	(wire
+		(pts
+			(xy 185.42 25.4) (xy 185.42 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "794205f1-2f7e-4200-b59c-c02481b0416f")
+	)
+	(wire
+		(pts
+			(xy 73.66 88.9) (xy 93.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79a42c80-d7a4-4e03-9070-f9fff835a239")
+	)
+	(wire
+		(pts
+			(xy 33.02 40.64) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a4231d0-fb4b-4c65-9cc1-75d3ed714150")
+	)
+	(wire
+		(pts
+			(xy 165.1 25.4) (xy 165.1 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8506f273-12d6-426d-910b-0c9eecbe3765")
+	)
+	(wire
+		(pts
+			(xy 177.8 88.9) (xy 154.94 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8af11afc-5332-4a82-a8bc-ab0167ac423c")
+	)
+	(wire
+		(pts
+			(xy 134.62 68.58) (xy 154.94 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8b5d907e-943a-431c-bc72-2abe781e3a29")
+	)
+	(wire
+		(pts
+			(xy 177.8 129.54) (xy 154.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c0fc5fb-7e6f-4660-88bb-9988ebc48535")
+	)
+	(wire
+		(pts
+			(xy 93.98 48.26) (xy 114.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d73bae8-988b-435b-a882-ae9668b41d7e")
+	)
+	(wire
+		(pts
+			(xy 104.14 142.24) (xy 104.14 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dd624a1-3da3-42c1-929d-9366cd043e3d")
+	)
+	(wire
+		(pts
+			(xy 185.42 48.26) (xy 185.42 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f339462-56e0-4361-9d9b-983c75fb21ef")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "909384ab-bc1c-47d8-a34d-c3d137febfc2")
+	)
+	(wire
+		(pts
+			(xy 124.46 101.6) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91eea887-ea8a-4221-ba92-e5ec1caacc4f")
+	)
+	(wire
+		(pts
+			(xy 124.46 142.24) (xy 124.46 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94397688-ce0e-48d4-a59c-7257120bf834")
+	)
+	(wire
+		(pts
+			(xy 114.3 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c79c76c-a95b-401f-9edb-a06a0cceaa4b")
+	)
+	(wire
+		(pts
+			(xy 53.34 48.26) (xy 73.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ec847-5716-4125-b40b-fdbd3a1587a7")
+	)
+	(wire
+		(pts
+			(xy 165.1 101.6) (xy 165.1 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f711890-a6d6-4440-8bc1-ed469cb6acc4")
+	)
+	(wire
+		(pts
+			(xy 93.98 101.6) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a226d887-7662-4dbd-b58b-e683f5d85955")
+	)
+	(wire
+		(pts
+			(xy 134.62 48.26) (xy 154.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2736023-3b9d-49fd-b999-28b7c4f9ccda")
+	)
+	(wire
+		(pts
+			(xy 124.46 40.64) (xy 124.46 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a67c0815-f186-4f70-926f-1b264c84d8d8")
+	)
+	(wire
+		(pts
+			(xy 63.5 60.96) (xy 63.5 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a6a1d300-b392-4504-80e5-ef4849e747ad")
+	)
+	(wire
+		(pts
+			(xy 154.94 162.56) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a803bbba-64cc-448d-a04f-7f03127ebddd")
+	)
+	(wire
+		(pts
+			(xy 53.34 149.86) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aac914ea-c9a3-4a8f-94e1-1f91cdd136a3")
+	)
+	(wire
+		(pts
+			(xy 93.98 129.54) (xy 114.3 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab578e4e-a4bf-4ab4-80fc-d97d4aea6370")
+	)
+	(wire
+		(pts
+			(xy 53.34 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "abbb9177-3783-4c3c-a4ad-361c4048cd21")
+	)
+	(wire
+		(pts
+			(xy 83.82 121.92) (xy 83.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73")
+	)
+	(wire
+		(pts
+			(xy 93.98 68.58) (xy 114.3 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aea6a633-b213-403d-b447-42d91d3ab4da")
+	)
+	(wire
+		(pts
+			(xy 114.3 170.18) (xy 134.62 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3e14390-7dc6-416b-bbd5-cdf868192ca4")
+	)
+	(wire
+		(pts
+			(xy 73.66 129.54) (xy 93.98 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f6f053-44f0-4391-9873-b6231b8014db")
+	)
+	(wire
+		(pts
+			(xy 144.78 101.6) (xy 144.78 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7b2475f-30dc-4ea2-b799-96c21242154c")
+	)
+	(wire
+		(pts
+			(xy 83.82 81.28) (xy 83.82 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5")
+	)
+	(wire
+		(pts
+			(xy 43.18 101.6) (xy 43.18 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb49a3de-620b-45ad-a54c-29dcceaf0796")
+	)
+	(wire
+		(pts
+			(xy 134.62 129.54) (xy 154.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "be9d25ae-f4eb-4b8a-906a-25cd5eb33eee")
+	)
+	(wire
+		(pts
+			(xy 144.78 121.92) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf12198a-9e62-45c3-b466-f5d86de75219")
+	)
+	(wire
+		(pts
+			(xy 63.5 25.4) (xy 63.5 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1a940de-fa49-4106-a8b9-697952eec2a2")
+	)
+	(wire
+		(pts
+			(xy 104.14 121.92) (xy 104.14 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c298ba49-6974-4340-859f-5d5a2b4132ff")
+	)
+	(wire
+		(pts
+			(xy 124.46 60.96) (xy 124.46 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c950d145-c024-47a8-ba57-97efd7bb658b")
+	)
+	(wire
+		(pts
+			(xy 144.78 142.24) (xy 144.78 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca92ed7f-ae97-4c0c-81e4-820de1c001c1")
+	)
+	(wire
+		(pts
+			(xy 185.42 109.22) (xy 185.42 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdde081d-7bdd-42e6-869e-3ff07b8b464b")
+	)
+	(wire
+		(pts
+			(xy 83.82 40.64) (xy 83.82 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cff15ec3-f29c-4d36-8776-64c5d29be534")
+	)
+	(wire
+		(pts
+			(xy 83.82 25.4) (xy 83.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1088709-a9b9-4e05-8ea2-f87942ee2796")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 93.98 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1347903-ae03-46a2-a707-154093060583")
+	)
+	(wire
+		(pts
+			(xy 134.62 170.18) (xy 154.94 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d187208d-eec6-46ce-8efb-063c47534382")
+	)
+	(wire
+		(pts
+			(xy 144.78 40.64) (xy 144.78 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2183fb3-afd3-46ca-955e-993ea31aa5d3")
+	)
+	(wire
+		(pts
+			(xy 43.18 142.24) (xy 43.18 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d76ad758-0ae0-4ce6-9f67-c689c066c744")
+	)
+	(wire
+		(pts
+			(xy 33.02 149.86) (xy 53.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da80b027-904b-4ca2-99c6-5937c80c825c")
+	)
+	(wire
+		(pts
+			(xy 63.5 142.24) (xy 63.5 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db492971-48ff-4667-996c-f5d540a20741")
+	)
+	(wire
+		(pts
+			(xy 177.8 68.58) (xy 154.94 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db5976d9-d358-409b-8c22-c774449a4749")
+	)
+	(wire
+		(pts
+			(xy 165.1 142.24) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dccfde3a-ff1d-42ec-97d5-a8f6cccea832")
+	)
+	(wire
+		(pts
+			(xy 33.02 170.18) (xy 53.34 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de8e54c6-84d9-47e5-8f08-dc3e96b8afdb")
+	)
+	(wire
+		(pts
+			(xy 43.18 81.28) (xy 43.18 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df5c3763-e66c-46c4-9070-0f73d8115bc4")
+	)
+	(wire
+		(pts
+			(xy 185.42 129.54) (xy 185.42 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfb5a082-e4d5-46ea-8dc8-c65064cd598b")
+	)
+	(wire
+		(pts
+			(xy 93.98 170.18) (xy 114.3 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb")
+	)
+	(wire
+		(pts
+			(xy 144.78 81.28) (xy 144.78 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e444742a-24b1-4bbf-b7ee-438e6dffc9cc")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6d06035-ccb7-4d3e-ae70-d73150e65bbb")
+	)
+	(wire
+		(pts
+			(xy 114.3 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa")
+	)
+	(wire
+		(pts
+			(xy 63.5 101.6) (xy 63.5 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edeeb0d9-51cc-411d-aac4-77f10b619702")
+	)
+	(wire
+		(pts
+			(xy 177.8 170.18) (xy 154.94 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eeafc558-c991-4da4-9667-7ee142f1f3fc")
+	)
+	(wire
+		(pts
+			(xy 104.14 40.64) (xy 104.14 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5c9f05-d71b-4562-9939-852432c066c5")
+	)
+	(wire
+		(pts
+			(xy 144.78 60.96) (xy 144.78 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0ce7c2b-d80c-49f2-bf63-62b750f7ca47")
+	)
+	(wire
+		(pts
+			(xy 134.62 142.24) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f781a362-e0d4-48be-9d13-5686e05b406f")
+	)
+	(wire
+		(pts
+			(xy 43.18 25.4) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa765e67-a220-4a00-944c-7663298f0ead")
+	)
+	(wire
+		(pts
+			(xy 83.82 142.24) (xy 83.82 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b")
+	)
+	(wire
+		(pts
+			(xy 134.62 88.9) (xy 154.94 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe9aa3a8-9e6f-4970-a032-3a3fd676df11")
+	)
+	(global_label "IO 3"
+		(shape bidirectional)
+		(at 104.14 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "24ec698b-5cae-4571-b9c4-c0e35d64a64d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 104.14 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 1"
+		(shape bidirectional)
+		(at 63.5 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d4b15a5-8b6c-4ca3-a7bb-7848c8036590")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 63.5 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 0"
+		(shape bidirectional)
+		(at 43.18 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "465a517d-f0e1-4825-8675-1cce54bfa7a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 43.18 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "INTR"
+		(shape bidirectional)
+		(at 185.42 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4e12b932-2346-4e84-b5a4-80468334f3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 193.61 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 2"
+		(shape bidirectional)
+		(at 83.82 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70d42e66-a74c-4de2-af96-d1860851d3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 83.82 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 165.1 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 165.1 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 144.78 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d44cceb0-f409-4e5f-a98a-9feead2e845d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 4"
+		(shape bidirectional)
+		(at 124.46 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f36f49e4-227f-479f-b914-786aa44dd568")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0263b847-a932-4a31-9f35-35bb23f7000d")
+		(property "Reference" "D62"
+			(at 152.4 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc2e60ca-c74f-4e4b-a0a0-9705327e9578")
+		)
+		(pin "2"
+			(uuid "d12efbfe-85ac-442f-8c0f-ddbe5646c7d5")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D62")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04430572-8314-4d21-974c-22350cead1a6")
+		(property "Reference" "DS1"
+			(at 55.88 65.405 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 55.88 62.865 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3e433df4-9fec-4cfb-b60f-eebca7c574cf")
+		)
+		(pin "2"
+			(uuid "9bcc1487-0612-4bdb-a2de-a8b2f590b28f")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 44.45 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080aaa87-0974-4a77-bf63-185495f411a0")
+		(property "Reference" "DS0"
+			(at 35.56 45.085 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 35.56 42.545 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bfacad1-28fd-4f2e-93dc-68f478b8a6ba")
+		)
+		(pin "2"
+			(uuid "376f73f9-79fa-4153-ae38-31ed5446db52")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09d14922-c46a-4bf1-bb2c-1d224060568c")
+		(property "Reference" "D40"
+			(at 111.76 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c2f1a1d2-df3d-4680-9706-2ca411fa6890")
+		)
+		(pin "2"
+			(uuid "f58fd788-6016-46e7-b903-3606dd2ec21d")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D40")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 149.86 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d18473f-e37a-4136-b721-5a2e40e4f8ed")
+		(property "Reference" "DI5"
+			(at 181.61 146.05 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 152.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5a885ca-5076-44e6-9a84-d07474947dde")
+		)
+		(pin "2"
+			(uuid "047b5b54-de8b-4afc-abc2-c6d1f2d17bd2")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 170.18 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0ef17723-f7f8-4fdb-8913-5a4ceefbc065")
+		(property "Reference" "DI6"
+			(at 181.61 166.37 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 172.72 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df5a6b10-ba48-4f34-96ce-3832d480a7ee")
+		)
+		(pin "2"
+			(uuid "59f34a55-6ac4-496d-8c40-1b8f1eafbcb5")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0fadd319-be81-4c25-8d23-e7495a114aa7")
+		(property "Reference" "RC4-0"
+			(at 119.38 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "efb1c47f-fe25-4bea-8081-43d3c19de5cd")
+		)
+		(pin "2"
+			(uuid "9138c970-6e3d-46df-9354-5174df2a4e52")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ff76361-9578-4f9f-a20c-f042e24a7755")
+		(property "Reference" "D5"
+			(at 30.48 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06")
+		)
+		(pin "2"
+			(uuid "cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "11f01cd8-f751-497f-9599-50fe1fc0a618")
+		(property "Reference" "RC5-4"
+			(at 139.7 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc28293-fab9-4f93-b3d5-ca9ee69110c4")
+		)
+		(pin "2"
+			(uuid "088ac770-af1e-4c4f-ad11-5b44a20594d8")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "13ddd48d-7d2b-415d-b8fa-15c71e245acc")
+		(property "Reference" "D61"
+			(at 152.4 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "745d89b9-e75a-40ae-97bc-d1eadf220f02")
+		)
+		(pin "2"
+			(uuid "7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D61")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1b13866a-6fbf-441b-9c64-56258379f43a")
+		(property "Reference" "D65"
+			(at 152.4 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c70f4670-9685-4aab-ac4f-4ebaf44d5847")
+		)
+		(pin "2"
+			(uuid "8b9c860d-59e1-424e-a148-1aa2c0db4056")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D65")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a")
+		(property "Reference" "RC6-4"
+			(at 160.02 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3427b432-e194-40af-9dcb-04dccafe2b0f")
+		)
+		(pin "2"
+			(uuid "8af48a1b-2c49-47d9-959c-ee33cdd6f977")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1e5f084d-4db5-48ad-a2a3-76f186559614")
+		(property "Reference" "RC3-1"
+			(at 99.06 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa")
+		)
+		(pin "2"
+			(uuid "40b7f115-b5d7-4fa0-b12b-c1c7b6866feb")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "244b7f9d-3923-4908-be6d-02c49eb4663c")
+		(property "Reference" "RC2-3"
+			(at 78.74 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1d79440a-2f90-4c0b-8d60-528615b0bd65")
+		)
+		(pin "2"
+			(uuid "7f1d0566-f385-4126-b190-2379308ed05b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 166.37 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2518146c-59f4-45b7-a4fa-f618686ab064")
+		(property "Reference" "DS6"
+			(at 157.48 167.005 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 157.48 164.465 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cee2f461-8f62-48d8-ac7b-1698deb984c1")
+		)
+		(pin "2"
+			(uuid "460b9088-619c-4166-a615-45e17ecf1f0d")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2519cd5e-8ecf-41a4-a9d0-5b856882cb05")
+		(property "Reference" "D63"
+			(at 152.4 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ea1c9827-ebfa-43f1-b2c6-5a572466713e")
+		)
+		(pin "2"
+			(uuid "0496ba9c-818c-4d39-979a-e8785e06d12a")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D63")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "28137b00-0d76-493b-92b8-23037474163f")
+		(property "Reference" "RC1-3"
+			(at 58.42 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3")
+		)
+		(pin "2"
+			(uuid "41d35b0f-21b5-4da8-92df-229c816b63c5")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c50947a-4bb9-43c2-b65c-4726e224b6b0")
+		(property "Reference" "RC3-0"
+			(at 99.06 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b")
+		)
+		(pin "2"
+			(uuid "30241adf-a2e7-4976-a53a-5c267616618e")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30340eba-9ed0-42ff-b11f-98a864f7223e")
+		(property "Reference" "RC1-4"
+			(at 58.42 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aa956a67-c26e-4a57-9ddb-59688a6476ad")
+		)
+		(pin "2"
+			(uuid "23cd0d93-5050-40ea-9d49-879bbcbb8bcd")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30b60f6a-8d20-44dd-b832-1906a957c513")
+		(property "Reference" "D54"
+			(at 132.08 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2ad1a4-b254-49a0-8435-d3a374353ffc")
+		)
+		(pin "2"
+			(uuid "27a3cb64-baf1-430a-b797-bd52c0e46cbe")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D54")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "310fec10-f10c-41d7-9446-87c12744e146")
+		(property "Reference" "D26"
+			(at 71.12 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e1d524d3-5d24-4c87-b480-74c57a74b567")
+		)
+		(pin "2"
+			(uuid "c0e9aa05-6318-4fdc-abee-cb43875c8e46")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D26")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35827986-7004-4f70-a10a-6ceb42f33d9f")
+		(property "Reference" "RC1-2"
+			(at 58.42 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "879d3b07-b41e-4233-b196-e223f635bdf3")
+		)
+		(pin "2"
+			(uuid "641f8ea7-6306-4550-92c8-e3cc0ed3e5a5")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976")
+		(property "Reference" "D43"
+			(at 111.76 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6fb6c4-b36c-4ff1-879b-43826c273a72")
+		)
+		(pin "2"
+			(uuid "198c65f6-b3df-4780-9f6d-1c910e870a1b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D43")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef0222e-2eac-4930-ac36-0f395f4593b6")
+		(property "Reference" "RC1-0"
+			(at 58.42 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20f0b9b8-9322-4d89-a423-dd3d807d99ff")
+		)
+		(pin "2"
+			(uuid "ce54609e-9d1d-4a3b-81a2-5a384dbe41c8")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef86e49-a152-4515-afb0-4098f497c742")
+		(property "Reference" "D31"
+			(at 91.44 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a")
+		)
+		(pin "2"
+			(uuid "b917ad78-96a8-428f-ad4f-d49149b5b97b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "402f0f46-5eb8-421b-9b9f-01a54b5cfa87")
+		(property "Reference" "RC4-1"
+			(at 119.38 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cb206c0-1fab-4ac5-b301-f9678369525b")
+		)
+		(pin "2"
+			(uuid "b99c2ecc-04a5-4c54-a491-d99fe2562dcc")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40d8058d-714e-4f99-a508-f64f9c8b575b")
+		(property "Reference" "D60"
+			(at 152.4 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66710233-d2ab-4921-aa86-488ee87fbb3a")
+		)
+		(pin "2"
+			(uuid "a9636da9-222c-478f-bc5b-71d3f0473300")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D60")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "433f3f09-0867-41a3-8ac6-5f00bd3314fc")
+		(property "Reference" "D32"
+			(at 91.44 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11a29637-fd50-4473-bb70-d4116312a4f5")
+		)
+		(pin "2"
+			(uuid "53f6307d-8380-45e9-b3fa-4d05a2bd575d")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44de9323-bd5d-49cd-bf0a-70392801309d")
+		(property "Reference" "D45"
+			(at 111.76 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb2b185b-5d98-46b8-8516-9e5c980291cf")
+		)
+		(pin "2"
+			(uuid "f730da3b-5ef9-4abc-8c8d-0794fe3feb87")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D45")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "454ad926-1c6a-4aa4-b6f8-25297463de18")
+		(property "Reference" "RC3-2"
+			(at 99.06 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0aebfce-7e76-40f1-83ef-5914b8ebbcc7")
+		)
+		(pin "2"
+			(uuid "744fce2b-a15c-45a6-92b0-e880efafb5f6")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 48.26 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46348ccc-126c-461a-8e39-f93f389ddaa7")
+		(property "Reference" "DI0"
+			(at 181.61 44.45 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 50.8 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c86bf5fa-c113-44c1-b93d-7a5d4ac11904")
+		)
+		(pin "2"
+			(uuid "dbd8322f-50c7-4271-821c-b0005fd066b2")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a7f7b3d-918b-431a-b79d-c66494b3ec50")
+		(property "Reference" "D52"
+			(at 132.08 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd114d76-87b2-4089-b211-b7b541ac42b3")
+		)
+		(pin "2"
+			(uuid "a360aa38-116c-4dd0-a569-f6a7a5a88a05")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D52")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4d978207-10b9-4a43-a474-2e66421925a0")
+		(property "Reference" "D64"
+			(at 152.4 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "27529674-e97c-460d-9de8-89cd61c8a6eb")
+		)
+		(pin "2"
+			(uuid "57e77ee6-e62d-402e-a614-a833da3fbafb")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D64")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5466fd2d-f22f-409b-b7da-f8d297aeb7a2")
+		(property "Reference" "RC6-5"
+			(at 160.02 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffdd8419-9afa-4f38-bfbf-7dc4e869b438")
+		)
+		(pin "2"
+			(uuid "0db27643-51f5-4634-a791-2c4813885195")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "553a576d-44a1-4bad-9211-394526206f63")
+		(property "Reference" "D41"
+			(at 111.76 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4a035e61-91c9-41ba-9328-bc9b284e86c2")
+		)
+		(pin "2"
+			(uuid "8628539f-d3cd-4957-a6bb-5c605649e715")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 68.58 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5692cd7d-67c7-4fe7-8b4d-c8bc86968b31")
+		(property "Reference" "DI1"
+			(at 181.61 64.77 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9abe1fc5-b3c1-424f-8519-d12916c57a11")
+		)
+		(pin "2"
+			(uuid "168b1203-c5fc-4b69-b8e5-94d0bdc27e41")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59263e5e-1eeb-458b-9b02-ca162d4a65d7")
+		(property "Reference" "D21"
+			(at 71.12 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2372f523-257f-414c-92f4-8d433cfbee15")
+		)
+		(pin "2"
+			(uuid "21891727-1d09-4cab-bd90-75c57b141f7c")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59fdee43-9b65-471d-9ea8-5dc40dc65f6e")
+		(property "Reference" "D35"
+			(at 91.44 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5834d436-0e26-481b-a20d-40fa6346502e")
+		)
+		(pin "2"
+			(uuid "59af1ddc-701f-49c0-b6cd-778072695c5c")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D35")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5aeb247f-6f79-4df2-b767-9ca89069182c")
+		(property "Reference" "D56"
+			(at 132.08 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d46c0cdd-d9c1-44c1-ba6c-034fc547ff01")
+		)
+		(pin "2"
+			(uuid "53f3e198-3ef2-40c4-a8f7-298435eddd0b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D56")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5c60f960-fb0a-46f6-9aff-5d8144586231")
+		(property "Reference" "RC4-6"
+			(at 119.38 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "990f1ee1-d6da-4ae8-809a-1911d8099a4c")
+		)
+		(pin "2"
+			(uuid "a8276c00-b61f-4db4-8f4f-e51e512de654")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f21a75c-b9ee-47bf-adcf-39a03e42660f")
+		(property "Reference" "D15"
+			(at 50.8 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1")
+		)
+		(pin "2"
+			(uuid "7a8a84c2-38d2-473b-955d-81dd816a398e")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fa8cce4-fbbf-4784-a459-71364b77e1a7")
+		(property "Reference" "RC0-2"
+			(at 38.1 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cb7750fa-a378-43a3-a1c6-638c32a1c79e")
+		)
+		(pin "2"
+			(uuid "67dfe958-6bd5-4618-98a3-d513db4ad5c0")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5ff7733c-a36f-4b29-a8e7-bdf79fabdf72")
+		(property "Reference" "D4"
+			(at 30.48 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed6062e9-f00a-474a-840f-39685bd66d70")
+		)
+		(pin "2"
+			(uuid "c0e85db4-b88d-4383-8de6-9f7370be62a6")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61b2e3fc-583b-407b-beff-dd8441f2f403")
+		(property "Reference" "RC2-6"
+			(at 78.74 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "752f308d-4723-4468-9745-81de18307ba3")
+		)
+		(pin "2"
+			(uuid "3267c09c-2818-42d7-96a9-6aaa2d6c4a92")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6368f5d6-df20-4a23-a72c-e29e990ea131")
+		(property "Reference" "D36"
+			(at 91.44 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cd72461-15a2-466d-828d-9560639fb78b")
+		)
+		(pin "2"
+			(uuid "e26d27e6-f81a-4557-bc98-f3f953d25d26")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D36")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "67aba0e0-2c92-4816-99a5-9091230a7899")
+		(property "Reference" "RC3-6"
+			(at 99.06 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c252319-dc79-4365-afaa-77dcde3e6c4e")
+		)
+		(pin "2"
+			(uuid "a5f35312-d094-4f22-9eb9-0edc1f8fb9c4")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6aa79de9-555a-4ed1-93d3-b801685ebd28")
+		(property "Reference" "D53"
+			(at 132.08 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b2031fe-ef72-48a9-afa6-c06144a31b2c")
+		)
+		(pin "2"
+			(uuid "7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D53")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "70d661b8-51f1-49b8-ad84-9ce8d120c0fc")
+		(property "Reference" "RC6-2"
+			(at 160.02 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e2175ea2-22e6-4720-ab54-24959d43a616")
+		)
+		(pin "2"
+			(uuid "63a1bf12-3f2f-4dc8-8a86-7932361b8306")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "72047ccc-8813-4e13-ae4a-04618a9ab771")
+		(property "Reference" "D23"
+			(at 71.12 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84")
+		)
+		(pin "2"
+			(uuid "6dee3493-b1eb-401e-abb4-cbdef0ef3867")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7322809e-8332-47c6-af41-fcf3bbcec7d0")
+		(property "Reference" "D34"
+			(at 91.44 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e3b096d1-dbd9-4fb8-8775-725a7aed0bc4")
+		)
+		(pin "2"
+			(uuid "63756bb0-b693-4bbc-82da-e89a6b927e71")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D34")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "76054860-648b-474e-9b4d-cc9d83653495")
+		(property "Reference" "D10"
+			(at 50.8 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d7e8bc-1ac3-4327-ab17-369de6ee755c")
+		)
+		(pin "2"
+			(uuid "c8283bba-c907-48e0-9745-e0818ca7ab04")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "77aa25a5-82c7-42c3-9d55-8606dd65ffa8")
+		(property "Reference" "RC5-1"
+			(at 139.7 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51db5d58-5004-4c9c-b8d1-c184bfb493da")
+		)
+		(pin "2"
+			(uuid "16d6f605-4627-49bd-9180-8203902febfd")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7876e2e4-9d5a-416f-b97a-e958a989e5b8")
+		(property "Reference" "D16"
+			(at 50.8 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8bd5710-8f18-4748-9b3c-a975f78342a1")
+		)
+		(pin "2"
+			(uuid "da0aa924-203b-4985-9bff-4185f3555d43")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D16")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8010e136-1dd3-496f-b7ef-81fb0c8b419e")
+		(property "Reference" "D20"
+			(at 71.12 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5aa5bf69-e040-48d4-81fc-332aff45c2f9")
+		)
+		(pin "2"
+			(uuid "f5458189-75e2-45c3-bf32-0320ebe63391")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80c46ab4-724f-418d-bb6f-e89792097e1a")
+		(property "Reference" "RC2-4"
+			(at 78.74 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc0fd3d-897b-4e06-ac65-16066b68709e")
+		)
+		(pin "2"
+			(uuid "b7b98128-d37a-4ac7-b049-5cf9bdd5aadb")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "81912d5a-1def-44e9-a6ef-abaf3ecd517d")
+		(property "Reference" "RC6-1"
+			(at 160.02 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fa9aca31-bd8b-4e2e-8b86-05d191575df9")
+		)
+		(pin "2"
+			(uuid "fce38bd6-fb8f-42a6-8d68-ecda7f1a588f")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83fb734e-dbcd-4939-9bb9-d97efd05ec97")
+		(property "Reference" "RC5-6"
+			(at 139.7 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7315a9fc-fd63-46c2-90db-bee656dc7568")
+		)
+		(pin "2"
+			(uuid "f2997912-9551-49e9-aab8-387875819f56")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "84146f81-04f3-4efb-b753-bdc596c8e7a9")
+		(property "Reference" "RC4-3"
+			(at 119.38 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "774ced50-3b17-48fe-b2d7-22681b1dd1f7")
+		)
+		(pin "2"
+			(uuid "bad310c0-ca25-47d0-b27e-42438b959c7b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86602dfb-ea19-4060-ad39-496c613a47cb")
+		(property "Reference" "D30"
+			(at 91.44 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "02958e5d-18b7-48f3-9883-661ceaa75da5")
+		)
+		(pin "2"
+			(uuid "abed4b13-9431-40c7-848f-b30c05e39dfd")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D30")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c168cda-0a39-478d-9d71-1073400c7ed7")
+		(property "Reference" "RC1-5"
+			(at 58.42 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d2851af-db15-44cf-8e07-da339bdc18b2")
+		)
+		(pin "2"
+			(uuid "94b381a2-7c19-4916-9f9a-ee00221d04d3")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 129.54 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7")
+		(property "Reference" "DI4"
+			(at 181.61 125.73 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c02807d6-1705-4325-bcb0-203f4e9a5baa")
+		)
+		(pin "2"
+			(uuid "d6c46059-bf9c-4959-836e-e4d33dcc5edd")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9578a4b6-1a56-40b7-be8d-56404ef59fdf")
+		(property "Reference" "RC1-6"
+			(at 58.42 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0b899b44-3ae3-40be-a452-1f16eaa5f4af")
+		)
+		(pin "2"
+			(uuid "11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 109.22 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "957e7a82-ca9c-46a8-bca9-099b05fe7e8f")
+		(property "Reference" "DI3"
+			(at 181.61 105.41 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc53fac9-006c-4101-8113-949ab8e05afb")
+		)
+		(pin "2"
+			(uuid "f6122429-5885-4b7a-b72a-162ca49c70c2")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9af5b930-d274-4b05-b0bf-e2c27b7e71dd")
+		(property "Reference" "D6"
+			(at 30.48 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bdad3d4-58ec-438c-beb8-3eea36a29d95")
+		)
+		(pin "2"
+			(uuid "5ff4e8af-dd18-4010-b183-21b8178cd684")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 181.61 88.9 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd")
+		(property "Reference" "DI2"
+			(at 181.61 85.09 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 183.515 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 181.61 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 181.61 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 181.61 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 181.61 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 181.61 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a")
+		)
+		(pin "2"
+			(uuid "81e4b9c6-9b09-4e38-94e9-cebdeae457ee")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e96ab02-44ee-4ac7-8251-0d309b7409ad")
+		(property "Reference" "RC5-3"
+			(at 139.7 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd85b120-1be2-4f17-a3d7-505a734afc72")
+		)
+		(pin "2"
+			(uuid "666e03ce-bf1c-4b58-ac4e-f01557ca11fd")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a3969e5a-abe0-44e9-adf1-6255946e3f4c")
+		(property "Reference" "RC6-0"
+			(at 160.02 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc4d6aea-ec1e-45c7-842c-68cd7e21336f")
+		)
+		(pin "2"
+			(uuid "f785fa77-0ac2-41ff-9704-1acbb4a72c84")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a400377f-e146-4099-97e7-db21e16d5759")
+		(property "Reference" "D3"
+			(at 30.48 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bfc71c1-6349-4b3f-bf89-22c83277904e")
+		)
+		(pin "2"
+			(uuid "dafd4b6c-6c2f-41e0-95ab-05ead276d86d")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a71b771b-4e14-4d95-98e7-86a6250f569e")
+		(property "Reference" "RC0-4"
+			(at 38.1 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "95049e61-b78e-490f-86e1-aba711db5c19")
+		)
+		(pin "2"
+			(uuid "6e474ba8-5b88-41c8-9259-b0ebfb6012f0")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "abf3c9d9-a279-4546-abcf-5e4f6862bc48")
+		(property "Reference" "D2"
+			(at 30.48 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a3499f31-3593-4cd9-977b-3b6479091d7b")
+		)
+		(pin "2"
+			(uuid "17f09d49-1093-4838-8e5c-8fc4c42e5d05")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac10b530-144b-4dfc-ab37-ad7a8ced8612")
+		(property "Reference" "RC4-5"
+			(at 119.38 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d6c95156-54b9-4f54-a278-f808b4871687")
+		)
+		(pin "2"
+			(uuid "c3dc8d92-1759-4195-a3c9-81260bc6d8b1")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 85.09 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "accba515-4e8d-4804-afea-f36f436141c3")
+		(property "Reference" "DS2"
+			(at 76.2 85.725 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 76.2 83.185 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "034e4344-7cda-43bc-a12a-f56b6e8f68f5")
+		)
+		(pin "2"
+			(uuid "6f0bef00-c613-46da-9667-752b92174ad1")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b2cc8c06-500a-41ac-a412-7baf61e0f24c")
+		(property "Reference" "RC6-3"
+			(at 160.02 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a77d5cb-df53-4102-99ed-4829fa686656")
+		)
+		(pin "2"
+			(uuid "22df81c2-2a06-44e2-bed1-a6d6c14df76a")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 146.05 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3573dc3-ef18-4f4c-817b-c984ae7cfae9")
+		(property "Reference" "DS5"
+			(at 137.16 146.685 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 137.16 144.145 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "813e7cf6-f821-4e03-95cc-308010bed54e")
+		)
+		(pin "2"
+			(uuid "9669a028-42d7-436f-8ec5-bc3423db62d6")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b39d56f9-3079-43e4-bb1b-80277fdae425")
+		(property "Reference" "RC4-2"
+			(at 119.38 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b205d044-9ffa-4dce-82fd-f51ba622a818")
+		)
+		(pin "2"
+			(uuid "29ce7588-4a17-4be4-9207-ea3ed2669aa1")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c497a9-b81f-4161-88cf-2e58ddb4cdd8")
+		(property "Reference" "RC3-4"
+			(at 99.06 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae78f0d3-f75a-49c8-ab9b-8a9831e434d7")
+		)
+		(pin "2"
+			(uuid "a59e897c-0784-437d-9243-baf91d40a453")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba927934-b2e1-4953-b21b-54ef02be8935")
+		(property "Reference" "RC0-5"
+			(at 38.1 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cadba0a-3bb3-40cd-acea-644da4b3e05f")
+		)
+		(pin "2"
+			(uuid "1368ebac-096c-415f-acaf-9afb071e729f")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bb2c72f0-a908-44e7-b7d5-67df52eed516")
+		(property "Reference" "DS4"
+			(at 116.84 126.365 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 116.84 123.825 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5ab0b348-3e2a-4517-90b3-fad111de6205")
+		)
+		(pin "2"
+			(uuid "6e7351bb-5d09-464f-9e8d-535ba0f5c6f3")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be02506a-2bb1-4713-b046-f0327dae72de")
+		(property "Reference" "RC0-1"
+			(at 38.1 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97a92abd-708c-465e-baf7-79fa35370a7c")
+		)
+		(pin "2"
+			(uuid "c9056b1e-419e-478d-9fc4-be1e95902d28")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d")
+		(property "Reference" "RC5-2"
+			(at 139.7 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f22c39d-012a-4297-b61c-1ff841801333")
+		)
+		(pin "2"
+			(uuid "adbe8c88-ad34-405b-866a-efb64899002f")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c11b6807-83e7-46af-9d7e-9d56aab4109c")
+		(property "Reference" "D46"
+			(at 111.76 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46")
+		)
+		(pin "2"
+			(uuid "6764bae9-067c-4178-897e-2c25048ade8b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D46")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c164cb58-7d29-400c-b219-f07036f5e8c9")
+		(property "Reference" "RC0-3"
+			(at 38.1 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92164ea1-76d0-4223-80cc-32c093c14fcd")
+		)
+		(pin "2"
+			(uuid "e615b2e5-6986-47ac-8f35-da60c20b811c")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c43b92c2-4283-44f7-8cb3-665623564383")
+		(property "Reference" "D42"
+			(at 111.76 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0929e13-ab77-4737-9d55-142bd9901b1c")
+		)
+		(pin "2"
+			(uuid "0f45988c-1752-479c-97d5-fbada14f9a42")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D42")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c72dd108-be98-47d5-b809-561778aa3212")
+		(property "Reference" "RC2-5"
+			(at 78.74 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d2f0fd-ce69-4d4e-a4ab-163c1691ef24")
+		)
+		(pin "2"
+			(uuid "03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe")
+		(property "Reference" "D50"
+			(at 132.08 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a606860e-126b-4f3e-bcfe-a2dfa8adc9c8")
+		)
+		(pin "2"
+			(uuid "59120505-a333-4c63-8904-aa379cfb043b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D50")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e")
+		(property "Reference" "D51"
+			(at 132.08 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48596e1c-4629-46bb-98c1-de11cd41e539")
+		)
+		(pin "2"
+			(uuid "f7decfb7-c4ef-4861-ba8a-043f44f3b09e")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D51")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf81ef85-b58f-422a-b88a-7b7914aa3581")
+		(property "Reference" "D12"
+			(at 50.8 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e34c154b-a3cb-467d-891b-2f2891056190")
+		)
+		(pin "2"
+			(uuid "dc926c49-c915-470d-b2b5-00749f3505bb")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d40b4fbb-e58c-433e-b2c5-236bb8aa92c5")
+		(property "Reference" "D1"
+			(at 30.48 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90049b07-ff34-407c-ad1c-bcb8b89b241c")
+		)
+		(pin "2"
+			(uuid "7bd5d68f-4902-47f7-bc35-be0973d0d904")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578")
+		(property "Reference" "RC5-0"
+			(at 139.7 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e5729530-792d-44f2-80ff-f6315aae335e")
+		)
+		(pin "2"
+			(uuid "01f42ec4-9037-47c0-8fc0-8f7345fd0a2b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69")
+		(property "Reference" "RC2-1"
+			(at 78.74 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba2015a3-c3ad-44cf-b530-b2a60bac2c12")
+		)
+		(pin "2"
+			(uuid "12bdf482-8bd0-4b7d-a511-fcaadc8ab54d")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "daefbaa6-3e17-4eca-837b-024ccac5fc10")
+		(property "Reference" "D14"
+			(at 50.8 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12e5236e-b23d-4e38-9768-e28d1693b6eb")
+		)
+		(pin "2"
+			(uuid "1be4fe23-ac83-4b50-b43f-2e4b33c335d7")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e490f25a-1360-4f95-aa79-5f1d93892bb3")
+		(property "Reference" "RC3-5"
+			(at 99.06 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "056973a8-92e3-49be-9b21-fe961241d12f")
+		)
+		(pin "2"
+			(uuid "01c4c06b-d45d-4ffb-ad72-57ca7686fd55")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 105.41 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b")
+		(property "Reference" "DS3"
+			(at 96.52 106.045 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 96.52 103.505 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "738869bf-f410-43b7-b7e7-4e927d69911a")
+		)
+		(pin "2"
+			(uuid "71649a24-87f4-49fb-9896-e50c64c03a31")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb153eb2-74b0-4cb9-b105-af356654d60d")
+		(property "Reference" "D24"
+			(at 71.12 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "77c4fd5e-5c79-4799-aab6-2f07a57c7df3")
+		)
+		(pin "2"
+			(uuid "a062346b-452b-46dc-a106-fab01848555d")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D24")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1920e34-64a4-41c9-8680-7fa42f5dfb9d")
+		(property "Reference" "RC2-0"
+			(at 78.74 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9242378-4df5-4b90-afbf-1098ccb8067f")
+		)
+		(pin "2"
+			(uuid "a135b9b9-316d-4cb2-a5a5-8d618a00a752")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc941f43-b642-4fef-8515-f8f851adced2")
+		(property "Reference" "D13"
+			(at 50.8 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c")
+		)
+		(pin "2"
+			(uuid "ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fcc35b13-8da5-4271-981a-5470b3add3e5")
+		(property "Reference" "D25"
+			(at 71.12 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0f0d662a-16b3-4c76-b4ee-49de18b57b47")
+		)
+		(pin "2"
+			(uuid "ba9a1f4c-173e-4b32-907f-fe9b31df718b")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fd13d6af-afdf-4367-a43b-1889348eabd8")
+		(property "Reference" "RC0-6"
+			(at 38.1 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "854af50a-a007-4ba3-a405-76f0f99e9817")
+		)
+		(pin "2"
+			(uuid "bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142")
+		)
+		(instances
+			(project "round-robin-8-42"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/round-robin-9-56.kicad_sch
+++ b/round-robin-9-56.kicad_sch
@@ -1,4893 +1,13185 @@
-(kicad_sch (version 20230121) (generator eeschema)
-
-  (uuid cbac505e-77a6-4a00-a758-435de33cca16)
-
-  (paper "A3" portrait)
-
-  (lib_symbols
-    (symbol "Diode:1N4148" (pin_numbers hide) (pin_names hide) (in_bom yes) (on_board yes)
-      (property "Reference" "D" (at 0 2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Value" "1N4148" (at 0 -2.54 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Device" "D" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Sim.Pins" "1=K 2=A" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "diode" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "100V 0.15A standard switching diode, DO-35" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_fp_filters" "D*DO?35*" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "1N4148_0_1"
-        (polyline
-          (pts
-            (xy -1.27 1.27)
-            (xy -1.27 -1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 0)
-            (xy -1.27 0)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 1.27 1.27)
-            (xy 1.27 -1.27)
-            (xy -1.27 0)
-            (xy 1.27 1.27)
-          )
-          (stroke (width 0.254) (type default))
-          (fill (type none))
-        )
-      )
-      (symbol "1N4148_1_1"
-        (pin passive line (at -3.81 0 0) (length 2.54)
-          (name "K" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 3.81 0 180) (length 2.54)
-          (name "A" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-    (symbol "Switch:SW_Push" (pin_numbers hide) (pin_names (offset 1.016) hide) (in_bom yes) (on_board yes)
-      (property "Reference" "SW" (at 1.27 2.54 0)
-        (effects (font (size 1.27 1.27)) (justify left))
-      )
-      (property "Value" "SW_Push" (at 0 -1.524 0)
-        (effects (font (size 1.27 1.27)))
-      )
-      (property "Footprint" "" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "Datasheet" "~" (at 0 5.08 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_keywords" "switch normally-open pushbutton push-button" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (property "ki_description" "Push button switch, generic, two pins" (at 0 0 0)
-        (effects (font (size 1.27 1.27)) hide)
-      )
-      (symbol "SW_Push_0_1"
-        (circle (center -2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 0 1.27)
-            (xy 0 3.048)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (polyline
-          (pts
-            (xy 2.54 1.27)
-            (xy -2.54 1.27)
-          )
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (circle (center 2.032 0) (radius 0.508)
-          (stroke (width 0) (type default))
-          (fill (type none))
-        )
-        (pin passive line (at -5.08 0 0) (length 2.54)
-          (name "1" (effects (font (size 1.27 1.27))))
-          (number "1" (effects (font (size 1.27 1.27))))
-        )
-        (pin passive line (at 5.08 0 180) (length 2.54)
-          (name "2" (effects (font (size 1.27 1.27))))
-          (number "2" (effects (font (size 1.27 1.27))))
-        )
-      )
-    )
-  )
-
-  (junction (at 165.1 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 00d75863-bb9f-4d4c-ae8f-f64498ed1533)
-  )
-  (junction (at 185.42 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 05e510f3-8ca9-490a-bdc5-77faace67735)
-  )
-  (junction (at 104.14 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 06a6d1a8-0f12-4174-b63e-d35d8ca618bf)
-  )
-  (junction (at 43.18 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 06e66b38-0070-40a1-8fc5-70306b17897f)
-  )
-  (junction (at 165.1 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 09e82fd3-a43f-4071-83d2-fb0a65931c0e)
-  )
-  (junction (at 63.5 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0a9113d4-8a8c-4abc-b886-f22c92ad18dc)
-  )
-  (junction (at 124.46 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29)
-  )
-  (junction (at 73.66 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 0c7244ee-ddfb-470b-a70b-1cfc53f83773)
-  )
-  (junction (at 134.62 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 0c73479c-4e07-428a-85f3-93341c42ca57)
-  )
-  (junction (at 93.98 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 0d5f3a7a-dc5d-4973-8743-eafaa1c1a462)
-  )
-  (junction (at 43.18 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 10cae212-bc64-40b9-b44f-13fd4a0406a6)
-  )
-  (junction (at 53.34 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 122dbfee-176c-4f21-802f-09581864dffb)
-  )
-  (junction (at 83.82 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 1278b5e3-5eff-46d6-a162-44fde2066970)
-  )
-  (junction (at 53.34 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 14bb4fc2-d7df-49aa-b10e-882abdd2aa5f)
-  )
-  (junction (at 175.26 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 14f29675-67ac-4b1d-961c-8c6e6dd4f1be)
-  )
-  (junction (at 185.42 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 15daf298-357b-4f73-8767-34988eed6eb8)
-  )
-  (junction (at 175.26 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 16d50d3e-3d74-42df-bcf0-4b5bdae4cc3c)
-  )
-  (junction (at 104.14 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 17f3773a-2c02-426d-bcd6-7a35c59a710a)
-  )
-  (junction (at 114.3 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 1a11ada5-19c8-45ac-810c-daedbb80ad5b)
-  )
-  (junction (at 73.66 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 1c386ee6-5b9d-4eae-92b5-9440e81067f6)
-  )
-  (junction (at 205.74 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 216bc563-0bc0-4447-af79-7933fdef7d63)
-  )
-  (junction (at 93.98 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 21e320b6-a0c4-4d5d-babf-ee5274120507)
-  )
-  (junction (at 185.42 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 23554013-cd0d-4767-9f22-8c19a7d8c5ca)
-  )
-  (junction (at 154.94 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 23916c3a-0d37-416a-91d3-82a34b3ade4a)
-  )
-  (junction (at 165.1 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 2501dc30-a271-4271-9ca6-b085328a23ec)
-  )
-  (junction (at 63.5 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 2a93f9b1-4c7f-4e48-96f4-3626f1d1eee3)
-  )
-  (junction (at 175.26 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 2aac8e6d-b0b1-4bc6-bef2-3b4f6d53dd56)
-  )
-  (junction (at 124.46 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 2b2b66bc-905d-4b48-89f5-1c62f6c27dbb)
-  )
-  (junction (at 134.62 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 2c5878fe-fb0a-42a4-a883-ea4209708ea5)
-  )
-  (junction (at 154.94 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 2cf168f3-fe97-43f2-b72e-223dd4e6b386)
-  )
-  (junction (at 73.66 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 30c9eca3-7c32-4704-8819-3599d7b84f53)
-  )
-  (junction (at 93.98 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 31a1b16e-8174-4fea-bc42-9c75ed9182a0)
-  )
-  (junction (at 83.82 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3)
-  )
-  (junction (at 114.3 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 347306fc-87ef-43e1-a98f-ca29ac9473e6)
-  )
-  (junction (at 124.46 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 352af8be-9d08-4866-961e-b8632013179f)
-  )
-  (junction (at 104.14 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 356b49b0-20ac-4c33-8df8-9b27dee0b312)
-  )
-  (junction (at 205.74 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c)
-  )
-  (junction (at 185.42 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 3abcfbc6-0288-48d7-a0e0-144f99e6dd30)
-  )
-  (junction (at 175.26 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 3d5bf705-38d5-49f9-b866-c0b1e791cec7)
-  )
-  (junction (at 134.62 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 3ddd9e62-5556-463c-9539-c0d582cc40e9)
-  )
-  (junction (at 175.26 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid 481456a1-3863-49d3-ab44-255934936ef4)
-  )
-  (junction (at 114.3 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 490a89d7-a161-4f1a-9b45-a55729d9d59b)
-  )
-  (junction (at 124.46 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 4c74baef-72cb-4cdf-b4eb-a3d28782257d)
-  )
-  (junction (at 53.34 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 4c7a50e9-7650-493b-b0a7-057b900a13a7)
-  )
-  (junction (at 63.5 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9)
-  )
-  (junction (at 165.1 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 4df4e0a7-6e46-4c32-959d-094f3457d75b)
-  )
-  (junction (at 43.18 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 4e641ba8-cbcf-42cf-89f0-ac977902bf98)
-  )
-  (junction (at 73.66 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 4fc826ad-ef7b-406a-9b89-76eb2c211523)
-  )
-  (junction (at 53.34 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 4fce0301-62b3-4ef1-9bae-8d55ea745d66)
-  )
-  (junction (at 185.42 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 508ddd33-e065-44a5-a999-5944a523ef76)
-  )
-  (junction (at 53.34 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 53bb27f5-9b54-4704-b90e-33b3053be6c4)
-  )
-  (junction (at 175.26 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid 56ce0611-d97b-47fb-88ed-1891d174fc71)
-  )
-  (junction (at 63.5 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 670a793c-4c48-41d1-9f07-66b1d7d84b06)
-  )
-  (junction (at 83.82 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 672e2ce9-8f2c-43ff-9498-0e342bc1c65e)
-  )
-  (junction (at 175.26 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 69a59b36-9d74-433e-ae55-f2c4f9ba5029)
-  )
-  (junction (at 63.5 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 6b0b87a9-8a81-4bd1-ac24-ffcd6512236b)
-  )
-  (junction (at 43.18 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid 6bfc7531-8adc-4c87-bf8a-788404262765)
-  )
-  (junction (at 134.62 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid 6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1)
-  )
-  (junction (at 154.94 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 6ff7fc69-ca50-4b66-851e-eb36da3cadd8)
-  )
-  (junction (at 63.5 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid 712da204-b8e1-4637-b967-521ccf7b108c)
-  )
-  (junction (at 73.66 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 71e77471-d824-448e-a6de-31cce05e17c2)
-  )
-  (junction (at 73.66 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 742ecb41-f257-40d3-a6f3-d155d6036628)
-  )
-  (junction (at 93.98 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid 782ee96d-a257-4c78-ac0f-a3b5279bef37)
-  )
-  (junction (at 53.34 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid 7943e9ed-5e22-49d3-a238-47d875f3e823)
-  )
-  (junction (at 43.18 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 7dbcae2f-e000-4aff-92b3-5518ea113182)
-  )
-  (junction (at 104.14 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 822096c9-a5b4-460b-8639-9bbf1bb1a2fa)
-  )
-  (junction (at 93.98 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid 84442e81-a253-49f6-ab0f-8ece0b39f637)
-  )
-  (junction (at 53.34 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 86d88f2b-6e5b-493a-b3a4-5436a8374fae)
-  )
-  (junction (at 104.14 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid 88441b0d-9a40-4e18-8fc9-814cc1cb4d3e)
-  )
-  (junction (at 185.42 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid 8a6c81db-4db5-4eb7-a06a-31575c90f62f)
-  )
-  (junction (at 83.82 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid 8bf191a4-2dcd-4018-b67a-91aef9fad846)
-  )
-  (junction (at 144.78 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid 8d88bb99-f0e4-4a81-b464-31814877675a)
-  )
-  (junction (at 205.74 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 95b0c111-7d27-49ee-a08f-b6f35d9d5b54)
-  )
-  (junction (at 93.98 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid 96a12dd2-d02f-4a86-aa6d-3a7015c06462)
-  )
-  (junction (at 134.62 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid 99c67f58-7bde-4417-a08c-823e6af847f2)
-  )
-  (junction (at 124.46 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid 9d2b0f02-b19d-4907-8835-9e7f8a8b9c34)
-  )
-  (junction (at 93.98 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid a2db7df7-b835-49df-98be-3c291238016c)
-  )
-  (junction (at 165.1 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid a7400bf6-86c3-4d41-886e-57235a457a4c)
-  )
-  (junction (at 165.1 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid a9baaad2-c62c-4b79-a10b-261651ef4961)
-  )
-  (junction (at 205.74 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid a9ece8f4-f868-428b-b7ff-a3dc07b47d6c)
-  )
-  (junction (at 144.78 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid aa4f9edb-d8b6-45e2-8d16-270f3c9fc990)
-  )
-  (junction (at 104.14 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid ab0811a2-347a-4a90-b4d0-f1b1ba038333)
-  )
-  (junction (at 83.82 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid b23bc3a0-3ebe-44a5-9126-8b5c4d648e08)
-  )
-  (junction (at 114.3 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid b5ce3eda-e357-44e1-9c69-f84009fc7a87)
-  )
-  (junction (at 154.94 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid b7093823-b63a-4a1a-b279-5afe0127ec9d)
-  )
-  (junction (at 205.74 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b98759bc-77be-4dce-9aa2-cc5ce3889034)
-  )
-  (junction (at 154.94 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid b995f4ca-5e8d-4350-aff6-b7bea568d7f5)
-  )
-  (junction (at 53.34 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3)
-  )
-  (junction (at 154.94 88.9) (diameter 0) (color 0 0 0 0)
-    (uuid be75ea2d-b3b9-4fd0-812b-104329fac661)
-  )
-  (junction (at 144.78 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid befc6138-873b-4406-bc9e-e5a72f7f36fe)
-  )
-  (junction (at 83.82 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0)
-  )
-  (junction (at 134.62 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid c29c26fc-c285-45ba-9e88-4c2a02375307)
-  )
-  (junction (at 165.1 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid c331d35d-23c9-43ea-b243-b660cb5f4bdb)
-  )
-  (junction (at 134.62 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid c3f1775c-0d63-41d3-b7d8-a4c96d241ce3)
-  )
-  (junction (at 93.98 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c41e97f8-87c8-4e82-92ed-e4644d6f526e)
-  )
-  (junction (at 205.74 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid c56d20e0-377b-42bf-89fc-25b698ca10b4)
-  )
-  (junction (at 114.3 68.58) (diameter 0) (color 0 0 0 0)
-    (uuid c5afc93c-0846-4cf9-8f93-4c8f2232c9fa)
-  )
-  (junction (at 43.18 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid c8f222f6-943e-4d7d-919b-3278ca0ede33)
-  )
-  (junction (at 144.78 60.96) (diameter 0) (color 0 0 0 0)
-    (uuid cc2d9922-84c9-42ce-883b-c028a251c101)
-  )
-  (junction (at 124.46 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid cd054c4e-f9d4-4701-a538-16740432e58d)
-  )
-  (junction (at 63.5 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid cfd86ddc-0810-4057-8a79-4468ec7b2424)
-  )
-  (junction (at 83.82 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid d5a179bd-82b1-4661-aebc-4c4d4801bdff)
-  )
-  (junction (at 144.78 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid d5b7ef4f-419a-421c-a02d-fd71016e6c97)
-  )
-  (junction (at 185.42 121.92) (diameter 0) (color 0 0 0 0)
-    (uuid d8d69513-50ec-441c-a953-5a6c226b729f)
-  )
-  (junction (at 114.3 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid dcab5abe-0f5a-44d8-b554-722164ca6a23)
-  )
-  (junction (at 154.94 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid dded6bb5-453a-4491-9278-65d2368e4bc0)
-  )
-  (junction (at 154.94 170.18) (diameter 0) (color 0 0 0 0)
-    (uuid e46432a2-96f1-448e-8928-bfcbbf445ca9)
-  )
-  (junction (at 175.26 48.26) (diameter 0) (color 0 0 0 0)
-    (uuid e543da5d-f03f-4f5d-b936-18074ebe3193)
-  )
-  (junction (at 114.3 149.86) (diameter 0) (color 0 0 0 0)
-    (uuid ee17efa1-5df9-47d0-aec2-a440d8b33e4c)
-  )
-  (junction (at 134.62 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid f1379b2f-59c4-4b61-a98f-3645b6e5fe6b)
-  )
-  (junction (at 104.14 101.6) (diameter 0) (color 0 0 0 0)
-    (uuid f24e6016-cf0c-4fe9-b584-ca06dfdbe767)
-  )
-  (junction (at 43.18 81.28) (diameter 0) (color 0 0 0 0)
-    (uuid f6f817c6-438a-4497-93b1-8dc1f36a395c)
-  )
-  (junction (at 124.46 142.24) (diameter 0) (color 0 0 0 0)
-    (uuid f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd)
-  )
-  (junction (at 144.78 162.56) (diameter 0) (color 0 0 0 0)
-    (uuid f8b3b54a-7c03-49e4-8762-b4ef31db5afd)
-  )
-  (junction (at 205.74 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fa2795fd-0138-4010-b310-3d5e73c1be1c)
-  )
-  (junction (at 73.66 129.54) (diameter 0) (color 0 0 0 0)
-    (uuid fbda2010-a213-45bb-958d-0c9446d51e42)
-  )
-  (junction (at 73.66 190.5) (diameter 0) (color 0 0 0 0)
-    (uuid fc393c80-fb90-44e5-ac86-763463fd8acd)
-  )
-  (junction (at 114.3 109.22) (diameter 0) (color 0 0 0 0)
-    (uuid fc6abd7a-92c0-4b05-85ed-b3bd910676e1)
-  )
-  (junction (at 144.78 40.64) (diameter 0) (color 0 0 0 0)
-    (uuid fdc0071f-cdad-424a-87db-7bd8a0569159)
-  )
-
-  (wire (pts (xy 154.94 68.58) (xy 175.26 68.58))
-    (stroke (width 0) (type default))
-    (uuid 022cd994-adba-45e0-8a4a-b0b516869c19)
-  )
-  (wire (pts (xy 83.82 60.96) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 022d84d0-7bcb-4024-8618-6f3a7f7b41aa)
-  )
-  (wire (pts (xy 144.78 25.4) (xy 144.78 40.64))
-    (stroke (width 0) (type default))
-    (uuid 0406a358-3219-4537-99c7-cfb994e5303c)
-  )
-  (wire (pts (xy 93.98 88.9) (xy 114.3 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0429bfe1-2992-4c6f-bb22-b2e8e5724910)
-  )
-  (wire (pts (xy 185.42 162.56) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid 070c607f-224b-4963-a847-a5abbe4e2e9d)
-  )
-  (wire (pts (xy 73.66 109.22) (xy 93.98 109.22))
-    (stroke (width 0) (type default))
-    (uuid 07ee4d30-e80a-41ae-829d-e3cecf87d77e)
-  )
-  (wire (pts (xy 114.3 48.26) (xy 134.62 48.26))
-    (stroke (width 0) (type default))
-    (uuid 0897e94f-d1e3-47ff-89f6-5de7a1349783)
-  )
-  (wire (pts (xy 205.74 68.58) (xy 205.74 88.9))
-    (stroke (width 0) (type default))
-    (uuid 0aee33c0-3781-43dc-99cb-690f399192cd)
-  )
-  (wire (pts (xy 198.12 149.86) (xy 175.26 149.86))
-    (stroke (width 0) (type default))
-    (uuid 0da59c6a-2c3c-449a-a3b7-c0b90d039443)
-  )
-  (wire (pts (xy 43.18 40.64) (xy 43.18 60.96))
-    (stroke (width 0) (type default))
-    (uuid 0f76c070-bcf8-4924-a8c5-3abe13c36f41)
-  )
-  (wire (pts (xy 63.5 81.28) (xy 63.5 101.6))
-    (stroke (width 0) (type default))
-    (uuid 11ef6261-91ba-4d4c-99ef-8991b7c91dc8)
-  )
-  (wire (pts (xy 104.14 101.6) (xy 104.14 121.92))
-    (stroke (width 0) (type default))
-    (uuid 12080e73-a151-4804-ac9b-ac3ac13653e9)
-  )
-  (wire (pts (xy 73.66 48.26) (xy 93.98 48.26))
-    (stroke (width 0) (type default))
-    (uuid 12a939e2-2ab8-4d74-a5c9-6d61a9528b6e)
-  )
-  (wire (pts (xy 154.94 190.5) (xy 175.26 190.5))
-    (stroke (width 0) (type default))
-    (uuid 15b0be77-2720-4b9e-8da7-956cf862467d)
-  )
-  (wire (pts (xy 93.98 190.5) (xy 114.3 190.5))
-    (stroke (width 0) (type default))
-    (uuid 1767f007-bd12-458a-9e69-f01cc8a5ed24)
-  )
-  (wire (pts (xy 104.14 25.4) (xy 104.14 40.64))
-    (stroke (width 0) (type default))
-    (uuid 1af5b449-9a68-414b-a41f-d6f6cba715a8)
-  )
-  (wire (pts (xy 73.66 81.28) (xy 83.82 81.28))
-    (stroke (width 0) (type default))
-    (uuid 1c0140d1-6775-49db-9fd5-7ecf63ae1284)
-  )
-  (wire (pts (xy 114.3 68.58) (xy 134.62 68.58))
-    (stroke (width 0) (type default))
-    (uuid 211f763f-7ef6-4fb5-98df-2e2ff37faa42)
-  )
-  (wire (pts (xy 63.5 40.64) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid 23f46f84-f16d-4b0b-b463-c2c0244adcc0)
-  )
-  (wire (pts (xy 33.02 129.54) (xy 53.34 129.54))
-    (stroke (width 0) (type default))
-    (uuid 24da3fea-844d-4666-b730-f8d7b708f242)
-  )
-  (wire (pts (xy 185.42 40.64) (xy 185.42 60.96))
-    (stroke (width 0) (type default))
-    (uuid 265c8115-55ea-4d09-95c1-3178314bfa04)
-  )
-  (wire (pts (xy 53.34 129.54) (xy 73.66 129.54))
-    (stroke (width 0) (type default))
-    (uuid 26f78b89-ba4b-4b48-90d1-1245694ead6f)
-  )
-  (wire (pts (xy 83.82 162.56) (xy 83.82 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2703e5ce-9651-45e1-8bd6-144e60387b78)
-  )
-  (wire (pts (xy 33.02 109.22) (xy 53.34 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2832f642-62e7-4a51-b112-f728658e7714)
-  )
-  (wire (pts (xy 53.34 68.58) (xy 73.66 68.58))
-    (stroke (width 0) (type default))
-    (uuid 29a0e612-9a4c-422c-a9b8-8a9fe3879b8a)
-  )
-  (wire (pts (xy 83.82 101.6) (xy 83.82 121.92))
-    (stroke (width 0) (type default))
-    (uuid 2a44e441-f6d5-4994-b7ba-34283a1facc7)
-  )
-  (wire (pts (xy 124.46 121.92) (xy 124.46 142.24))
-    (stroke (width 0) (type default))
-    (uuid 2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0)
-  )
-  (wire (pts (xy 114.3 149.86) (xy 134.62 149.86))
-    (stroke (width 0) (type default))
-    (uuid 2a65926a-d988-49f6-92e7-6e4d5936462f)
-  )
-  (wire (pts (xy 165.1 162.56) (xy 165.1 182.88))
-    (stroke (width 0) (type default))
-    (uuid 2afd7500-0a15-4710-acc0-4f03472785c3)
-  )
-  (wire (pts (xy 165.1 60.96) (xy 165.1 81.28))
-    (stroke (width 0) (type default))
-    (uuid 2b8c9def-eaec-4abd-b08a-c3613e6389df)
-  )
-  (wire (pts (xy 53.34 109.22) (xy 73.66 109.22))
-    (stroke (width 0) (type default))
-    (uuid 2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd)
-  )
-  (wire (pts (xy 124.46 25.4) (xy 124.46 40.64))
-    (stroke (width 0) (type default))
-    (uuid 3115f7a7-e786-49c1-9e4c-25c171cfeb33)
-  )
-  (wire (pts (xy 73.66 68.58) (xy 93.98 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3197b37c-ee5b-406a-ab67-08670d4b8c09)
-  )
-  (wire (pts (xy 154.94 170.18) (xy 175.26 170.18))
-    (stroke (width 0) (type default))
-    (uuid 3a0ad538-3c94-4a03-ba14-d3e55855f87e)
-  )
-  (wire (pts (xy 134.62 68.58) (xy 154.94 68.58))
-    (stroke (width 0) (type default))
-    (uuid 3b15c81d-3687-4710-9aa6-d57ee4885603)
-  )
-  (wire (pts (xy 63.5 121.92) (xy 63.5 142.24))
-    (stroke (width 0) (type default))
-    (uuid 3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5)
-  )
-  (wire (pts (xy 114.3 190.5) (xy 134.62 190.5))
-    (stroke (width 0) (type default))
-    (uuid 3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb)
-  )
-  (wire (pts (xy 154.94 48.26) (xy 175.26 48.26))
-    (stroke (width 0) (type default))
-    (uuid 3fe99eb3-808c-4fd5-8bf0-8eed87e32524)
-  )
-  (wire (pts (xy 73.66 170.18) (xy 93.98 170.18))
-    (stroke (width 0) (type default))
-    (uuid 40ad23e4-b284-4d51-a92e-26a2272af251)
-  )
-  (wire (pts (xy 165.1 121.92) (xy 165.1 142.24))
-    (stroke (width 0) (type default))
-    (uuid 411efa8a-c2b6-469e-b517-3b3f24ffe025)
-  )
-  (wire (pts (xy 198.12 170.18) (xy 175.26 170.18))
-    (stroke (width 0) (type default))
-    (uuid 42af6faa-4e9d-48bc-991c-1d19263dafd6)
-  )
-  (wire (pts (xy 73.66 190.5) (xy 93.98 190.5))
-    (stroke (width 0) (type default))
-    (uuid 432577d5-87d0-4924-a72a-e407dd2ee4b0)
-  )
-  (wire (pts (xy 134.62 170.18) (xy 154.94 170.18))
-    (stroke (width 0) (type default))
-    (uuid 44b0d7a3-542f-48ea-8a2f-25ca02bd7f05)
-  )
-  (wire (pts (xy 53.34 170.18) (xy 73.66 170.18))
-    (stroke (width 0) (type default))
-    (uuid 4554fe48-1b8d-466c-b3f4-c87fb3d79947)
-  )
-  (wire (pts (xy 43.18 60.96) (xy 43.18 81.28))
-    (stroke (width 0) (type default))
-    (uuid 456f0365-d37d-43a2-afac-d06c44cc48af)
-  )
-  (wire (pts (xy 154.94 129.54) (xy 175.26 129.54))
-    (stroke (width 0) (type default))
-    (uuid 462b3865-9668-49d6-a9d9-1406a843104e)
-  )
-  (wire (pts (xy 114.3 88.9) (xy 134.62 88.9))
-    (stroke (width 0) (type default))
-    (uuid 473d672b-6459-459b-93fc-780e5d8f9818)
-  )
-  (wire (pts (xy 124.46 81.28) (xy 124.46 101.6))
-    (stroke (width 0) (type default))
-    (uuid 495f9334-ca7f-4aa5-8d75-09576f1afa2c)
-  )
-  (wire (pts (xy 165.1 81.28) (xy 165.1 101.6))
-    (stroke (width 0) (type default))
-    (uuid 50f7b113-f5f8-43e0-9da7-2a02dc224210)
-  )
-  (wire (pts (xy 33.02 190.5) (xy 53.34 190.5))
-    (stroke (width 0) (type default))
-    (uuid 55243e41-6164-4661-b707-a6f503f12968)
-  )
-  (wire (pts (xy 53.34 190.5) (xy 73.66 190.5))
-    (stroke (width 0) (type default))
-    (uuid 557847f5-42a8-4c4a-a4d9-d21678c28920)
-  )
-  (wire (pts (xy 104.14 60.96) (xy 104.14 81.28))
-    (stroke (width 0) (type default))
-    (uuid 5837ecd4-cf70-4c14-9c7b-bb5f05f8274a)
-  )
-  (wire (pts (xy 104.14 81.28) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid 5b6ae0de-21c8-4433-a4e0-a3b552474fb0)
-  )
-  (wire (pts (xy 134.62 48.26) (xy 154.94 48.26))
-    (stroke (width 0) (type default))
-    (uuid 5d63c1a3-5086-42ca-8afa-60afe2472b23)
-  )
-  (wire (pts (xy 53.34 88.9) (xy 73.66 88.9))
-    (stroke (width 0) (type default))
-    (uuid 60b5d548-d07f-40b1-8e16-72d513f499f2)
-  )
-  (wire (pts (xy 154.94 109.22) (xy 175.26 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6196eb37-90e9-4f6c-80ae-9b758a88c740)
-  )
-  (wire (pts (xy 93.98 109.22) (xy 114.3 109.22))
-    (stroke (width 0) (type default))
-    (uuid 6414e19f-a27a-435d-a47f-a63cba9086f1)
-  )
-  (wire (pts (xy 134.62 109.22) (xy 154.94 109.22))
-    (stroke (width 0) (type default))
-    (uuid 64344100-c91d-4b5c-a8eb-9406d47360dd)
-  )
-  (wire (pts (xy 33.02 68.58) (xy 53.34 68.58))
-    (stroke (width 0) (type default))
-    (uuid 68161b0c-a285-475d-a645-59648d12bc07)
-  )
-  (wire (pts (xy 134.62 149.86) (xy 154.94 149.86))
-    (stroke (width 0) (type default))
-    (uuid 690a405c-1ac3-4b57-a93b-778dda168d2c)
-  )
-  (wire (pts (xy 134.62 190.5) (xy 154.94 190.5))
-    (stroke (width 0) (type default))
-    (uuid 6b21e6c7-ab97-41de-aae4-339e943db88e)
-  )
-  (wire (pts (xy 165.1 40.64) (xy 165.1 60.96))
-    (stroke (width 0) (type default))
-    (uuid 6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc)
-  )
-  (wire (pts (xy 205.74 149.86) (xy 205.74 170.18))
-    (stroke (width 0) (type default))
-    (uuid 6f77a68c-1e32-433a-820e-9683e6fd5e12)
-  )
-  (wire (pts (xy 205.74 88.9) (xy 205.74 109.22))
-    (stroke (width 0) (type default))
-    (uuid 70c6e975-f457-4759-9791-1d1de45afbb3)
-  )
-  (wire (pts (xy 198.12 48.26) (xy 175.26 48.26))
-    (stroke (width 0) (type default))
-    (uuid 70d9ae1f-ad85-40a1-ab0c-659459f5e5b0)
-  )
-  (wire (pts (xy 134.62 129.54) (xy 154.94 129.54))
-    (stroke (width 0) (type default))
-    (uuid 70f3f37d-4259-413e-b59a-babccfdc3a89)
-  )
-  (wire (pts (xy 43.18 121.92) (xy 43.18 142.24))
-    (stroke (width 0) (type default))
-    (uuid 727cc522-ef34-45d4-b711-997054ff0b37)
-  )
-  (wire (pts (xy 33.02 48.26) (xy 53.34 48.26))
-    (stroke (width 0) (type default))
-    (uuid 737596e8-f579-4b1f-aa71-a489d8ba56da)
-  )
-  (wire (pts (xy 93.98 149.86) (xy 114.3 149.86))
-    (stroke (width 0) (type default))
-    (uuid 770cc50c-0085-42e2-b068-cd0ae3b59919)
-  )
-  (wire (pts (xy 205.74 25.4) (xy 205.74 48.26))
-    (stroke (width 0) (type default))
-    (uuid 794205f1-2f7e-4200-b59c-c02481b0416f)
-  )
-  (wire (pts (xy 73.66 88.9) (xy 93.98 88.9))
-    (stroke (width 0) (type default))
-    (uuid 79a42c80-d7a4-4e03-9070-f9fff835a239)
-  )
-  (wire (pts (xy 33.02 40.64) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid 7a4231d0-fb4b-4c65-9cc1-75d3ed714150)
-  )
-  (wire (pts (xy 198.12 129.54) (xy 175.26 129.54))
-    (stroke (width 0) (type default))
-    (uuid 7a99f1c9-db3a-491d-88bf-362ef230f8fa)
-  )
-  (wire (pts (xy 185.42 142.24) (xy 185.42 162.56))
-    (stroke (width 0) (type default))
-    (uuid 7caa1de0-1c5d-4933-9515-38159a29c856)
-  )
-  (wire (pts (xy 165.1 25.4) (xy 165.1 40.64))
-    (stroke (width 0) (type default))
-    (uuid 8506f273-12d6-426d-910b-0c9eecbe3765)
-  )
-  (wire (pts (xy 154.94 149.86) (xy 175.26 149.86))
-    (stroke (width 0) (type default))
-    (uuid 869288c6-9182-45ca-8025-5bf497b3633a)
-  )
-  (wire (pts (xy 134.62 88.9) (xy 154.94 88.9))
-    (stroke (width 0) (type default))
-    (uuid 86d6e974-6898-4932-91cb-e8a4c4c283b7)
-  )
-  (wire (pts (xy 104.14 162.56) (xy 104.14 182.88))
-    (stroke (width 0) (type default))
-    (uuid 8c3cf446-d0cc-4b1b-9218-75f38db02fb3)
-  )
-  (wire (pts (xy 93.98 48.26) (xy 114.3 48.26))
-    (stroke (width 0) (type default))
-    (uuid 8d73bae8-988b-435b-a882-ae9668b41d7e)
-  )
-  (wire (pts (xy 104.14 142.24) (xy 104.14 162.56))
-    (stroke (width 0) (type default))
-    (uuid 8dd624a1-3da3-42c1-929d-9366cd043e3d)
-  )
-  (wire (pts (xy 205.74 48.26) (xy 205.74 68.58))
-    (stroke (width 0) (type default))
-    (uuid 8f339462-56e0-4361-9d9b-983c75fb21ef)
-  )
-  (wire (pts (xy 33.02 88.9) (xy 53.34 88.9))
-    (stroke (width 0) (type default))
-    (uuid 909384ab-bc1c-47d8-a34d-c3d137febfc2)
-  )
-  (wire (pts (xy 124.46 101.6) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid 91eea887-ea8a-4221-ba92-e5ec1caacc4f)
-  )
-  (wire (pts (xy 124.46 142.24) (xy 124.46 162.56))
-    (stroke (width 0) (type default))
-    (uuid 94397688-ce0e-48d4-a59c-7257120bf834)
-  )
-  (wire (pts (xy 185.42 60.96) (xy 185.42 81.28))
-    (stroke (width 0) (type default))
-    (uuid 96776fa9-dbd1-46ef-91bd-e95f23cda112)
-  )
-  (wire (pts (xy 114.3 109.22) (xy 134.62 109.22))
-    (stroke (width 0) (type default))
-    (uuid 9c79c76c-a95b-401f-9edb-a06a0cceaa4b)
-  )
-  (wire (pts (xy 53.34 48.26) (xy 73.66 48.26))
-    (stroke (width 0) (type default))
-    (uuid 9d5ec847-5716-4125-b40b-fdbd3a1587a7)
-  )
-  (wire (pts (xy 165.1 101.6) (xy 165.1 121.92))
-    (stroke (width 0) (type default))
-    (uuid 9f711890-a6d6-4440-8bc1-ed469cb6acc4)
-  )
-  (wire (pts (xy 93.98 101.6) (xy 104.14 101.6))
-    (stroke (width 0) (type default))
-    (uuid a226d887-7662-4dbd-b58b-e683f5d85955)
-  )
-  (wire (pts (xy 124.46 40.64) (xy 124.46 60.96))
-    (stroke (width 0) (type default))
-    (uuid a67c0815-f186-4f70-926f-1b264c84d8d8)
-  )
-  (wire (pts (xy 154.94 162.56) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid a803bbba-64cc-448d-a04f-7f03127ebddd)
-  )
-  (wire (pts (xy 53.34 60.96) (xy 63.5 60.96))
-    (stroke (width 0) (type default))
-    (uuid a8b2f54a-5770-4ce0-a536-efbd997d7a20)
-  )
-  (wire (pts (xy 53.34 149.86) (xy 73.66 149.86))
-    (stroke (width 0) (type default))
-    (uuid aac914ea-c9a3-4a8f-94e1-1f91cdd136a3)
-  )
-  (wire (pts (xy 93.98 129.54) (xy 114.3 129.54))
-    (stroke (width 0) (type default))
-    (uuid ab578e4e-a4bf-4ab4-80fc-d97d4aea6370)
-  )
-  (wire (pts (xy 83.82 121.92) (xy 83.82 142.24))
-    (stroke (width 0) (type default))
-    (uuid ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73)
-  )
-  (wire (pts (xy 93.98 68.58) (xy 114.3 68.58))
-    (stroke (width 0) (type default))
-    (uuid aea6a633-b213-403d-b447-42d91d3ab4da)
-  )
-  (wire (pts (xy 114.3 170.18) (xy 134.62 170.18))
-    (stroke (width 0) (type default))
-    (uuid b3e14390-7dc6-416b-bbd5-cdf868192ca4)
-  )
-  (wire (pts (xy 73.66 129.54) (xy 93.98 129.54))
-    (stroke (width 0) (type default))
-    (uuid b3f6f053-44f0-4391-9873-b6231b8014db)
-  )
-  (wire (pts (xy 144.78 101.6) (xy 144.78 121.92))
-    (stroke (width 0) (type default))
-    (uuid b7b2475f-30dc-4ea2-b799-96c21242154c)
-  )
-  (wire (pts (xy 83.82 81.28) (xy 83.82 101.6))
-    (stroke (width 0) (type default))
-    (uuid b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5)
-  )
-  (wire (pts (xy 205.74 170.18) (xy 205.74 190.5))
-    (stroke (width 0) (type default))
-    (uuid ba045c1c-f33c-4ee8-bfe6-db2af30446e4)
-  )
-  (wire (pts (xy 43.18 101.6) (xy 43.18 121.92))
-    (stroke (width 0) (type default))
-    (uuid bb49a3de-620b-45ad-a54c-29dcceaf0796)
-  )
-  (wire (pts (xy 144.78 121.92) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid bf12198a-9e62-45c3-b466-f5d86de75219)
-  )
-  (wire (pts (xy 63.5 25.4) (xy 63.5 40.64))
-    (stroke (width 0) (type default))
-    (uuid c1a940de-fa49-4106-a8b9-697952eec2a2)
-  )
-  (wire (pts (xy 104.14 121.92) (xy 104.14 142.24))
-    (stroke (width 0) (type default))
-    (uuid c298ba49-6974-4340-859f-5d5a2b4132ff)
-  )
-  (wire (pts (xy 175.26 182.88) (xy 185.42 182.88))
-    (stroke (width 0) (type default))
-    (uuid c3f1f747-e966-4c2c-8090-4f190e07864a)
-  )
-  (wire (pts (xy 124.46 162.56) (xy 124.46 182.88))
-    (stroke (width 0) (type default))
-    (uuid c6080a0e-4059-4120-b2e7-12c9aff607b7)
-  )
-  (wire (pts (xy 124.46 60.96) (xy 124.46 81.28))
-    (stroke (width 0) (type default))
-    (uuid c950d145-c024-47a8-ba57-97efd7bb658b)
-  )
-  (wire (pts (xy 154.94 88.9) (xy 175.26 88.9))
-    (stroke (width 0) (type default))
-    (uuid c980f191-a655-4149-a076-6b096870a525)
-  )
-  (wire (pts (xy 144.78 142.24) (xy 144.78 162.56))
-    (stroke (width 0) (type default))
-    (uuid ca92ed7f-ae97-4c0c-81e4-820de1c001c1)
-  )
-  (wire (pts (xy 63.5 60.96) (xy 63.5 81.28))
-    (stroke (width 0) (type default))
-    (uuid cb0b70bc-5356-48db-954a-95ddc89ced6c)
-  )
-  (wire (pts (xy 205.74 109.22) (xy 205.74 129.54))
-    (stroke (width 0) (type default))
-    (uuid cdde081d-7bdd-42e6-869e-3ff07b8b464b)
-  )
-  (wire (pts (xy 198.12 109.22) (xy 175.26 109.22))
-    (stroke (width 0) (type default))
-    (uuid ce3513a3-7030-4d5c-af7c-adab3e5b7829)
-  )
-  (wire (pts (xy 185.42 121.92) (xy 185.42 142.24))
-    (stroke (width 0) (type default))
-    (uuid cee2f4f4-6cbc-4838-b71a-3189173bbcfe)
-  )
-  (wire (pts (xy 83.82 40.64) (xy 83.82 60.96))
-    (stroke (width 0) (type default))
-    (uuid cff15ec3-f29c-4d36-8776-64c5d29be534)
-  )
-  (wire (pts (xy 83.82 25.4) (xy 83.82 40.64))
-    (stroke (width 0) (type default))
-    (uuid d1088709-a9b9-4e05-8ea2-f87942ee2796)
-  )
-  (wire (pts (xy 73.66 149.86) (xy 93.98 149.86))
-    (stroke (width 0) (type default))
-    (uuid d1347903-ae03-46a2-a707-154093060583)
-  )
-  (wire (pts (xy 144.78 40.64) (xy 144.78 60.96))
-    (stroke (width 0) (type default))
-    (uuid d2183fb3-afd3-46ca-955e-993ea31aa5d3)
-  )
-  (wire (pts (xy 185.42 25.4) (xy 185.42 40.64))
-    (stroke (width 0) (type default))
-    (uuid d2951d7e-82c5-4b56-9a90-ca8ae6d71e44)
-  )
-  (wire (pts (xy 43.18 162.56) (xy 43.18 182.88))
-    (stroke (width 0) (type default))
-    (uuid d56982aa-6580-4d04-83ea-6bf3a85282cc)
-  )
-  (wire (pts (xy 185.42 101.6) (xy 185.42 121.92))
-    (stroke (width 0) (type default))
-    (uuid d675b927-bdff-4eac-82e7-3f468caedaf2)
-  )
-  (wire (pts (xy 43.18 142.24) (xy 43.18 162.56))
-    (stroke (width 0) (type default))
-    (uuid d76ad758-0ae0-4ce6-9f67-c689c066c744)
-  )
-  (wire (pts (xy 33.02 149.86) (xy 53.34 149.86))
-    (stroke (width 0) (type default))
-    (uuid da80b027-904b-4ca2-99c6-5937c80c825c)
-  )
-  (wire (pts (xy 63.5 142.24) (xy 63.5 162.56))
-    (stroke (width 0) (type default))
-    (uuid db492971-48ff-4667-996c-f5d540a20741)
-  )
-  (wire (pts (xy 165.1 142.24) (xy 165.1 162.56))
-    (stroke (width 0) (type default))
-    (uuid dccfde3a-ff1d-42ec-97d5-a8f6cccea832)
-  )
-  (wire (pts (xy 33.02 170.18) (xy 53.34 170.18))
-    (stroke (width 0) (type default))
-    (uuid de8e54c6-84d9-47e5-8f08-dc3e96b8afdb)
-  )
-  (wire (pts (xy 43.18 81.28) (xy 43.18 101.6))
-    (stroke (width 0) (type default))
-    (uuid df5c3763-e66c-46c4-9070-0f73d8115bc4)
-  )
-  (wire (pts (xy 205.74 129.54) (xy 205.74 149.86))
-    (stroke (width 0) (type default))
-    (uuid dfb5a082-e4d5-46ea-8dc8-c65064cd598b)
-  )
-  (wire (pts (xy 93.98 170.18) (xy 114.3 170.18))
-    (stroke (width 0) (type default))
-    (uuid e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb)
-  )
-  (wire (pts (xy 144.78 81.28) (xy 144.78 101.6))
-    (stroke (width 0) (type default))
-    (uuid e444742a-24b1-4bbf-b7ee-438e6dffc9cc)
-  )
-  (wire (pts (xy 114.3 121.92) (xy 124.46 121.92))
-    (stroke (width 0) (type default))
-    (uuid e6d06035-ccb7-4d3e-ae70-d73150e65bbb)
-  )
-  (wire (pts (xy 114.3 129.54) (xy 134.62 129.54))
-    (stroke (width 0) (type default))
-    (uuid e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa)
-  )
-  (wire (pts (xy 63.5 101.6) (xy 63.5 121.92))
-    (stroke (width 0) (type default))
-    (uuid edeeb0d9-51cc-411d-aac4-77f10b619702)
-  )
-  (wire (pts (xy 104.14 40.64) (xy 104.14 60.96))
-    (stroke (width 0) (type default))
-    (uuid ef5c9f05-d71b-4562-9939-852432c066c5)
-  )
-  (wire (pts (xy 144.78 162.56) (xy 144.78 182.88))
-    (stroke (width 0) (type default))
-    (uuid efa47227-d3f9-4214-af64-a7e9107c0edb)
-  )
-  (wire (pts (xy 198.12 190.5) (xy 175.26 190.5))
-    (stroke (width 0) (type default))
-    (uuid f03d9d15-7d07-44a8-9513-609786ba48ec)
-  )
-  (wire (pts (xy 144.78 60.96) (xy 144.78 81.28))
-    (stroke (width 0) (type default))
-    (uuid f0ce7c2b-d80c-49f2-bf63-62b750f7ca47)
-  )
-  (wire (pts (xy 198.12 88.9) (xy 175.26 88.9))
-    (stroke (width 0) (type default))
-    (uuid f20ebf37-e65b-4aeb-a205-d06b5686157f)
-  )
-  (wire (pts (xy 198.12 68.58) (xy 175.26 68.58))
-    (stroke (width 0) (type default))
-    (uuid f3441c62-c2bc-4e2d-8ece-acf37a6441d0)
-  )
-  (wire (pts (xy 63.5 162.56) (xy 63.5 182.88))
-    (stroke (width 0) (type default))
-    (uuid f5658dea-a5b6-4ba9-9360-11c3315c15be)
-  )
-  (wire (pts (xy 134.62 142.24) (xy 144.78 142.24))
-    (stroke (width 0) (type default))
-    (uuid f781a362-e0d4-48be-9d13-5686e05b406f)
-  )
-  (wire (pts (xy 43.18 25.4) (xy 43.18 40.64))
-    (stroke (width 0) (type default))
-    (uuid fa765e67-a220-4a00-944c-7663298f0ead)
-  )
-  (wire (pts (xy 83.82 142.24) (xy 83.82 162.56))
-    (stroke (width 0) (type default))
-    (uuid fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b)
-  )
-  (wire (pts (xy 185.42 81.28) (xy 185.42 101.6))
-    (stroke (width 0) (type default))
-    (uuid ffe6085a-a7be-4653-b911-c10de4574454)
-  )
-
-  (global_label "IO 3" (shape bidirectional) (at 104.14 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 24ec698b-5cae-4571-b9c4-c0e35d64a64d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 104.14 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 1" (shape bidirectional) (at 63.5 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 2d4b15a5-8b6c-4ca3-a7bb-7848c8036590)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 63.5 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 7" (shape bidirectional) (at 185.42 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 45d4e03e-6cff-41ce-b946-708382da0601)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 185.42 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 0" (shape bidirectional) (at 43.18 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 465a517d-f0e1-4825-8675-1cce54bfa7a5)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 43.18 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "INTR" (shape bidirectional) (at 205.74 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 4e12b932-2346-4e84-b5a4-80468334f3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 213.93 25.4 0)
-      (effects (font (size 1.27 1.27)) (justify left) hide)
-    )
-  )
-  (global_label "IO 2" (shape bidirectional) (at 83.82 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 70d42e66-a74c-4de2-af96-d1860851d3fb)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 83.82 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 165.1 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid 89461221-a936-49a3-bf5d-18ec120f3e0c)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 165.1 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 5" (shape bidirectional) (at 144.78 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid d44cceb0-f409-4e5f-a98a-9feead2e845d)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 144.78 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-  (global_label "IO 4" (shape bidirectional) (at 124.46 25.4 90) (fields_autoplaced)
-    (effects (font (size 1.27 1.27)) (justify left))
-    (uuid f36f49e4-227f-479f-b914-786aa44dd568)
-    (property "Intersheetrefs" "${INTERSHEET_REFS}" (at 124.46 17.2705 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 190.5 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0188dba3-054f-4958-9440-27c9ca673633)
-    (property "Reference" "DI7" (at 201.93 186.69 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 193.04 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 190.5 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid deea1889-824f-4f7a-a6be-9546db353c85))
-    (pin "2" (uuid 2080be86-a538-40a8-8f30-ead2a96d02d3))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0263b847-a932-4a31-9f35-35bb23f7000d)
-    (property "Reference" "D62" (at 152.4 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc2e60ca-c74f-4e4b-a0a0-9705327e9578))
-    (pin "2" (uuid d12efbfe-85ac-442f-8c0f-ddbe5646c7d5))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D62") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 64.77 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 04430572-8314-4d21-974c-22350cead1a6)
-    (property "Reference" "DS1" (at 55.88 65.405 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 55.88 62.865 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3e433df4-9fec-4cfb-b60f-eebca7c574cf))
-    (pin "2" (uuid 9bcc1487-0612-4bdb-a2de-a8b2f590b28f))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 44.45 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 080aaa87-0974-4a77-bf63-185495f411a0)
-    (property "Reference" "DS0" (at 35.56 45.085 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 35.56 42.545 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0bfacad1-28fd-4f2e-93dc-68f478b8a6ba))
-    (pin "2" (uuid 376f73f9-79fa-4153-ae38-31ed5446db52))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 09d14922-c46a-4bf1-bb2c-1d224060568c)
-    (property "Reference" "D40" (at 111.76 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c2f1a1d2-df3d-4680-9706-2ca411fa6890))
-    (pin "2" (uuid f58fd788-6016-46e7-b903-3606dd2ec21d))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D40") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 149.86 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0d18473f-e37a-4136-b721-5a2e40e4f8ed)
-    (property "Reference" "DI5" (at 201.93 146.05 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 152.4 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 149.86 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d5a885ca-5076-44e6-9a84-d07474947dde))
-    (pin "2" (uuid 047b5b54-de8b-4afc-abc2-c6d1f2d17bd2))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 170.18 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 0ef17723-f7f8-4fdb-8913-5a4ceefbc065)
-    (property "Reference" "DI6" (at 201.93 166.37 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 172.72 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 170.18 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid df5a6b10-ba48-4f34-96ce-3832d480a7ee))
-    (pin "2" (uuid 59f34a55-6ac4-496d-8c40-1b8f1eafbcb5))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0fadd319-be81-4c25-8d23-e7495a114aa7)
-    (property "Reference" "RC4-0" (at 119.38 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid efb1c47f-fe25-4bea-8081-43d3c19de5cd))
-    (pin "2" (uuid 9138c970-6e3d-46df-9354-5174df2a4e52))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 0ff76361-9578-4f9f-a20c-f042e24a7755)
-    (property "Reference" "D5" (at 30.48 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06))
-    (pin "2" (uuid cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 11f01cd8-f751-497f-9599-50fe1fc0a618)
-    (property "Reference" "RC5-4" (at 139.7 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc28293-fab9-4f93-b3d5-ca9ee69110c4))
-    (pin "2" (uuid 088ac770-af1e-4c4f-ad11-5b44a20594d8))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 13ddd48d-7d2b-415d-b8fa-15c71e245acc)
-    (property "Reference" "D61" (at 152.4 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 745d89b9-e75a-40ae-97bc-d1eadf220f02))
-    (pin "2" (uuid 7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D61") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1b13866a-6fbf-441b-9c64-56258379f43a)
-    (property "Reference" "D65" (at 152.4 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c70f4670-9685-4aab-ac4f-4ebaf44d5847))
-    (pin "2" (uuid 8b9c860d-59e1-424e-a148-1aa2c0db4056))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D65") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a)
-    (property "Reference" "RC6-4" (at 160.02 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 3427b432-e194-40af-9dcb-04dccafe2b0f))
-    (pin "2" (uuid 8af48a1b-2c49-47d9-959c-ee33cdd6f977))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 1e5f084d-4db5-48ad-a2a3-76f186559614)
-    (property "Reference" "RC3-1" (at 99.06 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa))
-    (pin "2" (uuid 40b7f115-b5d7-4fa0-b12b-c1c7b6866feb))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 22a72d93-d5b5-4a6b-95f6-755ac10ccf50)
-    (property "Reference" "RC4-7" (at 119.38 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 18c97ab1-62df-42bc-9dfa-dba3415ee8e2))
-    (pin "2" (uuid ff0eb9a3-538a-4ebf-a42b-97fe870ddfea))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 244b7f9d-3923-4908-be6d-02c49eb4663c)
-    (property "Reference" "RC2-3" (at 78.74 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1d79440a-2f90-4c0b-8d60-528615b0bd65))
-    (pin "2" (uuid 7f1d0566-f385-4126-b190-2379308ed05b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 166.37 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2518146c-59f4-45b7-a4fa-f618686ab064)
-    (property "Reference" "DS6" (at 157.48 167.005 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 157.48 164.465 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cee2f461-8f62-48d8-ac7b-1698deb984c1))
-    (pin "2" (uuid 460b9088-619c-4166-a615-45e17ecf1f0d))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2519cd5e-8ecf-41a4-a9d0-5b856882cb05)
-    (property "Reference" "D63" (at 152.4 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ea1c9827-ebfa-43f1-b2c6-5a572466713e))
-    (pin "2" (uuid 0496ba9c-818c-4d39-979a-e8785e06d12a))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D63") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 28137b00-0d76-493b-92b8-23037474163f)
-    (property "Reference" "RC1-3" (at 58.42 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3))
-    (pin "2" (uuid 41d35b0f-21b5-4da8-92df-229c816b63c5))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2a208574-f638-4917-a68f-bc3ff176d324)
-    (property "Reference" "D75" (at 172.72 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 503e8179-7a4a-4075-8fcf-2d7bb00a3908))
-    (pin "2" (uuid a744b0f2-49c4-46a7-9ec2-cefb21173879))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D75") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 2c50947a-4bb9-43c2-b65c-4726e224b6b0)
-    (property "Reference" "RC3-0" (at 99.06 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b))
-    (pin "2" (uuid 30241adf-a2e7-4976-a53a-5c267616618e))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30340eba-9ed0-42ff-b11f-98a864f7223e)
-    (property "Reference" "RC1-4" (at 58.42 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid aa956a67-c26e-4a57-9ddb-59688a6476ad))
-    (pin "2" (uuid 23cd0d93-5050-40ea-9d49-879bbcbb8bcd))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 30b60f6a-8d20-44dd-b832-1906a957c513)
-    (property "Reference" "D54" (at 132.08 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5c2ad1a4-b254-49a0-8435-d3a374353ffc))
-    (pin "2" (uuid 27a3cb64-baf1-430a-b797-bd52c0e46cbe))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D54") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 310fec10-f10c-41d7-9446-87c12744e146)
-    (property "Reference" "D26" (at 71.12 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e1d524d3-5d24-4c87-b480-74c57a74b567))
-    (pin "2" (uuid c0e9aa05-6318-4fdc-abee-cb43875c8e46))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D26") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 35827986-7004-4f70-a10a-6ceb42f33d9f)
-    (property "Reference" "RC1-2" (at 58.42 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 879d3b07-b41e-4233-b196-e223f635bdf3))
-    (pin "2" (uuid 641f8ea7-6306-4550-92c8-e3cc0ed3e5a5))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 369ff51e-db51-4132-aa26-7b5d981cba74)
-    (property "Reference" "D17" (at 50.8 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9b5adb2f-c180-494e-86cd-ef0a68591be2))
-    (pin "2" (uuid 24774a87-3207-4ab9-a94d-2b9e1b568e65))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D17") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 37da2014-affc-4731-b642-c4245ff411f2)
-    (property "Reference" "RC5-7" (at 139.7 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ac410347-ba8b-493b-832e-a3f9e3359951))
-    (pin "2" (uuid 4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976)
-    (property "Reference" "D43" (at 111.76 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7d6fb6c4-b36c-4ff1-879b-43826c273a72))
-    (pin "2" (uuid 198c65f6-b3df-4780-9f6d-1c910e870a1b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D43") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3a9b19be-43ef-409c-9489-c069efbfa3ee)
-    (property "Reference" "RC0-7" (at 38.1 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 898cdd62-8ad6-4d58-b6f7-f4db79a4cca2))
-    (pin "2" (uuid 277b2226-c100-403c-a519-ef9cdc3923fe))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ac53e86-aa26-4394-9e99-e33f3c863b14)
-    (property "Reference" "RC7-1" (at 180.34 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e6efb38c-f391-43d6-9511-8c7da50b3d51))
-    (pin "2" (uuid 03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef0222e-2eac-4930-ac36-0f395f4593b6)
-    (property "Reference" "RC1-0" (at 58.42 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 20f0b9b8-9322-4d89-a423-dd3d807d99ff))
-    (pin "2" (uuid ce54609e-9d1d-4a3b-81a2-5a384dbe41c8))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 3ef86e49-a152-4515-afb0-4098f497c742)
-    (property "Reference" "D31" (at 91.44 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a))
-    (pin "2" (uuid b917ad78-96a8-428f-ad4f-d49149b5b97b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D31") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 402f0f46-5eb8-421b-9b9f-01a54b5cfa87)
-    (property "Reference" "RC4-1" (at 119.38 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cb206c0-1fab-4ac5-b301-f9678369525b))
-    (pin "2" (uuid b99c2ecc-04a5-4c54-a491-d99fe2562dcc))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 40d8058d-714e-4f99-a508-f64f9c8b575b)
-    (property "Reference" "D60" (at 152.4 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 66710233-d2ab-4921-aa86-488ee87fbb3a))
-    (pin "2" (uuid a9636da9-222c-478f-bc5b-71d3f0473300))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D60") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 430b936d-b8ad-4c28-b93d-4046aec980c7)
-    (property "Reference" "D67" (at 152.4 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9255475-7a77-44cc-9bd9-589d63ced82b))
-    (pin "2" (uuid 9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D67") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 433f3f09-0867-41a3-8ac6-5f00bd3314fc)
-    (property "Reference" "D32" (at 91.44 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 11a29637-fd50-4473-bb70-d4116312a4f5))
-    (pin "2" (uuid 53f6307d-8380-45e9-b3fa-4d05a2bd575d))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D32") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44499808-710f-44ae-bed2-0632db78b8c8)
-    (property "Reference" "D71" (at 172.72 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f8805b31-9770-4092-b10a-101cf112fd76))
-    (pin "2" (uuid 9f3056b1-b197-421f-9d54-08cf5cc88970))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D71") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 44de9323-bd5d-49cd-bf0a-70392801309d)
-    (property "Reference" "D45" (at 111.76 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fb2b185b-5d98-46b8-8516-9e5c980291cf))
-    (pin "2" (uuid f730da3b-5ef9-4abc-8c8d-0794fe3feb87))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D45") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 454ad926-1c6a-4aa4-b6f8-25297463de18)
-    (property "Reference" "RC3-2" (at 99.06 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid f0aebfce-7e76-40f1-83ef-5914b8ebbcc7))
-    (pin "2" (uuid 744fce2b-a15c-45a6-92b0-e880efafb5f6))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 48.26 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 46348ccc-126c-461a-8e39-f93f389ddaa7)
-    (property "Reference" "DI0" (at 201.93 44.45 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 50.8 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 48.26 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c86bf5fa-c113-44c1-b93d-7a5d4ac11904))
-    (pin "2" (uuid dbd8322f-50c7-4271-821c-b0005fd066b2))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4a7f7b3d-918b-431a-b79d-c66494b3ec50)
-    (property "Reference" "D52" (at 132.08 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd114d76-87b2-4089-b211-b7b541ac42b3))
-    (pin "2" (uuid a360aa38-116c-4dd0-a569-f6a7a5a88a05))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D52") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 154.94 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 4d978207-10b9-4a43-a474-2e66421925a0)
-    (property "Reference" "D64" (at 152.4 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 152.4 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 154.94 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 27529674-e97c-460d-9de8-89cd61c8a6eb))
-    (pin "2" (uuid 57e77ee6-e62d-402e-a614-a833da3fbafb))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D64") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5466fd2d-f22f-409b-b7da-f8d297aeb7a2)
-    (property "Reference" "RC6-5" (at 160.02 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ffdd8419-9afa-4f38-bfbf-7dc4e869b438))
-    (pin "2" (uuid 0db27643-51f5-4634-a791-2c4813885195))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5518d7f7-6de1-409b-a6d0-90efa78c0b82)
-    (property "Reference" "D7" (at 30.48 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9bdf2265-17dd-4712-9f75-996577068823))
-    (pin "2" (uuid cd2654f9-f2c1-4ff7-bbce-8fe664862762))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 553a576d-44a1-4bad-9211-394526206f63)
-    (property "Reference" "D41" (at 111.76 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 4a035e61-91c9-41ba-9328-bc9b284e86c2))
-    (pin "2" (uuid 8628539f-d3cd-4957-a6bb-5c605649e715))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D41") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55c4f5cb-c530-414c-92f5-fbf9e58a8885)
-    (property "Reference" "D37" (at 91.44 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 64d90630-a755-4eae-b416-80d8ff93fde4))
-    (pin "2" (uuid 77e4ef56-5ac3-4295-aacb-04ae680de9b7))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D37") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 55dc1959-7c17-496b-b079-56725e7400ff)
-    (property "Reference" "RC7-6" (at 180.34 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d91f51f-9558-44e7-9b69-c9ba25dbac1f))
-    (pin "2" (uuid f7ee2403-2740-4116-96fa-c5f3c0c9f293))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 563bf078-cf50-4f0f-84d6-a83a0feddd45)
-    (property "Reference" "D70" (at 172.72 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 91318668-36ae-48a7-a13c-18d4c2f08036))
-    (pin "2" (uuid 29b99e4d-eeeb-4f18-b49f-b44a360c9eac))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D70") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 68.58 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 5692cd7d-67c7-4fe7-8b4d-c8bc86968b31)
-    (property "Reference" "DI1" (at 201.93 64.77 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 71.12 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 68.58 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9abe1fc5-b3c1-424f-8519-d12916c57a11))
-    (pin "2" (uuid 168b1203-c5fc-4b69-b8e5-94d0bdc27e41))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59263e5e-1eeb-458b-9b02-ca162d4a65d7)
-    (property "Reference" "D21" (at 71.12 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2372f523-257f-414c-92f4-8d433cfbee15))
-    (pin "2" (uuid 21891727-1d09-4cab-bd90-75c57b141f7c))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D21") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 59fdee43-9b65-471d-9ea8-5dc40dc65f6e)
-    (property "Reference" "D35" (at 91.44 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5834d436-0e26-481b-a20d-40fa6346502e))
-    (pin "2" (uuid 59af1ddc-701f-49c0-b6cd-778072695c5c))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D35") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5aeb247f-6f79-4df2-b767-9ca89069182c)
-    (property "Reference" "D56" (at 132.08 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d46c0cdd-d9c1-44c1-ba6c-034fc547ff01))
-    (pin "2" (uuid 53f3e198-3ef2-40c4-a8f7-298435eddd0b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D56") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5c60f960-fb0a-46f6-9aff-5d8144586231)
-    (property "Reference" "RC4-6" (at 119.38 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 990f1ee1-d6da-4ae8-809a-1911d8099a4c))
-    (pin "2" (uuid a8276c00-b61f-4db4-8f4f-e51e512de654))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5f21a75c-b9ee-47bf-adcf-39a03e42660f)
-    (property "Reference" "D15" (at 50.8 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1))
-    (pin "2" (uuid 7a8a84c2-38d2-473b-955d-81dd816a398e))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D15") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5fa8cce4-fbbf-4784-a459-71364b77e1a7)
-    (property "Reference" "RC0-2" (at 38.1 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cb7750fa-a378-43a3-a1c6-638c32a1c79e))
-    (pin "2" (uuid 67dfe958-6bd5-4618-98a3-d513db4ad5c0))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 5ff7733c-a36f-4b29-a8e7-bdf79fabdf72)
-    (property "Reference" "D4" (at 30.48 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ed6062e9-f00a-474a-840f-39685bd66d70))
-    (pin "2" (uuid c0e85db4-b88d-4383-8de6-9f7370be62a6))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 61b2e3fc-583b-407b-beff-dd8441f2f403)
-    (property "Reference" "RC2-6" (at 78.74 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 752f308d-4723-4468-9745-81de18307ba3))
-    (pin "2" (uuid 3267c09c-2818-42d7-96a9-6aaa2d6c4a92))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6368f5d6-df20-4a23-a72c-e29e990ea131)
-    (property "Reference" "D36" (at 91.44 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2cd72461-15a2-466d-828d-9560639fb78b))
-    (pin "2" (uuid e26d27e6-f81a-4557-bc98-f3f953d25d26))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D36") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 64616073-76e8-465f-9707-663a78749bf1)
-    (property "Reference" "RC7-3" (at 180.34 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0925180b-4c04-468a-84a3-7e0c543a243b))
-    (pin "2" (uuid 000c5508-f583-4022-ad6d-ee3a9a754164))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 67aba0e0-2c92-4816-99a5-9091230a7899)
-    (property "Reference" "RC3-6" (at 99.06 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 9c252319-dc79-4365-afaa-77dcde3e6c4e))
-    (pin "2" (uuid a5f35312-d094-4f22-9eb9-0edc1f8fb9c4))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 6aa79de9-555a-4ed1-93d3-b801685ebd28)
-    (property "Reference" "D53" (at 132.08 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8b2031fe-ef72-48a9-afa6-c06144a31b2c))
-    (pin "2" (uuid 7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D53") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 70d661b8-51f1-49b8-ad84-9ce8d120c0fc)
-    (property "Reference" "RC6-2" (at 160.02 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e2175ea2-22e6-4720-ab54-24959d43a616))
-    (pin "2" (uuid 63a1bf12-3f2f-4dc8-8a86-7932361b8306))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 72047ccc-8813-4e13-ae4a-04618a9ab771)
-    (property "Reference" "D23" (at 71.12 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84))
-    (pin "2" (uuid 6dee3493-b1eb-401e-abb4-cbdef0ef3867))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D23") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7322809e-8332-47c6-af41-fcf3bbcec7d0)
-    (property "Reference" "D34" (at 91.44 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e3b096d1-dbd9-4fb8-8775-725a7aed0bc4))
-    (pin "2" (uuid 63756bb0-b693-4bbc-82da-e89a6b927e71))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D34") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 76054860-648b-474e-9b4d-cc9d83653495)
-    (property "Reference" "D10" (at 50.8 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d7e8bc-1ac3-4327-ab17-369de6ee755c))
-    (pin "2" (uuid c8283bba-c907-48e0-9745-e0818ca7ab04))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D10") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 77aa25a5-82c7-42c3-9d55-8606dd65ffa8)
-    (property "Reference" "RC5-1" (at 139.7 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 51db5d58-5004-4c9c-b8d1-c184bfb493da))
-    (pin "2" (uuid 16d6f605-4627-49bd-9180-8203902febfd))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 7876e2e4-9d5a-416f-b97a-e958a989e5b8)
-    (property "Reference" "D16" (at 50.8 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8bd5710-8f18-4748-9b3c-a975f78342a1))
-    (pin "2" (uuid da0aa924-203b-4985-9bff-4185f3555d43))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D16") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8010e136-1dd3-496f-b7ef-81fb0c8b419e)
-    (property "Reference" "D20" (at 71.12 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5aa5bf69-e040-48d4-81fc-332aff45c2f9))
-    (pin "2" (uuid f5458189-75e2-45c3-bf32-0320ebe63391))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D20") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 80c46ab4-724f-418d-bb6f-e89792097e1a)
-    (property "Reference" "RC2-4" (at 78.74 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5bc0fd3d-897b-4e06-ac65-16066b68709e))
-    (pin "2" (uuid b7b98128-d37a-4ac7-b049-5cf9bdd5aadb))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 814545b5-c5a6-4c45-83b2-5c1b5ef43a22)
-    (property "Reference" "D57" (at 132.08 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid adc35f03-9c02-4ca4-bbc5-866d317a7469))
-    (pin "2" (uuid f05a395b-0185-4ab8-bf1d-fa0561316ad4))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D57") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 81912d5a-1def-44e9-a6ef-abaf3ecd517d)
-    (property "Reference" "RC6-1" (at 160.02 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fa9aca31-bd8b-4e2e-8b86-05d191575df9))
-    (pin "2" (uuid fce38bd6-fb8f-42a6-8d68-ecda7f1a588f))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 820f9c2f-0705-41a0-aa6a-3a211d61773f)
-    (property "Reference" "RC6-7" (at 160.02 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid eb135129-1d78-4d36-9389-941aee94da0a))
-    (pin "2" (uuid 2a32e7b7-f134-4c47-a153-d8fce8404094))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83cc3bf3-09a0-4d14-be9d-180ca479485f)
-    (property "Reference" "D73" (at 172.72 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 22a68b69-e4e9-436e-b154-616fe8bb66c2))
-    (pin "2" (uuid b8e81b5d-9257-4482-8c33-cdfcb13c22e7))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D73") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 83fb734e-dbcd-4939-9bb9-d97efd05ec97)
-    (property "Reference" "RC5-6" (at 139.7 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7315a9fc-fd63-46c2-90db-bee656dc7568))
-    (pin "2" (uuid f2997912-9551-49e9-aab8-387875819f56))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 84146f81-04f3-4efb-b753-bdc596c8e7a9)
-    (property "Reference" "RC4-3" (at 119.38 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 774ced50-3b17-48fe-b2d7-22681b1dd1f7))
-    (pin "2" (uuid bad310c0-ca25-47d0-b27e-42438b959c7b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 86602dfb-ea19-4060-ad39-496c613a47cb)
-    (property "Reference" "D30" (at 91.44 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 91.44 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 02958e5d-18b7-48f3-9883-661ceaa75da5))
-    (pin "2" (uuid abed4b13-9431-40c7-848f-b30c05e39dfd))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D30") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8b2b0803-8190-43b4-9c0d-a9a9edc27829)
-    (property "Reference" "RC2-7" (at 78.74 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d8e9f64d-5849-4a62-8bf4-dafc65fcdd75))
-    (pin "2" (uuid e45fa11d-c755-4d62-baa5-974f973ba20f))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8c168cda-0a39-478d-9d71-1073400c7ed7)
-    (property "Reference" "RC1-5" (at 58.42 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0d2851af-db15-44cf-8e07-da339bdc18b2))
-    (pin "2" (uuid 94b381a2-7c19-4916-9f9a-ee00221d04d3))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 129.54 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7)
-    (property "Reference" "DI4" (at 201.93 125.73 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 132.08 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 129.54 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c02807d6-1705-4325-bcb0-203f4e9a5baa))
-    (pin "2" (uuid d6c46059-bf9c-4959-836e-e4d33dcc5edd))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 8eb7a7fa-054b-460a-a80c-73a56219fecd)
-    (property "Reference" "RC7-0" (at 180.34 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid be9c1065-912d-49b5-8f2f-271b4a0c1db2))
-    (pin "2" (uuid 626f5614-e69d-4277-acf6-7ff35b08ddb4))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 90049005-7b99-4d2f-9282-dbf53b76b55d)
-    (property "Reference" "RC3-7" (at 99.06 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 62acb361-e48a-40de-9689-6c103c4c7663))
-    (pin "2" (uuid f3ee11cf-4f81-4591-ab5d-f41aece910dc))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 186.69 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 91a5d9b4-63df-4567-88f7-1d2f7ac8c33d)
-    (property "Reference" "DS7" (at 177.8 187.325 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 177.8 184.785 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2ec7f316-054f-444d-9c0b-c2c6e1d51faf))
-    (pin "2" (uuid e22dc61a-a86f-42a7-9c26-623bb8233a05))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9578a4b6-1a56-40b7-be8d-56404ef59fdf)
-    (property "Reference" "RC1-6" (at 58.42 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0b899b44-3ae3-40be-a452-1f16eaa5f4af))
-    (pin "2" (uuid 11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 109.22 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 957e7a82-ca9c-46a8-bca9-099b05fe7e8f)
-    (property "Reference" "DI3" (at 201.93 105.41 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 111.76 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 109.22 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid cc53fac9-006c-4101-8113-949ab8e05afb))
-    (pin "2" (uuid f6122429-5885-4b7a-b72a-162ca49c70c2))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9af5b930-d274-4b05-b0bf-e2c27b7e71dd)
-    (property "Reference" "D6" (at 30.48 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bdad3d4-58ec-438c-beb8-3eea36a29d95))
-    (pin "2" (uuid 5ff4e8af-dd18-4010-b183-21b8178cd684))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 201.93 88.9 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no)
-    (uuid 9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd)
-    (property "Reference" "DI2" (at 201.93 85.09 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "1N4148" (at 203.835 91.44 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 201.93 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 201.93 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 201.93 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 201.93 88.9 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a))
-    (pin "2" (uuid 81e4b9c6-9b09-4e38-94e9-cebdeae457ee))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DI2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid 9e96ab02-44ee-4ac7-8251-0d309b7409ad)
-    (property "Reference" "RC5-3" (at 139.7 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fd85b120-1be2-4f17-a3d7-505a734afc72))
-    (pin "2" (uuid 666e03ce-bf1c-4b58-ac4e-f01557ca11fd))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a3969e5a-abe0-44e9-adf1-6255946e3f4c)
-    (property "Reference" "RC6-0" (at 160.02 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid bc4d6aea-ec1e-45c7-842c-68cd7e21336f))
-    (pin "2" (uuid f785fa77-0ac2-41ff-9704-1acbb4a72c84))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a400377f-e146-4099-97e7-db21e16d5759)
-    (property "Reference" "D3" (at 30.48 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7bfc71c1-6349-4b3f-bf89-22c83277904e))
-    (pin "2" (uuid dafd4b6c-6c2f-41e0-95ab-05ead276d86d))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a576c983-0812-4f76-8327-d260ce9c2826)
-    (property "Reference" "D27" (at 71.12 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid c11deb1a-dbe0-4d39-8303-331b09dd3cc0))
-    (pin "2" (uuid 9251c46a-97e6-41c1-9326-a6a8b52abc12))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D27") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid a71b771b-4e14-4d95-98e7-86a6250f569e)
-    (property "Reference" "RC0-4" (at 38.1 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 95049e61-b78e-490f-86e1-aba711db5c19))
-    (pin "2" (uuid 6e474ba8-5b88-41c8-9259-b0ebfb6012f0))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid abf3c9d9-a279-4546-abcf-5e4f6862bc48)
-    (property "Reference" "D2" (at 30.48 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a3499f31-3593-4cd9-977b-3b6479091d7b))
-    (pin "2" (uuid 17f09d49-1093-4838-8e5c-8fc4c42e5d05))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ac10b530-144b-4dfc-ab37-ad7a8ced8612)
-    (property "Reference" "RC4-5" (at 119.38 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid d6c95156-54b9-4f54-a278-f808b4871687))
-    (pin "2" (uuid c3dc8d92-1759-4195-a3c9-81260bc6d8b1))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 85.09 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid accba515-4e8d-4804-afea-f36f436141c3)
-    (property "Reference" "DS2" (at 76.2 85.725 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 76.2 83.185 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 034e4344-7cda-43bc-a12a-f56b6e8f68f5))
-    (pin "2" (uuid 6f0bef00-c613-46da-9667-752b92174ad1))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid afcc8d67-6ed8-4a82-aef7-417b4229ad61)
-    (property "Reference" "RC7-4" (at 180.34 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 982715f0-55ee-4146-b98e-756e5b630dca))
-    (pin "2" (uuid 7f384a84-9632-4ac9-a8b6-05778cf49f62))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 160.02 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b2cc8c06-500a-41ac-a412-7baf61e0f24c)
-    (property "Reference" "RC6-3" (at 160.02 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 160.02 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 160.02 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0a77d5cb-df53-4102-99ed-4829fa686656))
-    (pin "2" (uuid 22df81c2-2a06-44e2-bed1-a6d6c14df76a))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC6-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 146.05 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3573dc3-ef18-4f4c-817b-c984ae7cfae9)
-    (property "Reference" "DS5" (at 137.16 146.685 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 137.16 144.145 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 813e7cf6-f821-4e03-95cc-308010bed54e))
-    (pin "2" (uuid 9669a028-42d7-436f-8ec5-bc3423db62d6))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 119.38 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b39d56f9-3079-43e4-bb1b-80277fdae425)
-    (property "Reference" "RC4-2" (at 119.38 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 119.38 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 119.38 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid b205d044-9ffa-4dce-82fd-f51ba622a818))
-    (pin "2" (uuid 29ce7588-4a17-4be4-9207-ea3ed2669aa1))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC4-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 121.92 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid b3c497a9-b81f-4161-88cf-2e58ddb4cdd8)
-    (property "Reference" "RC3-4" (at 99.06 115.57 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 118.11 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 116.84 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ae78f0d3-f75a-49c8-ab9b-8a9831e434d7))
-    (pin "2" (uuid a59e897c-0784-437d-9243-baf91d40a453))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ba927934-b2e1-4953-b21b-54ef02be8935)
-    (property "Reference" "RC0-5" (at 38.1 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 1cadba0a-3bb3-40cd-acea-644da4b3e05f))
-    (pin "2" (uuid 1368ebac-096c-415f-acaf-9afb071e729f))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 125.73 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid bb2c72f0-a908-44e7-b7d5-67df52eed516)
-    (property "Reference" "DS4" (at 116.84 126.365 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 116.84 123.825 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 5ab0b348-3e2a-4517-90b3-fad111de6205))
-    (pin "2" (uuid 6e7351bb-5d09-464f-9e8d-535ba0f5c6f3))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS4") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be02506a-2bb1-4713-b046-f0327dae72de)
-    (property "Reference" "RC0-1" (at 38.1 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 97a92abd-708c-465e-baf7-79fa35370a7c))
-    (pin "2" (uuid c9056b1e-419e-478d-9fc4-be1e95902d28))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d)
-    (property "Reference" "RC5-2" (at 139.7 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8f22c39d-012a-4297-b61c-1ff841801333))
-    (pin "2" (uuid adbe8c88-ad34-405b-866a-efb64899002f))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c11b6807-83e7-46af-9d7e-9d56aab4109c)
-    (property "Reference" "D46" (at 111.76 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46))
-    (pin "2" (uuid 6764bae9-067c-4178-897e-2c25048ade8b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D46") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 101.6 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c164cb58-7d29-400c-b219-f07036f5e8c9)
-    (property "Reference" "RC0-3" (at 38.1 95.25 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 97.79 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 96.52 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92164ea1-76d0-4223-80cc-32c093c14fcd))
-    (pin "2" (uuid e615b2e5-6986-47ac-8f35-da60c20b811c))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c43b92c2-4283-44f7-8cb3-665623564383)
-    (property "Reference" "D42" (at 111.76 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a0929e13-ab77-4737-9d55-142bd9901b1c))
-    (pin "2" (uuid 0f45988c-1752-479c-97d5-fbada14f9a42))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D42") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c72dd108-be98-47d5-b809-561778aa3212)
-    (property "Reference" "RC2-5" (at 78.74 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 99d2f0fd-ce69-4d4e-a4ab-163c1691ef24))
-    (pin "2" (uuid 03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 44.45 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe)
-    (property "Reference" "D50" (at 132.08 43.815 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 46.355 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 44.45 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a606860e-126b-4f3e-bcfe-a2dfa8adc9c8))
-    (pin "2" (uuid 59120505-a333-4c63-8904-aa379cfb043b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D50") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid c996541a-3b07-4fed-9687-afa9b7ffb878)
-    (property "Reference" "RC7-5" (at 180.34 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 560b334e-ed5f-40a2-b100-5974e92ce94c))
-    (pin "2" (uuid 55bbe733-1ff6-4a73-b892-49d49c6c0fc9))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 180.34 81.28 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce521a1c-e123-4f49-866e-f4f51848f864)
-    (property "Reference" "RC7-2" (at 180.34 74.93 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 180.34 77.47 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 180.34 76.2 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 2a9b15ea-df9e-4ef0-a128-13d2e129d7f7))
-    (pin "2" (uuid e9530707-f705-4741-a308-e08f558f67a1))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC7-2") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 134.62 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e)
-    (property "Reference" "D51" (at 132.08 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 132.08 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 134.62 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 48596e1c-4629-46bb-98c1-de11cd41e539))
-    (pin "2" (uuid f7decfb7-c4ef-4861-ba8a-043f44f3b09e))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D51") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid cf81ef85-b58f-422a-b88a-7b7914aa3581)
-    (property "Reference" "D12" (at 50.8 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e34c154b-a3cb-467d-891b-2f2891056190))
-    (pin "2" (uuid dc926c49-c915-470d-b2b5-00749f3505bb))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D12") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 33.02 64.77 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d40b4fbb-e58c-433e-b2c5-236bb8aa92c5)
-    (property "Reference" "D1" (at 30.48 64.135 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 30.48 66.675 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 33.02 64.77 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 90049b07-ff34-407c-ad1c-bcb8b89b241c))
-    (pin "2" (uuid 7bd5d68f-4902-47f7-bc35-be0973d0d904))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 139.7 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578)
-    (property "Reference" "RC5-0" (at 139.7 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 139.7 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 139.7 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid e5729530-792d-44f2-80ff-f6315aae335e))
-    (pin "2" (uuid 01f42ec4-9037-47c0-8fc0-8f7345fd0a2b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC5-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 60.96 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69)
-    (property "Reference" "RC2-1" (at 78.74 54.61 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 57.15 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 55.88 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid ba2015a3-c3ad-44cf-b530-b2a60bac2c12))
-    (pin "2" (uuid 12bdf482-8bd0-4b7d-a511-fcaadc8ab54d))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-1") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid daefbaa6-3e17-4eca-837b-024ccac5fc10)
-    (property "Reference" "D14" (at 50.8 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 12e5236e-b23d-4e38-9768-e28d1693b6eb))
-    (pin "2" (uuid 1be4fe23-ac83-4b50-b43f-2e4b33c335d7))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D14") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 114.3 186.69 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid df14ac0c-5b64-41d1-ac61-954e84a88f4b)
-    (property "Reference" "D47" (at 111.76 186.055 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 111.76 188.595 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 114.3 186.69 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7284aa2f-4456-4e07-9251-a86b7acd95b1))
-    (pin "2" (uuid c06243a0-5a23-4af5-88df-f2a88bfb1da0))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D47") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 85.09 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e255666b-19cd-45a4-b5c1-8997235eb1ad)
-    (property "Reference" "D72" (at 172.72 84.455 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 86.995 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 85.09 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 92803ca1-7814-4c2f-986c-c7a2afaea4b2))
-    (pin "2" (uuid f1e544c9-5e94-460f-960c-d30fdb857f44))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D72") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 99.06 142.24 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e490f25a-1360-4f95-aa79-5f1d93892bb3)
-    (property "Reference" "RC3-5" (at 99.06 135.89 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 99.06 138.43 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 99.06 137.16 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 056973a8-92e3-49be-9b21-fe961241d12f))
-    (pin "2" (uuid 01c4c06b-d45d-4ffb-ad72-57ca7686fd55))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC3-5") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 166.37 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid e6262d19-9b35-41b6-845a-39c20b831416)
-    (property "Reference" "D76" (at 172.72 165.735 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 168.275 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 166.37 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 8324bd70-bd5e-4513-bc52-cc4e838003e8))
-    (pin "2" (uuid 64285f25-2c5b-4231-8d94-7ba284d5a2d2))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D76") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 93.98 105.41 90) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b)
-    (property "Reference" "DS3" (at 96.52 106.045 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 96.52 103.505 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 93.98 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 738869bf-f410-43b7-b7e7-4e927d69911a))
-    (pin "2" (uuid 71649a24-87f4-49fb-9896-e50c64c03a31))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "DS3") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid eb153eb2-74b0-4cb9-b105-af356654d60d)
-    (property "Reference" "D24" (at 71.12 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 77c4fd5e-5c79-4799-aab6-2f07a57c7df3))
-    (pin "2" (uuid a062346b-452b-46dc-a106-fab01848555d))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D24") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 175.26 125.73 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid ef64a689-efe5-479a-a53a-19c9f4177765)
-    (property "Reference" "D74" (at 172.72 125.095 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 172.72 127.635 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 175.26 125.73 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid fc4be4a8-3bcc-4a9b-8dca-654b73020c91))
-    (pin "2" (uuid 982449b6-25db-4afc-abf2-592e07b23449))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D74") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 78.74 40.64 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1920e34-64a4-41c9-8680-7fa42f5dfb9d)
-    (property "Reference" "RC2-0" (at 78.74 34.29 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 78.74 36.83 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 78.74 35.56 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid a9242378-4df5-4b90-afbf-1098ccb8067f))
-    (pin "2" (uuid a135b9b9-316d-4cb2-a5a5-8d618a00a752))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC2-0") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 58.42 182.88 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid f1a5bcca-72b0-4fb1-9570-8abc0f731fb7)
-    (property "Reference" "RC1-7" (at 58.42 176.53 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 58.42 179.07 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 58.42 177.8 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 058cb33f-3013-4884-ba52-2b175c6e6f25))
-    (pin "2" (uuid cb54004f-a1b9-489e-9cdf-00b812c2d5fa))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC1-7") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 53.34 105.41 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fc941f43-b642-4fef-8515-f8f851adced2)
-    (property "Reference" "D13" (at 50.8 104.775 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 50.8 107.315 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 53.34 105.41 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c))
-    (pin "2" (uuid ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D13") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Diode:1N4148") (at 73.66 146.05 270) (mirror x) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fcc35b13-8da5-4271-981a-5470b3add3e5)
-    (property "Reference" "D25" (at 71.12 145.415 90) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)) (justify right))
-    )
-    (property "Value" "1N4148" (at 71.12 147.955 90)
-      (effects (font (size 1.27 1.27)) (justify right) hide)
-    )
-    (property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Device" "D" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Sim.Pins" "1=K 2=A" (at 73.66 146.05 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 0f0d662a-16b3-4c76-b4ee-49de18b57b47))
-    (pin "2" (uuid ba9a1f4c-173e-4b32-907f-fe9b31df718b))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "D25") (unit 1)
-        )
-      )
-    )
-  )
-
-  (symbol (lib_id "Switch:SW_Push") (at 38.1 162.56 0) (mirror y) (unit 1)
-    (in_bom yes) (on_board yes) (dnp no) (fields_autoplaced)
-    (uuid fd13d6af-afdf-4367-a43b-1889348eabd8)
-    (property "Reference" "RC0-6" (at 38.1 156.21 0) (do_not_autoplace)
-      (effects (font (size 1.27 1.27)))
-    )
-    (property "Value" "SW_Push" (at 38.1 158.75 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Footprint" "" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (property "Datasheet" "~" (at 38.1 157.48 0)
-      (effects (font (size 1.27 1.27)) hide)
-    )
-    (pin "1" (uuid 854af50a-a007-4ba3-a405-76f0f99e9817))
-    (pin "2" (uuid bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142))
-    (instances
-      (project "round-robin-9-56"
-        (path "/cbac505e-77a6-4a00-a758-435de33cca16"
-          (reference "RC0-6") (unit 1)
-        )
-      )
-    )
-  )
-
-  (sheet_instances
-    (path "/" (page "1"))
-  )
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "cbac505e-77a6-4a00-a758-435de33cca16")
+	(paper "A3" portrait)
+	(lib_symbols
+		(symbol "Diode:1N4148"
+			(pin_numbers hide)
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "1N4148"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "100V 0.15A standard switching diode, DO-35"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Device" "D"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "D*DO?35*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "1N4148_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "1N4148_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 165.1 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "00d75863-bb9f-4d4c-ae8f-f64498ed1533")
+	)
+	(junction
+		(at 185.42 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "05e510f3-8ca9-490a-bdc5-77faace67735")
+	)
+	(junction
+		(at 104.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06a6d1a8-0f12-4174-b63e-d35d8ca618bf")
+	)
+	(junction
+		(at 43.18 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "06e66b38-0070-40a1-8fc5-70306b17897f")
+	)
+	(junction
+		(at 165.1 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "09e82fd3-a43f-4071-83d2-fb0a65931c0e")
+	)
+	(junction
+		(at 63.5 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0a9113d4-8a8c-4abc-b886-f22c92ad18dc")
+	)
+	(junction
+		(at 124.46 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0ba6e65e-9f02-4eb9-b939-d3ba4ccc5e29")
+	)
+	(junction
+		(at 73.66 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c7244ee-ddfb-470b-a70b-1cfc53f83773")
+	)
+	(junction
+		(at 134.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c73479c-4e07-428a-85f3-93341c42ca57")
+	)
+	(junction
+		(at 93.98 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0d5f3a7a-dc5d-4973-8743-eafaa1c1a462")
+	)
+	(junction
+		(at 43.18 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "10cae212-bc64-40b9-b44f-13fd4a0406a6")
+	)
+	(junction
+		(at 53.34 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "122dbfee-176c-4f21-802f-09581864dffb")
+	)
+	(junction
+		(at 83.82 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1278b5e3-5eff-46d6-a162-44fde2066970")
+	)
+	(junction
+		(at 53.34 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14bb4fc2-d7df-49aa-b10e-882abdd2aa5f")
+	)
+	(junction
+		(at 175.26 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "14f29675-67ac-4b1d-961c-8c6e6dd4f1be")
+	)
+	(junction
+		(at 185.42 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "15daf298-357b-4f73-8767-34988eed6eb8")
+	)
+	(junction
+		(at 175.26 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "16d50d3e-3d74-42df-bcf0-4b5bdae4cc3c")
+	)
+	(junction
+		(at 104.14 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "17f3773a-2c02-426d-bcd6-7a35c59a710a")
+	)
+	(junction
+		(at 114.3 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a11ada5-19c8-45ac-810c-daedbb80ad5b")
+	)
+	(junction
+		(at 73.66 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c386ee6-5b9d-4eae-92b5-9440e81067f6")
+	)
+	(junction
+		(at 205.74 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "216bc563-0bc0-4447-af79-7933fdef7d63")
+	)
+	(junction
+		(at 93.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "21e320b6-a0c4-4d5d-babf-ee5274120507")
+	)
+	(junction
+		(at 185.42 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23554013-cd0d-4767-9f22-8c19a7d8c5ca")
+	)
+	(junction
+		(at 154.94 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23916c3a-0d37-416a-91d3-82a34b3ade4a")
+	)
+	(junction
+		(at 165.1 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2501dc30-a271-4271-9ca6-b085328a23ec")
+	)
+	(junction
+		(at 63.5 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2a93f9b1-4c7f-4e48-96f4-3626f1d1eee3")
+	)
+	(junction
+		(at 175.26 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2aac8e6d-b0b1-4bc6-bef2-3b4f6d53dd56")
+	)
+	(junction
+		(at 124.46 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2b2b66bc-905d-4b48-89f5-1c62f6c27dbb")
+	)
+	(junction
+		(at 134.62 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c5878fe-fb0a-42a4-a883-ea4209708ea5")
+	)
+	(junction
+		(at 154.94 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2cf168f3-fe97-43f2-b72e-223dd4e6b386")
+	)
+	(junction
+		(at 73.66 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30c9eca3-7c32-4704-8819-3599d7b84f53")
+	)
+	(junction
+		(at 93.98 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "31a1b16e-8174-4fea-bc42-9c75ed9182a0")
+	)
+	(junction
+		(at 83.82 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "344fcd9d-2f1e-43d6-a0f3-e3833b67b5c3")
+	)
+	(junction
+		(at 114.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "347306fc-87ef-43e1-a98f-ca29ac9473e6")
+	)
+	(junction
+		(at 124.46 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "352af8be-9d08-4866-961e-b8632013179f")
+	)
+	(junction
+		(at 104.14 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "356b49b0-20ac-4c33-8df8-9b27dee0b312")
+	)
+	(junction
+		(at 205.74 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3968f7a6-6ea1-4cc7-a32c-1fc47e614e0c")
+	)
+	(junction
+		(at 185.42 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3abcfbc6-0288-48d7-a0e0-144f99e6dd30")
+	)
+	(junction
+		(at 175.26 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3d5bf705-38d5-49f9-b866-c0b1e791cec7")
+	)
+	(junction
+		(at 134.62 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ddd9e62-5556-463c-9539-c0d582cc40e9")
+	)
+	(junction
+		(at 175.26 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "481456a1-3863-49d3-ab44-255934936ef4")
+	)
+	(junction
+		(at 114.3 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "490a89d7-a161-4f1a-9b45-a55729d9d59b")
+	)
+	(junction
+		(at 124.46 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c74baef-72cb-4cdf-b4eb-a3d28782257d")
+	)
+	(junction
+		(at 53.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c7a50e9-7650-493b-b0a7-057b900a13a7")
+	)
+	(junction
+		(at 63.5 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4c82cb1a-f0d3-4fc1-9a71-8dc5407edae9")
+	)
+	(junction
+		(at 165.1 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4df4e0a7-6e46-4c32-959d-094f3457d75b")
+	)
+	(junction
+		(at 43.18 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e641ba8-cbcf-42cf-89f0-ac977902bf98")
+	)
+	(junction
+		(at 73.66 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fc826ad-ef7b-406a-9b89-76eb2c211523")
+	)
+	(junction
+		(at 53.34 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4fce0301-62b3-4ef1-9bae-8d55ea745d66")
+	)
+	(junction
+		(at 185.42 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "508ddd33-e065-44a5-a999-5944a523ef76")
+	)
+	(junction
+		(at 53.34 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53bb27f5-9b54-4704-b90e-33b3053be6c4")
+	)
+	(junction
+		(at 175.26 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "56ce0611-d97b-47fb-88ed-1891d174fc71")
+	)
+	(junction
+		(at 63.5 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "670a793c-4c48-41d1-9f07-66b1d7d84b06")
+	)
+	(junction
+		(at 83.82 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "672e2ce9-8f2c-43ff-9498-0e342bc1c65e")
+	)
+	(junction
+		(at 175.26 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "69a59b36-9d74-433e-ae55-f2c4f9ba5029")
+	)
+	(junction
+		(at 63.5 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6b0b87a9-8a81-4bd1-ac24-ffcd6512236b")
+	)
+	(junction
+		(at 43.18 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6bfc7531-8adc-4c87-bf8a-788404262765")
+	)
+	(junction
+		(at 134.62 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6f50979b-4b60-48b8-a0b7-e2a6eb29d3b1")
+	)
+	(junction
+		(at 154.94 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6ff7fc69-ca50-4b66-851e-eb36da3cadd8")
+	)
+	(junction
+		(at 63.5 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "712da204-b8e1-4637-b967-521ccf7b108c")
+	)
+	(junction
+		(at 73.66 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71e77471-d824-448e-a6de-31cce05e17c2")
+	)
+	(junction
+		(at 73.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "742ecb41-f257-40d3-a6f3-d155d6036628")
+	)
+	(junction
+		(at 93.98 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "782ee96d-a257-4c78-ac0f-a3b5279bef37")
+	)
+	(junction
+		(at 53.34 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7943e9ed-5e22-49d3-a238-47d875f3e823")
+	)
+	(junction
+		(at 43.18 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7dbcae2f-e000-4aff-92b3-5518ea113182")
+	)
+	(junction
+		(at 104.14 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "822096c9-a5b4-460b-8639-9bbf1bb1a2fa")
+	)
+	(junction
+		(at 93.98 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84442e81-a253-49f6-ab0f-8ece0b39f637")
+	)
+	(junction
+		(at 53.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "86d88f2b-6e5b-493a-b3a4-5436a8374fae")
+	)
+	(junction
+		(at 104.14 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "88441b0d-9a40-4e18-8fc9-814cc1cb4d3e")
+	)
+	(junction
+		(at 185.42 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8a6c81db-4db5-4eb7-a06a-31575c90f62f")
+	)
+	(junction
+		(at 83.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8bf191a4-2dcd-4018-b67a-91aef9fad846")
+	)
+	(junction
+		(at 144.78 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d88bb99-f0e4-4a81-b464-31814877675a")
+	)
+	(junction
+		(at 205.74 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "95b0c111-7d27-49ee-a08f-b6f35d9d5b54")
+	)
+	(junction
+		(at 93.98 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "96a12dd2-d02f-4a86-aa6d-3a7015c06462")
+	)
+	(junction
+		(at 134.62 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "99c67f58-7bde-4417-a08c-823e6af847f2")
+	)
+	(junction
+		(at 124.46 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9d2b0f02-b19d-4907-8835-9e7f8a8b9c34")
+	)
+	(junction
+		(at 93.98 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a2db7df7-b835-49df-98be-3c291238016c")
+	)
+	(junction
+		(at 165.1 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a7400bf6-86c3-4d41-886e-57235a457a4c")
+	)
+	(junction
+		(at 165.1 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9baaad2-c62c-4b79-a10b-261651ef4961")
+	)
+	(junction
+		(at 205.74 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a9ece8f4-f868-428b-b7ff-a3dc07b47d6c")
+	)
+	(junction
+		(at 144.78 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aa4f9edb-d8b6-45e2-8d16-270f3c9fc990")
+	)
+	(junction
+		(at 104.14 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ab0811a2-347a-4a90-b4d0-f1b1ba038333")
+	)
+	(junction
+		(at 83.82 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b23bc3a0-3ebe-44a5-9126-8b5c4d648e08")
+	)
+	(junction
+		(at 114.3 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b5ce3eda-e357-44e1-9c69-f84009fc7a87")
+	)
+	(junction
+		(at 154.94 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b7093823-b63a-4a1a-b279-5afe0127ec9d")
+	)
+	(junction
+		(at 205.74 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b98759bc-77be-4dce-9aa2-cc5ce3889034")
+	)
+	(junction
+		(at 154.94 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b995f4ca-5e8d-4350-aff6-b7bea568d7f5")
+	)
+	(junction
+		(at 53.34 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb7d2031-8b90-4fe6-8414-ba8b40e2a3f3")
+	)
+	(junction
+		(at 154.94 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be75ea2d-b3b9-4fd0-812b-104329fac661")
+	)
+	(junction
+		(at 144.78 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "befc6138-873b-4406-bc9e-e5a72f7f36fe")
+	)
+	(junction
+		(at 83.82 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf8f640a-3a6d-49e0-9f0f-26ea7aea9fd0")
+	)
+	(junction
+		(at 134.62 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c29c26fc-c285-45ba-9e88-4c2a02375307")
+	)
+	(junction
+		(at 165.1 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c331d35d-23c9-43ea-b243-b660cb5f4bdb")
+	)
+	(junction
+		(at 134.62 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c3f1775c-0d63-41d3-b7d8-a4c96d241ce3")
+	)
+	(junction
+		(at 93.98 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c41e97f8-87c8-4e82-92ed-e4644d6f526e")
+	)
+	(junction
+		(at 205.74 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c56d20e0-377b-42bf-89fc-25b698ca10b4")
+	)
+	(junction
+		(at 114.3 68.58)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c5afc93c-0846-4cf9-8f93-4c8f2232c9fa")
+	)
+	(junction
+		(at 43.18 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c8f222f6-943e-4d7d-919b-3278ca0ede33")
+	)
+	(junction
+		(at 144.78 60.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cc2d9922-84c9-42ce-883b-c028a251c101")
+	)
+	(junction
+		(at 124.46 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cd054c4e-f9d4-4701-a538-16740432e58d")
+	)
+	(junction
+		(at 63.5 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cfd86ddc-0810-4057-8a79-4468ec7b2424")
+	)
+	(junction
+		(at 83.82 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5a179bd-82b1-4661-aebc-4c4d4801bdff")
+	)
+	(junction
+		(at 144.78 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b7ef4f-419a-421c-a02d-fd71016e6c97")
+	)
+	(junction
+		(at 185.42 121.92)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d8d69513-50ec-441c-a953-5a6c226b729f")
+	)
+	(junction
+		(at 114.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcab5abe-0f5a-44d8-b554-722164ca6a23")
+	)
+	(junction
+		(at 154.94 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dded6bb5-453a-4491-9278-65d2368e4bc0")
+	)
+	(junction
+		(at 154.94 170.18)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e46432a2-96f1-448e-8928-bfcbbf445ca9")
+	)
+	(junction
+		(at 175.26 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e543da5d-f03f-4f5d-b936-18074ebe3193")
+	)
+	(junction
+		(at 114.3 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ee17efa1-5df9-47d0-aec2-a440d8b33e4c")
+	)
+	(junction
+		(at 134.62 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f1379b2f-59c4-4b61-a98f-3645b6e5fe6b")
+	)
+	(junction
+		(at 104.14 101.6)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f24e6016-cf0c-4fe9-b584-ca06dfdbe767")
+	)
+	(junction
+		(at 43.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6f817c6-438a-4497-93b1-8dc1f36a395c")
+	)
+	(junction
+		(at 124.46 142.24)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8ac5bee-ddb1-4a9e-b1a1-2b01a1ce4bbd")
+	)
+	(junction
+		(at 144.78 162.56)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f8b3b54a-7c03-49e4-8762-b4ef31db5afd")
+	)
+	(junction
+		(at 205.74 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa2795fd-0138-4010-b310-3d5e73c1be1c")
+	)
+	(junction
+		(at 73.66 129.54)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fbda2010-a213-45bb-958d-0c9446d51e42")
+	)
+	(junction
+		(at 73.66 190.5)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc393c80-fb90-44e5-ac86-763463fd8acd")
+	)
+	(junction
+		(at 114.3 109.22)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fc6abd7a-92c0-4b05-85ed-b3bd910676e1")
+	)
+	(junction
+		(at 144.78 40.64)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdc0071f-cdad-424a-87db-7bd8a0569159")
+	)
+	(wire
+		(pts
+			(xy 154.94 68.58) (xy 175.26 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022cd994-adba-45e0-8a4a-b0b516869c19")
+	)
+	(wire
+		(pts
+			(xy 83.82 60.96) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "022d84d0-7bcb-4024-8618-6f3a7f7b41aa")
+	)
+	(wire
+		(pts
+			(xy 144.78 25.4) (xy 144.78 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0406a358-3219-4537-99c7-cfb994e5303c")
+	)
+	(wire
+		(pts
+			(xy 93.98 88.9) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0429bfe1-2992-4c6f-bb22-b2e8e5724910")
+	)
+	(wire
+		(pts
+			(xy 185.42 162.56) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "070c607f-224b-4963-a847-a5abbe4e2e9d")
+	)
+	(wire
+		(pts
+			(xy 73.66 109.22) (xy 93.98 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "07ee4d30-e80a-41ae-829d-e3cecf87d77e")
+	)
+	(wire
+		(pts
+			(xy 114.3 48.26) (xy 134.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0897e94f-d1e3-47ff-89f6-5de7a1349783")
+	)
+	(wire
+		(pts
+			(xy 205.74 68.58) (xy 205.74 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aee33c0-3781-43dc-99cb-690f399192cd")
+	)
+	(wire
+		(pts
+			(xy 198.12 149.86) (xy 175.26 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0da59c6a-2c3c-449a-a3b7-c0b90d039443")
+	)
+	(wire
+		(pts
+			(xy 43.18 40.64) (xy 43.18 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f76c070-bcf8-4924-a8c5-3abe13c36f41")
+	)
+	(wire
+		(pts
+			(xy 63.5 81.28) (xy 63.5 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ef6261-91ba-4d4c-99ef-8991b7c91dc8")
+	)
+	(wire
+		(pts
+			(xy 104.14 101.6) (xy 104.14 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12080e73-a151-4804-ac9b-ac3ac13653e9")
+	)
+	(wire
+		(pts
+			(xy 73.66 48.26) (xy 93.98 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "12a939e2-2ab8-4d74-a5c9-6d61a9528b6e")
+	)
+	(wire
+		(pts
+			(xy 154.94 190.5) (xy 175.26 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "15b0be77-2720-4b9e-8da7-956cf862467d")
+	)
+	(wire
+		(pts
+			(xy 93.98 190.5) (xy 114.3 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1767f007-bd12-458a-9e69-f01cc8a5ed24")
+	)
+	(wire
+		(pts
+			(xy 104.14 25.4) (xy 104.14 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af5b449-9a68-414b-a41f-d6f6cba715a8")
+	)
+	(wire
+		(pts
+			(xy 73.66 81.28) (xy 83.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c0140d1-6775-49db-9fd5-7ecf63ae1284")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 134.62 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "211f763f-7ef6-4fb5-98df-2e2ff37faa42")
+	)
+	(wire
+		(pts
+			(xy 63.5 40.64) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "23f46f84-f16d-4b0b-b463-c2c0244adcc0")
+	)
+	(wire
+		(pts
+			(xy 33.02 129.54) (xy 53.34 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24da3fea-844d-4666-b730-f8d7b708f242")
+	)
+	(wire
+		(pts
+			(xy 185.42 40.64) (xy 185.42 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "265c8115-55ea-4d09-95c1-3178314bfa04")
+	)
+	(wire
+		(pts
+			(xy 53.34 129.54) (xy 73.66 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26f78b89-ba4b-4b48-90d1-1245694ead6f")
+	)
+	(wire
+		(pts
+			(xy 83.82 162.56) (xy 83.82 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2703e5ce-9651-45e1-8bd6-144e60387b78")
+	)
+	(wire
+		(pts
+			(xy 33.02 109.22) (xy 53.34 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2832f642-62e7-4a51-b112-f728658e7714")
+	)
+	(wire
+		(pts
+			(xy 53.34 68.58) (xy 73.66 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "29a0e612-9a4c-422c-a9b8-8a9fe3879b8a")
+	)
+	(wire
+		(pts
+			(xy 83.82 101.6) (xy 83.82 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a44e441-f6d5-4994-b7ba-34283a1facc7")
+	)
+	(wire
+		(pts
+			(xy 124.46 121.92) (xy 124.46 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a60a5d5-73f3-4ce9-bda4-0f0fab82f0f0")
+	)
+	(wire
+		(pts
+			(xy 114.3 149.86) (xy 134.62 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a65926a-d988-49f6-92e7-6e4d5936462f")
+	)
+	(wire
+		(pts
+			(xy 165.1 162.56) (xy 165.1 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2afd7500-0a15-4710-acc0-4f03472785c3")
+	)
+	(wire
+		(pts
+			(xy 165.1 60.96) (xy 165.1 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2b8c9def-eaec-4abd-b08a-c3613e6389df")
+	)
+	(wire
+		(pts
+			(xy 53.34 109.22) (xy 73.66 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d1d7d99-fe56-43a5-ab91-5840fd9bf3dd")
+	)
+	(wire
+		(pts
+			(xy 124.46 25.4) (xy 124.46 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3115f7a7-e786-49c1-9e4c-25c171cfeb33")
+	)
+	(wire
+		(pts
+			(xy 73.66 68.58) (xy 93.98 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3197b37c-ee5b-406a-ab67-08670d4b8c09")
+	)
+	(wire
+		(pts
+			(xy 154.94 170.18) (xy 175.26 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3a0ad538-3c94-4a03-ba14-d3e55855f87e")
+	)
+	(wire
+		(pts
+			(xy 134.62 68.58) (xy 154.94 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b15c81d-3687-4710-9aa6-d57ee4885603")
+	)
+	(wire
+		(pts
+			(xy 63.5 121.92) (xy 63.5 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3ba1621d-2d7d-4a08-ab33-d42d9d3ea1a5")
+	)
+	(wire
+		(pts
+			(xy 114.3 190.5) (xy 134.62 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3cd8eed4-eef6-4c5e-921e-c5fc2e148fbb")
+	)
+	(wire
+		(pts
+			(xy 154.94 48.26) (xy 175.26 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3fe99eb3-808c-4fd5-8bf0-8eed87e32524")
+	)
+	(wire
+		(pts
+			(xy 73.66 170.18) (xy 93.98 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40ad23e4-b284-4d51-a92e-26a2272af251")
+	)
+	(wire
+		(pts
+			(xy 165.1 121.92) (xy 165.1 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "411efa8a-c2b6-469e-b517-3b3f24ffe025")
+	)
+	(wire
+		(pts
+			(xy 198.12 170.18) (xy 175.26 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "42af6faa-4e9d-48bc-991c-1d19263dafd6")
+	)
+	(wire
+		(pts
+			(xy 73.66 190.5) (xy 93.98 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "432577d5-87d0-4924-a72a-e407dd2ee4b0")
+	)
+	(wire
+		(pts
+			(xy 134.62 170.18) (xy 154.94 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44b0d7a3-542f-48ea-8a2f-25ca02bd7f05")
+	)
+	(wire
+		(pts
+			(xy 53.34 170.18) (xy 73.66 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4554fe48-1b8d-466c-b3f4-c87fb3d79947")
+	)
+	(wire
+		(pts
+			(xy 43.18 60.96) (xy 43.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456f0365-d37d-43a2-afac-d06c44cc48af")
+	)
+	(wire
+		(pts
+			(xy 154.94 129.54) (xy 175.26 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "462b3865-9668-49d6-a9d9-1406a843104e")
+	)
+	(wire
+		(pts
+			(xy 114.3 88.9) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "473d672b-6459-459b-93fc-780e5d8f9818")
+	)
+	(wire
+		(pts
+			(xy 124.46 81.28) (xy 124.46 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "495f9334-ca7f-4aa5-8d75-09576f1afa2c")
+	)
+	(wire
+		(pts
+			(xy 165.1 81.28) (xy 165.1 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f7b113-f5f8-43e0-9da7-2a02dc224210")
+	)
+	(wire
+		(pts
+			(xy 33.02 190.5) (xy 53.34 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55243e41-6164-4661-b707-a6f503f12968")
+	)
+	(wire
+		(pts
+			(xy 53.34 190.5) (xy 73.66 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "557847f5-42a8-4c4a-a4d9-d21678c28920")
+	)
+	(wire
+		(pts
+			(xy 104.14 60.96) (xy 104.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5837ecd4-cf70-4c14-9c7b-bb5f05f8274a")
+	)
+	(wire
+		(pts
+			(xy 104.14 81.28) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5b6ae0de-21c8-4433-a4e0-a3b552474fb0")
+	)
+	(wire
+		(pts
+			(xy 134.62 48.26) (xy 154.94 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5d63c1a3-5086-42ca-8afa-60afe2472b23")
+	)
+	(wire
+		(pts
+			(xy 53.34 88.9) (xy 73.66 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "60b5d548-d07f-40b1-8e16-72d513f499f2")
+	)
+	(wire
+		(pts
+			(xy 154.94 109.22) (xy 175.26 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6196eb37-90e9-4f6c-80ae-9b758a88c740")
+	)
+	(wire
+		(pts
+			(xy 93.98 109.22) (xy 114.3 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6414e19f-a27a-435d-a47f-a63cba9086f1")
+	)
+	(wire
+		(pts
+			(xy 134.62 109.22) (xy 154.94 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "64344100-c91d-4b5c-a8eb-9406d47360dd")
+	)
+	(wire
+		(pts
+			(xy 33.02 68.58) (xy 53.34 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "68161b0c-a285-475d-a645-59648d12bc07")
+	)
+	(wire
+		(pts
+			(xy 134.62 149.86) (xy 154.94 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "690a405c-1ac3-4b57-a93b-778dda168d2c")
+	)
+	(wire
+		(pts
+			(xy 134.62 190.5) (xy 154.94 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6b21e6c7-ab97-41de-aae4-339e943db88e")
+	)
+	(wire
+		(pts
+			(xy 165.1 40.64) (xy 165.1 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d9364f2-aacd-4c12-a2bc-a787d4a6bdfc")
+	)
+	(wire
+		(pts
+			(xy 205.74 149.86) (xy 205.74 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6f77a68c-1e32-433a-820e-9683e6fd5e12")
+	)
+	(wire
+		(pts
+			(xy 205.74 88.9) (xy 205.74 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70c6e975-f457-4759-9791-1d1de45afbb3")
+	)
+	(wire
+		(pts
+			(xy 198.12 48.26) (xy 175.26 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70d9ae1f-ad85-40a1-ab0c-659459f5e5b0")
+	)
+	(wire
+		(pts
+			(xy 134.62 129.54) (xy 154.94 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70f3f37d-4259-413e-b59a-babccfdc3a89")
+	)
+	(wire
+		(pts
+			(xy 43.18 121.92) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "727cc522-ef34-45d4-b711-997054ff0b37")
+	)
+	(wire
+		(pts
+			(xy 33.02 48.26) (xy 53.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "737596e8-f579-4b1f-aa71-a489d8ba56da")
+	)
+	(wire
+		(pts
+			(xy 93.98 149.86) (xy 114.3 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "770cc50c-0085-42e2-b068-cd0ae3b59919")
+	)
+	(wire
+		(pts
+			(xy 205.74 25.4) (xy 205.74 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "794205f1-2f7e-4200-b59c-c02481b0416f")
+	)
+	(wire
+		(pts
+			(xy 73.66 88.9) (xy 93.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79a42c80-d7a4-4e03-9070-f9fff835a239")
+	)
+	(wire
+		(pts
+			(xy 33.02 40.64) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a4231d0-fb4b-4c65-9cc1-75d3ed714150")
+	)
+	(wire
+		(pts
+			(xy 198.12 129.54) (xy 175.26 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a99f1c9-db3a-491d-88bf-362ef230f8fa")
+	)
+	(wire
+		(pts
+			(xy 185.42 142.24) (xy 185.42 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7caa1de0-1c5d-4933-9515-38159a29c856")
+	)
+	(wire
+		(pts
+			(xy 165.1 25.4) (xy 165.1 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8506f273-12d6-426d-910b-0c9eecbe3765")
+	)
+	(wire
+		(pts
+			(xy 154.94 149.86) (xy 175.26 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "869288c6-9182-45ca-8025-5bf497b3633a")
+	)
+	(wire
+		(pts
+			(xy 134.62 88.9) (xy 154.94 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "86d6e974-6898-4932-91cb-e8a4c4c283b7")
+	)
+	(wire
+		(pts
+			(xy 104.14 162.56) (xy 104.14 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c3cf446-d0cc-4b1b-9218-75f38db02fb3")
+	)
+	(wire
+		(pts
+			(xy 93.98 48.26) (xy 114.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8d73bae8-988b-435b-a882-ae9668b41d7e")
+	)
+	(wire
+		(pts
+			(xy 104.14 142.24) (xy 104.14 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dd624a1-3da3-42c1-929d-9366cd043e3d")
+	)
+	(wire
+		(pts
+			(xy 205.74 48.26) (xy 205.74 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8f339462-56e0-4361-9d9b-983c75fb21ef")
+	)
+	(wire
+		(pts
+			(xy 33.02 88.9) (xy 53.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "909384ab-bc1c-47d8-a34d-c3d137febfc2")
+	)
+	(wire
+		(pts
+			(xy 124.46 101.6) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91eea887-ea8a-4221-ba92-e5ec1caacc4f")
+	)
+	(wire
+		(pts
+			(xy 124.46 142.24) (xy 124.46 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "94397688-ce0e-48d4-a59c-7257120bf834")
+	)
+	(wire
+		(pts
+			(xy 185.42 60.96) (xy 185.42 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96776fa9-dbd1-46ef-91bd-e95f23cda112")
+	)
+	(wire
+		(pts
+			(xy 114.3 109.22) (xy 134.62 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c79c76c-a95b-401f-9edb-a06a0cceaa4b")
+	)
+	(wire
+		(pts
+			(xy 53.34 48.26) (xy 73.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9d5ec847-5716-4125-b40b-fdbd3a1587a7")
+	)
+	(wire
+		(pts
+			(xy 165.1 101.6) (xy 165.1 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f711890-a6d6-4440-8bc1-ed469cb6acc4")
+	)
+	(wire
+		(pts
+			(xy 93.98 101.6) (xy 104.14 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a226d887-7662-4dbd-b58b-e683f5d85955")
+	)
+	(wire
+		(pts
+			(xy 124.46 40.64) (xy 124.46 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a67c0815-f186-4f70-926f-1b264c84d8d8")
+	)
+	(wire
+		(pts
+			(xy 154.94 162.56) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a803bbba-64cc-448d-a04f-7f03127ebddd")
+	)
+	(wire
+		(pts
+			(xy 53.34 60.96) (xy 63.5 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8b2f54a-5770-4ce0-a536-efbd997d7a20")
+	)
+	(wire
+		(pts
+			(xy 53.34 149.86) (xy 73.66 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aac914ea-c9a3-4a8f-94e1-1f91cdd136a3")
+	)
+	(wire
+		(pts
+			(xy 93.98 129.54) (xy 114.3 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab578e4e-a4bf-4ab4-80fc-d97d4aea6370")
+	)
+	(wire
+		(pts
+			(xy 83.82 121.92) (xy 83.82 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad3d1aaf-ac2d-4bdd-a33a-c7050cdade73")
+	)
+	(wire
+		(pts
+			(xy 93.98 68.58) (xy 114.3 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aea6a633-b213-403d-b447-42d91d3ab4da")
+	)
+	(wire
+		(pts
+			(xy 114.3 170.18) (xy 134.62 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3e14390-7dc6-416b-bbd5-cdf868192ca4")
+	)
+	(wire
+		(pts
+			(xy 73.66 129.54) (xy 93.98 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3f6f053-44f0-4391-9873-b6231b8014db")
+	)
+	(wire
+		(pts
+			(xy 144.78 101.6) (xy 144.78 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7b2475f-30dc-4ea2-b799-96c21242154c")
+	)
+	(wire
+		(pts
+			(xy 83.82 81.28) (xy 83.82 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8cdca18-a7ef-4771-9b6b-7140c8fe7ed5")
+	)
+	(wire
+		(pts
+			(xy 205.74 170.18) (xy 205.74 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba045c1c-f33c-4ee8-bfe6-db2af30446e4")
+	)
+	(wire
+		(pts
+			(xy 43.18 101.6) (xy 43.18 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bb49a3de-620b-45ad-a54c-29dcceaf0796")
+	)
+	(wire
+		(pts
+			(xy 144.78 121.92) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bf12198a-9e62-45c3-b466-f5d86de75219")
+	)
+	(wire
+		(pts
+			(xy 63.5 25.4) (xy 63.5 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1a940de-fa49-4106-a8b9-697952eec2a2")
+	)
+	(wire
+		(pts
+			(xy 104.14 121.92) (xy 104.14 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c298ba49-6974-4340-859f-5d5a2b4132ff")
+	)
+	(wire
+		(pts
+			(xy 175.26 182.88) (xy 185.42 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c3f1f747-e966-4c2c-8090-4f190e07864a")
+	)
+	(wire
+		(pts
+			(xy 124.46 162.56) (xy 124.46 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6080a0e-4059-4120-b2e7-12c9aff607b7")
+	)
+	(wire
+		(pts
+			(xy 124.46 60.96) (xy 124.46 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c950d145-c024-47a8-ba57-97efd7bb658b")
+	)
+	(wire
+		(pts
+			(xy 154.94 88.9) (xy 175.26 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c980f191-a655-4149-a076-6b096870a525")
+	)
+	(wire
+		(pts
+			(xy 144.78 142.24) (xy 144.78 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ca92ed7f-ae97-4c0c-81e4-820de1c001c1")
+	)
+	(wire
+		(pts
+			(xy 63.5 60.96) (xy 63.5 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb0b70bc-5356-48db-954a-95ddc89ced6c")
+	)
+	(wire
+		(pts
+			(xy 205.74 109.22) (xy 205.74 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdde081d-7bdd-42e6-869e-3ff07b8b464b")
+	)
+	(wire
+		(pts
+			(xy 198.12 109.22) (xy 175.26 109.22)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ce3513a3-7030-4d5c-af7c-adab3e5b7829")
+	)
+	(wire
+		(pts
+			(xy 185.42 121.92) (xy 185.42 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cee2f4f4-6cbc-4838-b71a-3189173bbcfe")
+	)
+	(wire
+		(pts
+			(xy 83.82 40.64) (xy 83.82 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cff15ec3-f29c-4d36-8776-64c5d29be534")
+	)
+	(wire
+		(pts
+			(xy 83.82 25.4) (xy 83.82 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1088709-a9b9-4e05-8ea2-f87942ee2796")
+	)
+	(wire
+		(pts
+			(xy 73.66 149.86) (xy 93.98 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1347903-ae03-46a2-a707-154093060583")
+	)
+	(wire
+		(pts
+			(xy 144.78 40.64) (xy 144.78 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2183fb3-afd3-46ca-955e-993ea31aa5d3")
+	)
+	(wire
+		(pts
+			(xy 185.42 25.4) (xy 185.42 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d2951d7e-82c5-4b56-9a90-ca8ae6d71e44")
+	)
+	(wire
+		(pts
+			(xy 43.18 162.56) (xy 43.18 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d56982aa-6580-4d04-83ea-6bf3a85282cc")
+	)
+	(wire
+		(pts
+			(xy 185.42 101.6) (xy 185.42 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d675b927-bdff-4eac-82e7-3f468caedaf2")
+	)
+	(wire
+		(pts
+			(xy 43.18 142.24) (xy 43.18 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d76ad758-0ae0-4ce6-9f67-c689c066c744")
+	)
+	(wire
+		(pts
+			(xy 33.02 149.86) (xy 53.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da80b027-904b-4ca2-99c6-5937c80c825c")
+	)
+	(wire
+		(pts
+			(xy 63.5 142.24) (xy 63.5 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "db492971-48ff-4667-996c-f5d540a20741")
+	)
+	(wire
+		(pts
+			(xy 165.1 142.24) (xy 165.1 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dccfde3a-ff1d-42ec-97d5-a8f6cccea832")
+	)
+	(wire
+		(pts
+			(xy 33.02 170.18) (xy 53.34 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "de8e54c6-84d9-47e5-8f08-dc3e96b8afdb")
+	)
+	(wire
+		(pts
+			(xy 43.18 81.28) (xy 43.18 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df5c3763-e66c-46c4-9070-0f73d8115bc4")
+	)
+	(wire
+		(pts
+			(xy 205.74 129.54) (xy 205.74 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dfb5a082-e4d5-46ea-8dc8-c65064cd598b")
+	)
+	(wire
+		(pts
+			(xy 93.98 170.18) (xy 114.3 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e2dd35e8-7a9e-4c46-80ce-a9b70434b9bb")
+	)
+	(wire
+		(pts
+			(xy 144.78 81.28) (xy 144.78 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e444742a-24b1-4bbf-b7ee-438e6dffc9cc")
+	)
+	(wire
+		(pts
+			(xy 114.3 121.92) (xy 124.46 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e6d06035-ccb7-4d3e-ae70-d73150e65bbb")
+	)
+	(wire
+		(pts
+			(xy 114.3 129.54) (xy 134.62 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99ce7c9-d0ee-4d36-aaba-3d8f9465eefa")
+	)
+	(wire
+		(pts
+			(xy 63.5 101.6) (xy 63.5 121.92)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "edeeb0d9-51cc-411d-aac4-77f10b619702")
+	)
+	(wire
+		(pts
+			(xy 104.14 40.64) (xy 104.14 60.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5c9f05-d71b-4562-9939-852432c066c5")
+	)
+	(wire
+		(pts
+			(xy 144.78 162.56) (xy 144.78 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "efa47227-d3f9-4214-af64-a7e9107c0edb")
+	)
+	(wire
+		(pts
+			(xy 198.12 190.5) (xy 175.26 190.5)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f03d9d15-7d07-44a8-9513-609786ba48ec")
+	)
+	(wire
+		(pts
+			(xy 144.78 60.96) (xy 144.78 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f0ce7c2b-d80c-49f2-bf63-62b750f7ca47")
+	)
+	(wire
+		(pts
+			(xy 198.12 88.9) (xy 175.26 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f20ebf37-e65b-4aeb-a205-d06b5686157f")
+	)
+	(wire
+		(pts
+			(xy 198.12 68.58) (xy 175.26 68.58)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f3441c62-c2bc-4e2d-8ece-acf37a6441d0")
+	)
+	(wire
+		(pts
+			(xy 63.5 162.56) (xy 63.5 182.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f5658dea-a5b6-4ba9-9360-11c3315c15be")
+	)
+	(wire
+		(pts
+			(xy 134.62 142.24) (xy 144.78 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f781a362-e0d4-48be-9d13-5686e05b406f")
+	)
+	(wire
+		(pts
+			(xy 43.18 25.4) (xy 43.18 40.64)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fa765e67-a220-4a00-944c-7663298f0ead")
+	)
+	(wire
+		(pts
+			(xy 83.82 142.24) (xy 83.82 162.56)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fcc2b499-a70e-45e6-ad42-f6f5fcc59a3b")
+	)
+	(wire
+		(pts
+			(xy 185.42 81.28) (xy 185.42 101.6)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ffe6085a-a7be-4653-b911-c10de4574454")
+	)
+	(global_label "IO 3"
+		(shape bidirectional)
+		(at 104.14 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "24ec698b-5cae-4571-b9c4-c0e35d64a64d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 104.14 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 1"
+		(shape bidirectional)
+		(at 63.5 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "2d4b15a5-8b6c-4ca3-a7bb-7848c8036590")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 63.5 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 7"
+		(shape bidirectional)
+		(at 185.42 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "45d4e03e-6cff-41ce-b946-708382da0601")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 185.42 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 0"
+		(shape bidirectional)
+		(at 43.18 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "465a517d-f0e1-4825-8675-1cce54bfa7a5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 43.18 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "INTR"
+		(shape bidirectional)
+		(at 205.74 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "4e12b932-2346-4e84-b5a4-80468334f3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 213.93 25.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 2"
+		(shape bidirectional)
+		(at 83.82 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "70d42e66-a74c-4de2-af96-d1860851d3fb")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 83.82 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 165.1 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 165.1 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 5"
+		(shape bidirectional)
+		(at 144.78 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "d44cceb0-f409-4e5f-a98a-9feead2e845d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 144.78 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "IO 4"
+		(shape bidirectional)
+		(at 124.46 25.4 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "f36f49e4-227f-479f-b914-786aa44dd568")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 124.46 17.2705 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 190.5 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0188dba3-054f-4958-9440-27c9ca673633")
+		(property "Reference" "DI7"
+			(at 201.93 186.69 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 193.04 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 190.5 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "deea1889-824f-4f7a-a6be-9546db353c85")
+		)
+		(pin "2"
+			(uuid "2080be86-a538-40a8-8f30-ead2a96d02d3")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0263b847-a932-4a31-9f35-35bb23f7000d")
+		(property "Reference" "D62"
+			(at 152.4 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc2e60ca-c74f-4e4b-a0a0-9705327e9578")
+		)
+		(pin "2"
+			(uuid "d12efbfe-85ac-442f-8c0f-ddbe5646c7d5")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D62")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04430572-8314-4d21-974c-22350cead1a6")
+		(property "Reference" "DS1"
+			(at 55.88 65.405 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 55.88 62.865 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3e433df4-9fec-4cfb-b60f-eebca7c574cf")
+		)
+		(pin "2"
+			(uuid "9bcc1487-0612-4bdb-a2de-a8b2f590b28f")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 44.45 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "080aaa87-0974-4a77-bf63-185495f411a0")
+		(property "Reference" "DS0"
+			(at 35.56 45.085 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 35.56 42.545 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0bfacad1-28fd-4f2e-93dc-68f478b8a6ba")
+		)
+		(pin "2"
+			(uuid "376f73f9-79fa-4153-ae38-31ed5446db52")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "09d14922-c46a-4bf1-bb2c-1d224060568c")
+		(property "Reference" "D40"
+			(at 111.76 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c2f1a1d2-df3d-4680-9706-2ca411fa6890")
+		)
+		(pin "2"
+			(uuid "f58fd788-6016-46e7-b903-3606dd2ec21d")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D40")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 149.86 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d18473f-e37a-4136-b721-5a2e40e4f8ed")
+		(property "Reference" "DI5"
+			(at 201.93 146.05 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 152.4 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 149.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5a885ca-5076-44e6-9a84-d07474947dde")
+		)
+		(pin "2"
+			(uuid "047b5b54-de8b-4afc-abc2-c6d1f2d17bd2")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 170.18 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0ef17723-f7f8-4fdb-8913-5a4ceefbc065")
+		(property "Reference" "DI6"
+			(at 201.93 166.37 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 172.72 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 170.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "df5a6b10-ba48-4f34-96ce-3832d480a7ee")
+		)
+		(pin "2"
+			(uuid "59f34a55-6ac4-496d-8c40-1b8f1eafbcb5")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0fadd319-be81-4c25-8d23-e7495a114aa7")
+		(property "Reference" "RC4-0"
+			(at 119.38 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "efb1c47f-fe25-4bea-8081-43d3c19de5cd")
+		)
+		(pin "2"
+			(uuid "9138c970-6e3d-46df-9354-5174df2a4e52")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0ff76361-9578-4f9f-a20c-f042e24a7755")
+		(property "Reference" "D5"
+			(at 30.48 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "215dbe63-78d5-4c5a-ae6e-aa6f73ab7e06")
+		)
+		(pin "2"
+			(uuid "cd1f2b01-8443-4a0a-8ce8-ea0d6bc111da")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "11f01cd8-f751-497f-9599-50fe1fc0a618")
+		(property "Reference" "RC5-4"
+			(at 139.7 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc28293-fab9-4f93-b3d5-ca9ee69110c4")
+		)
+		(pin "2"
+			(uuid "088ac770-af1e-4c4f-ad11-5b44a20594d8")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "13ddd48d-7d2b-415d-b8fa-15c71e245acc")
+		(property "Reference" "D61"
+			(at 152.4 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "745d89b9-e75a-40ae-97bc-d1eadf220f02")
+		)
+		(pin "2"
+			(uuid "7ff3a9ae-64ca-4ad0-bc63-dacab15ecf0e")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D61")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1b13866a-6fbf-441b-9c64-56258379f43a")
+		(property "Reference" "D65"
+			(at 152.4 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c70f4670-9685-4aab-ac4f-4ebaf44d5847")
+		)
+		(pin "2"
+			(uuid "8b9c860d-59e1-424e-a148-1aa2c0db4056")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D65")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d2a13d5-1bca-4bb1-bf83-5b5cb3077c3a")
+		(property "Reference" "RC6-4"
+			(at 160.02 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3427b432-e194-40af-9dcb-04dccafe2b0f")
+		)
+		(pin "2"
+			(uuid "8af48a1b-2c49-47d9-959c-ee33cdd6f977")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1e5f084d-4db5-48ad-a2a3-76f186559614")
+		(property "Reference" "RC3-1"
+			(at 99.06 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05e6d5ac-3dbc-44e7-ab3b-09a3816be3aa")
+		)
+		(pin "2"
+			(uuid "40b7f115-b5d7-4fa0-b12b-c1c7b6866feb")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "22a72d93-d5b5-4a6b-95f6-755ac10ccf50")
+		(property "Reference" "RC4-7"
+			(at 119.38 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "18c97ab1-62df-42bc-9dfa-dba3415ee8e2")
+		)
+		(pin "2"
+			(uuid "ff0eb9a3-538a-4ebf-a42b-97fe870ddfea")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "244b7f9d-3923-4908-be6d-02c49eb4663c")
+		(property "Reference" "RC2-3"
+			(at 78.74 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1d79440a-2f90-4c0b-8d60-528615b0bd65")
+		)
+		(pin "2"
+			(uuid "7f1d0566-f385-4126-b190-2379308ed05b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 166.37 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2518146c-59f4-45b7-a4fa-f618686ab064")
+		(property "Reference" "DS6"
+			(at 157.48 167.005 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 157.48 164.465 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cee2f461-8f62-48d8-ac7b-1698deb984c1")
+		)
+		(pin "2"
+			(uuid "460b9088-619c-4166-a615-45e17ecf1f0d")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2519cd5e-8ecf-41a4-a9d0-5b856882cb05")
+		(property "Reference" "D63"
+			(at 152.4 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ea1c9827-ebfa-43f1-b2c6-5a572466713e")
+		)
+		(pin "2"
+			(uuid "0496ba9c-818c-4d39-979a-e8785e06d12a")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D63")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "28137b00-0d76-493b-92b8-23037474163f")
+		(property "Reference" "RC1-3"
+			(at 58.42 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc6bb7bc-50f2-4b6c-a405-b8f7797f3de3")
+		)
+		(pin "2"
+			(uuid "41d35b0f-21b5-4da8-92df-229c816b63c5")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2a208574-f638-4917-a68f-bc3ff176d324")
+		(property "Reference" "D75"
+			(at 172.72 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "503e8179-7a4a-4075-8fcf-2d7bb00a3908")
+		)
+		(pin "2"
+			(uuid "a744b0f2-49c4-46a7-9ec2-cefb21173879")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D75")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2c50947a-4bb9-43c2-b65c-4726e224b6b0")
+		(property "Reference" "RC3-0"
+			(at 99.06 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f049e2c7-0e76-4c0d-9aa1-dc797d8fdd4b")
+		)
+		(pin "2"
+			(uuid "30241adf-a2e7-4976-a53a-5c267616618e")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30340eba-9ed0-42ff-b11f-98a864f7223e")
+		(property "Reference" "RC1-4"
+			(at 58.42 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aa956a67-c26e-4a57-9ddb-59688a6476ad")
+		)
+		(pin "2"
+			(uuid "23cd0d93-5050-40ea-9d49-879bbcbb8bcd")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "30b60f6a-8d20-44dd-b832-1906a957c513")
+		(property "Reference" "D54"
+			(at 132.08 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5c2ad1a4-b254-49a0-8435-d3a374353ffc")
+		)
+		(pin "2"
+			(uuid "27a3cb64-baf1-430a-b797-bd52c0e46cbe")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D54")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "310fec10-f10c-41d7-9446-87c12744e146")
+		(property "Reference" "D26"
+			(at 71.12 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e1d524d3-5d24-4c87-b480-74c57a74b567")
+		)
+		(pin "2"
+			(uuid "c0e9aa05-6318-4fdc-abee-cb43875c8e46")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D26")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35827986-7004-4f70-a10a-6ceb42f33d9f")
+		(property "Reference" "RC1-2"
+			(at 58.42 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "879d3b07-b41e-4233-b196-e223f635bdf3")
+		)
+		(pin "2"
+			(uuid "641f8ea7-6306-4550-92c8-e3cc0ed3e5a5")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "369ff51e-db51-4132-aa26-7b5d981cba74")
+		(property "Reference" "D17"
+			(at 50.8 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b5adb2f-c180-494e-86cd-ef0a68591be2")
+		)
+		(pin "2"
+			(uuid "24774a87-3207-4ab9-a94d-2b9e1b568e65")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D17")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "37da2014-affc-4731-b642-c4245ff411f2")
+		(property "Reference" "RC5-7"
+			(at 139.7 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ac410347-ba8b-493b-832e-a3f9e3359951")
+		)
+		(pin "2"
+			(uuid "4aa3f0e8-ff28-4f49-bfbe-75cf9f8a7c2b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38fc0c4b-ef9c-48bf-b61c-3d1e8cb92976")
+		(property "Reference" "D43"
+			(at 111.76 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6fb6c4-b36c-4ff1-879b-43826c273a72")
+		)
+		(pin "2"
+			(uuid "198c65f6-b3df-4780-9f6d-1c910e870a1b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D43")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3a9b19be-43ef-409c-9489-c069efbfa3ee")
+		(property "Reference" "RC0-7"
+			(at 38.1 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "898cdd62-8ad6-4d58-b6f7-f4db79a4cca2")
+		)
+		(pin "2"
+			(uuid "277b2226-c100-403c-a519-ef9cdc3923fe")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ac53e86-aa26-4394-9e99-e33f3c863b14")
+		(property "Reference" "RC7-1"
+			(at 180.34 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e6efb38c-f391-43d6-9511-8c7da50b3d51")
+		)
+		(pin "2"
+			(uuid "03dd1ed8-eebf-4c13-9ef2-1b79e9d6b73f")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef0222e-2eac-4930-ac36-0f395f4593b6")
+		(property "Reference" "RC1-0"
+			(at 58.42 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "20f0b9b8-9322-4d89-a423-dd3d807d99ff")
+		)
+		(pin "2"
+			(uuid "ce54609e-9d1d-4a3b-81a2-5a384dbe41c8")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ef86e49-a152-4515-afb0-4098f497c742")
+		(property "Reference" "D31"
+			(at 91.44 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2b4e4f85-02b3-4bd8-8346-5f9ac3f51e4a")
+		)
+		(pin "2"
+			(uuid "b917ad78-96a8-428f-ad4f-d49149b5b97b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D31")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "402f0f46-5eb8-421b-9b9f-01a54b5cfa87")
+		(property "Reference" "RC4-1"
+			(at 119.38 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cb206c0-1fab-4ac5-b301-f9678369525b")
+		)
+		(pin "2"
+			(uuid "b99c2ecc-04a5-4c54-a491-d99fe2562dcc")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40d8058d-714e-4f99-a508-f64f9c8b575b")
+		(property "Reference" "D60"
+			(at 152.4 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66710233-d2ab-4921-aa86-488ee87fbb3a")
+		)
+		(pin "2"
+			(uuid "a9636da9-222c-478f-bc5b-71d3f0473300")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D60")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "430b936d-b8ad-4c28-b93d-4046aec980c7")
+		(property "Reference" "D67"
+			(at 152.4 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9255475-7a77-44cc-9bd9-589d63ced82b")
+		)
+		(pin "2"
+			(uuid "9cccdf4d-7cc5-4ab6-bae6-dc3087913f3b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D67")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "433f3f09-0867-41a3-8ac6-5f00bd3314fc")
+		(property "Reference" "D32"
+			(at 91.44 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11a29637-fd50-4473-bb70-d4116312a4f5")
+		)
+		(pin "2"
+			(uuid "53f6307d-8380-45e9-b3fa-4d05a2bd575d")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D32")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44499808-710f-44ae-bed2-0632db78b8c8")
+		(property "Reference" "D71"
+			(at 172.72 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f8805b31-9770-4092-b10a-101cf112fd76")
+		)
+		(pin "2"
+			(uuid "9f3056b1-b197-421f-9d54-08cf5cc88970")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D71")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44de9323-bd5d-49cd-bf0a-70392801309d")
+		(property "Reference" "D45"
+			(at 111.76 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb2b185b-5d98-46b8-8516-9e5c980291cf")
+		)
+		(pin "2"
+			(uuid "f730da3b-5ef9-4abc-8c8d-0794fe3feb87")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D45")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "454ad926-1c6a-4aa4-b6f8-25297463de18")
+		(property "Reference" "RC3-2"
+			(at 99.06 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0aebfce-7e76-40f1-83ef-5914b8ebbcc7")
+		)
+		(pin "2"
+			(uuid "744fce2b-a15c-45a6-92b0-e880efafb5f6")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 48.26 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "46348ccc-126c-461a-8e39-f93f389ddaa7")
+		(property "Reference" "DI0"
+			(at 201.93 44.45 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 50.8 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c86bf5fa-c113-44c1-b93d-7a5d4ac11904")
+		)
+		(pin "2"
+			(uuid "dbd8322f-50c7-4271-821c-b0005fd066b2")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a7f7b3d-918b-431a-b79d-c66494b3ec50")
+		(property "Reference" "D52"
+			(at 132.08 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd114d76-87b2-4089-b211-b7b541ac42b3")
+		)
+		(pin "2"
+			(uuid "a360aa38-116c-4dd0-a569-f6a7a5a88a05")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D52")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 154.94 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4d978207-10b9-4a43-a474-2e66421925a0")
+		(property "Reference" "D64"
+			(at 152.4 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 152.4 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 154.94 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "27529674-e97c-460d-9de8-89cd61c8a6eb")
+		)
+		(pin "2"
+			(uuid "57e77ee6-e62d-402e-a614-a833da3fbafb")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D64")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5466fd2d-f22f-409b-b7da-f8d297aeb7a2")
+		(property "Reference" "RC6-5"
+			(at 160.02 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffdd8419-9afa-4f38-bfbf-7dc4e869b438")
+		)
+		(pin "2"
+			(uuid "0db27643-51f5-4634-a791-2c4813885195")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5518d7f7-6de1-409b-a6d0-90efa78c0b82")
+		(property "Reference" "D7"
+			(at 30.48 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9bdf2265-17dd-4712-9f75-996577068823")
+		)
+		(pin "2"
+			(uuid "cd2654f9-f2c1-4ff7-bbce-8fe664862762")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "553a576d-44a1-4bad-9211-394526206f63")
+		(property "Reference" "D41"
+			(at 111.76 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4a035e61-91c9-41ba-9328-bc9b284e86c2")
+		)
+		(pin "2"
+			(uuid "8628539f-d3cd-4957-a6bb-5c605649e715")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D41")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55c4f5cb-c530-414c-92f5-fbf9e58a8885")
+		(property "Reference" "D37"
+			(at 91.44 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "64d90630-a755-4eae-b416-80d8ff93fde4")
+		)
+		(pin "2"
+			(uuid "77e4ef56-5ac3-4295-aacb-04ae680de9b7")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D37")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "55dc1959-7c17-496b-b079-56725e7400ff")
+		(property "Reference" "RC7-6"
+			(at 180.34 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d91f51f-9558-44e7-9b69-c9ba25dbac1f")
+		)
+		(pin "2"
+			(uuid "f7ee2403-2740-4116-96fa-c5f3c0c9f293")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "563bf078-cf50-4f0f-84d6-a83a0feddd45")
+		(property "Reference" "D70"
+			(at 172.72 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "91318668-36ae-48a7-a13c-18d4c2f08036")
+		)
+		(pin "2"
+			(uuid "29b99e4d-eeeb-4f18-b49f-b44a360c9eac")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D70")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 68.58 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5692cd7d-67c7-4fe7-8b4d-c8bc86968b31")
+		(property "Reference" "DI1"
+			(at 201.93 64.77 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 71.12 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9abe1fc5-b3c1-424f-8519-d12916c57a11")
+		)
+		(pin "2"
+			(uuid "168b1203-c5fc-4b69-b8e5-94d0bdc27e41")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59263e5e-1eeb-458b-9b02-ca162d4a65d7")
+		(property "Reference" "D21"
+			(at 71.12 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2372f523-257f-414c-92f4-8d433cfbee15")
+		)
+		(pin "2"
+			(uuid "21891727-1d09-4cab-bd90-75c57b141f7c")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D21")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59fdee43-9b65-471d-9ea8-5dc40dc65f6e")
+		(property "Reference" "D35"
+			(at 91.44 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5834d436-0e26-481b-a20d-40fa6346502e")
+		)
+		(pin "2"
+			(uuid "59af1ddc-701f-49c0-b6cd-778072695c5c")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D35")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5aeb247f-6f79-4df2-b767-9ca89069182c")
+		(property "Reference" "D56"
+			(at 132.08 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d46c0cdd-d9c1-44c1-ba6c-034fc547ff01")
+		)
+		(pin "2"
+			(uuid "53f3e198-3ef2-40c4-a8f7-298435eddd0b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D56")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5c60f960-fb0a-46f6-9aff-5d8144586231")
+		(property "Reference" "RC4-6"
+			(at 119.38 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "990f1ee1-d6da-4ae8-809a-1911d8099a4c")
+		)
+		(pin "2"
+			(uuid "a8276c00-b61f-4db4-8f4f-e51e512de654")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f21a75c-b9ee-47bf-adcf-39a03e42660f")
+		(property "Reference" "D15"
+			(at 50.8 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15a944cb-2e3c-4cbc-a2d8-78aee4fee2b1")
+		)
+		(pin "2"
+			(uuid "7a8a84c2-38d2-473b-955d-81dd816a398e")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fa8cce4-fbbf-4784-a459-71364b77e1a7")
+		(property "Reference" "RC0-2"
+			(at 38.1 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cb7750fa-a378-43a3-a1c6-638c32a1c79e")
+		)
+		(pin "2"
+			(uuid "67dfe958-6bd5-4618-98a3-d513db4ad5c0")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5ff7733c-a36f-4b29-a8e7-bdf79fabdf72")
+		(property "Reference" "D4"
+			(at 30.48 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed6062e9-f00a-474a-840f-39685bd66d70")
+		)
+		(pin "2"
+			(uuid "c0e85db4-b88d-4383-8de6-9f7370be62a6")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61b2e3fc-583b-407b-beff-dd8441f2f403")
+		(property "Reference" "RC2-6"
+			(at 78.74 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "752f308d-4723-4468-9745-81de18307ba3")
+		)
+		(pin "2"
+			(uuid "3267c09c-2818-42d7-96a9-6aaa2d6c4a92")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6368f5d6-df20-4a23-a72c-e29e990ea131")
+		(property "Reference" "D36"
+			(at 91.44 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2cd72461-15a2-466d-828d-9560639fb78b")
+		)
+		(pin "2"
+			(uuid "e26d27e6-f81a-4557-bc98-f3f953d25d26")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D36")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "64616073-76e8-465f-9707-663a78749bf1")
+		(property "Reference" "RC7-3"
+			(at 180.34 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0925180b-4c04-468a-84a3-7e0c543a243b")
+		)
+		(pin "2"
+			(uuid "000c5508-f583-4022-ad6d-ee3a9a754164")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "67aba0e0-2c92-4816-99a5-9091230a7899")
+		(property "Reference" "RC3-6"
+			(at 99.06 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c252319-dc79-4365-afaa-77dcde3e6c4e")
+		)
+		(pin "2"
+			(uuid "a5f35312-d094-4f22-9eb9-0edc1f8fb9c4")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6aa79de9-555a-4ed1-93d3-b801685ebd28")
+		(property "Reference" "D53"
+			(at 132.08 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b2031fe-ef72-48a9-afa6-c06144a31b2c")
+		)
+		(pin "2"
+			(uuid "7c191a2c-e1e0-4f88-9eb0-bf2ac5d1436a")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D53")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "70d661b8-51f1-49b8-ad84-9ce8d120c0fc")
+		(property "Reference" "RC6-2"
+			(at 160.02 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e2175ea2-22e6-4720-ab54-24959d43a616")
+		)
+		(pin "2"
+			(uuid "63a1bf12-3f2f-4dc8-8a86-7932361b8306")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "72047ccc-8813-4e13-ae4a-04618a9ab771")
+		(property "Reference" "D23"
+			(at 71.12 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "47d8bdc8-b7c5-4e74-ac40-5c68f0b0df84")
+		)
+		(pin "2"
+			(uuid "6dee3493-b1eb-401e-abb4-cbdef0ef3867")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D23")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7322809e-8332-47c6-af41-fcf3bbcec7d0")
+		(property "Reference" "D34"
+			(at 91.44 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e3b096d1-dbd9-4fb8-8775-725a7aed0bc4")
+		)
+		(pin "2"
+			(uuid "63756bb0-b693-4bbc-82da-e89a6b927e71")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D34")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "76054860-648b-474e-9b4d-cc9d83653495")
+		(property "Reference" "D10"
+			(at 50.8 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d7e8bc-1ac3-4327-ab17-369de6ee755c")
+		)
+		(pin "2"
+			(uuid "c8283bba-c907-48e0-9745-e0818ca7ab04")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "77aa25a5-82c7-42c3-9d55-8606dd65ffa8")
+		(property "Reference" "RC5-1"
+			(at 139.7 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51db5d58-5004-4c9c-b8d1-c184bfb493da")
+		)
+		(pin "2"
+			(uuid "16d6f605-4627-49bd-9180-8203902febfd")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7876e2e4-9d5a-416f-b97a-e958a989e5b8")
+		(property "Reference" "D16"
+			(at 50.8 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8bd5710-8f18-4748-9b3c-a975f78342a1")
+		)
+		(pin "2"
+			(uuid "da0aa924-203b-4985-9bff-4185f3555d43")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D16")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8010e136-1dd3-496f-b7ef-81fb0c8b419e")
+		(property "Reference" "D20"
+			(at 71.12 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5aa5bf69-e040-48d4-81fc-332aff45c2f9")
+		)
+		(pin "2"
+			(uuid "f5458189-75e2-45c3-bf32-0320ebe63391")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D20")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "80c46ab4-724f-418d-bb6f-e89792097e1a")
+		(property "Reference" "RC2-4"
+			(at 78.74 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5bc0fd3d-897b-4e06-ac65-16066b68709e")
+		)
+		(pin "2"
+			(uuid "b7b98128-d37a-4ac7-b049-5cf9bdd5aadb")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "814545b5-c5a6-4c45-83b2-5c1b5ef43a22")
+		(property "Reference" "D57"
+			(at 132.08 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "adc35f03-9c02-4ca4-bbc5-866d317a7469")
+		)
+		(pin "2"
+			(uuid "f05a395b-0185-4ab8-bf1d-fa0561316ad4")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D57")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "81912d5a-1def-44e9-a6ef-abaf3ecd517d")
+		(property "Reference" "RC6-1"
+			(at 160.02 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fa9aca31-bd8b-4e2e-8b86-05d191575df9")
+		)
+		(pin "2"
+			(uuid "fce38bd6-fb8f-42a6-8d68-ecda7f1a588f")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "820f9c2f-0705-41a0-aa6a-3a211d61773f")
+		(property "Reference" "RC6-7"
+			(at 160.02 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eb135129-1d78-4d36-9389-941aee94da0a")
+		)
+		(pin "2"
+			(uuid "2a32e7b7-f134-4c47-a153-d8fce8404094")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83cc3bf3-09a0-4d14-be9d-180ca479485f")
+		(property "Reference" "D73"
+			(at 172.72 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22a68b69-e4e9-436e-b154-616fe8bb66c2")
+		)
+		(pin "2"
+			(uuid "b8e81b5d-9257-4482-8c33-cdfcb13c22e7")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D73")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "83fb734e-dbcd-4939-9bb9-d97efd05ec97")
+		(property "Reference" "RC5-6"
+			(at 139.7 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7315a9fc-fd63-46c2-90db-bee656dc7568")
+		)
+		(pin "2"
+			(uuid "f2997912-9551-49e9-aab8-387875819f56")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "84146f81-04f3-4efb-b753-bdc596c8e7a9")
+		(property "Reference" "RC4-3"
+			(at 119.38 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "774ced50-3b17-48fe-b2d7-22681b1dd1f7")
+		)
+		(pin "2"
+			(uuid "bad310c0-ca25-47d0-b27e-42438b959c7b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "86602dfb-ea19-4060-ad39-496c613a47cb")
+		(property "Reference" "D30"
+			(at 91.44 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 91.44 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "02958e5d-18b7-48f3-9883-661ceaa75da5")
+		)
+		(pin "2"
+			(uuid "abed4b13-9431-40c7-848f-b30c05e39dfd")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D30")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8b2b0803-8190-43b4-9c0d-a9a9edc27829")
+		(property "Reference" "RC2-7"
+			(at 78.74 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d8e9f64d-5849-4a62-8bf4-dafc65fcdd75")
+		)
+		(pin "2"
+			(uuid "e45fa11d-c755-4d62-baa5-974f973ba20f")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c168cda-0a39-478d-9d71-1073400c7ed7")
+		(property "Reference" "RC1-5"
+			(at 58.42 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0d2851af-db15-44cf-8e07-da339bdc18b2")
+		)
+		(pin "2"
+			(uuid "94b381a2-7c19-4916-9f9a-ee00221d04d3")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 129.54 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d0c70ce-19cb-4e8b-b6c2-d4db7ec5cde7")
+		(property "Reference" "DI4"
+			(at 201.93 125.73 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 132.08 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 129.54 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c02807d6-1705-4325-bcb0-203f4e9a5baa")
+		)
+		(pin "2"
+			(uuid "d6c46059-bf9c-4959-836e-e4d33dcc5edd")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8eb7a7fa-054b-460a-a80c-73a56219fecd")
+		(property "Reference" "RC7-0"
+			(at 180.34 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "be9c1065-912d-49b5-8f2f-271b4a0c1db2")
+		)
+		(pin "2"
+			(uuid "626f5614-e69d-4277-acf6-7ff35b08ddb4")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "90049005-7b99-4d2f-9282-dbf53b76b55d")
+		(property "Reference" "RC3-7"
+			(at 99.06 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "62acb361-e48a-40de-9689-6c103c4c7663")
+		)
+		(pin "2"
+			(uuid "f3ee11cf-4f81-4591-ab5d-f41aece910dc")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 186.69 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "91a5d9b4-63df-4567-88f7-1d2f7ac8c33d")
+		(property "Reference" "DS7"
+			(at 177.8 187.325 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 177.8 184.785 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2ec7f316-054f-444d-9c0b-c2c6e1d51faf")
+		)
+		(pin "2"
+			(uuid "e22dc61a-a86f-42a7-9c26-623bb8233a05")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9578a4b6-1a56-40b7-be8d-56404ef59fdf")
+		(property "Reference" "RC1-6"
+			(at 58.42 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0b899b44-3ae3-40be-a452-1f16eaa5f4af")
+		)
+		(pin "2"
+			(uuid "11e73d1b-80a3-4e76-b7dd-cbbb811ab0ce")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 109.22 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "957e7a82-ca9c-46a8-bca9-099b05fe7e8f")
+		(property "Reference" "DI3"
+			(at 201.93 105.41 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 111.76 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 109.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cc53fac9-006c-4101-8113-949ab8e05afb")
+		)
+		(pin "2"
+			(uuid "f6122429-5885-4b7a-b72a-162ca49c70c2")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9af5b930-d274-4b05-b0bf-e2c27b7e71dd")
+		(property "Reference" "D6"
+			(at 30.48 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bdad3d4-58ec-438c-beb8-3eea36a29d95")
+		)
+		(pin "2"
+			(uuid "5ff4e8af-dd18-4010-b183-21b8178cd684")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 201.93 88.9 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9b1e7973-b25b-4ce0-a5ae-cf1eff4b5cbd")
+		(property "Reference" "DI2"
+			(at 201.93 85.09 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 203.835 91.44 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 201.93 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 201.93 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 201.93 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 201.93 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 201.93 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e4d18c9-d9c9-45b7-af82-8eb82ea36e4a")
+		)
+		(pin "2"
+			(uuid "81e4b9c6-9b09-4e38-94e9-cebdeae457ee")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DI2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e96ab02-44ee-4ac7-8251-0d309b7409ad")
+		(property "Reference" "RC5-3"
+			(at 139.7 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fd85b120-1be2-4f17-a3d7-505a734afc72")
+		)
+		(pin "2"
+			(uuid "666e03ce-bf1c-4b58-ac4e-f01557ca11fd")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a3969e5a-abe0-44e9-adf1-6255946e3f4c")
+		(property "Reference" "RC6-0"
+			(at 160.02 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc4d6aea-ec1e-45c7-842c-68cd7e21336f")
+		)
+		(pin "2"
+			(uuid "f785fa77-0ac2-41ff-9704-1acbb4a72c84")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a400377f-e146-4099-97e7-db21e16d5759")
+		(property "Reference" "D3"
+			(at 30.48 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7bfc71c1-6349-4b3f-bf89-22c83277904e")
+		)
+		(pin "2"
+			(uuid "dafd4b6c-6c2f-41e0-95ab-05ead276d86d")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a576c983-0812-4f76-8327-d260ce9c2826")
+		(property "Reference" "D27"
+			(at 71.12 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c11deb1a-dbe0-4d39-8303-331b09dd3cc0")
+		)
+		(pin "2"
+			(uuid "9251c46a-97e6-41c1-9326-a6a8b52abc12")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D27")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a71b771b-4e14-4d95-98e7-86a6250f569e")
+		(property "Reference" "RC0-4"
+			(at 38.1 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "95049e61-b78e-490f-86e1-aba711db5c19")
+		)
+		(pin "2"
+			(uuid "6e474ba8-5b88-41c8-9259-b0ebfb6012f0")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "abf3c9d9-a279-4546-abcf-5e4f6862bc48")
+		(property "Reference" "D2"
+			(at 30.48 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a3499f31-3593-4cd9-977b-3b6479091d7b")
+		)
+		(pin "2"
+			(uuid "17f09d49-1093-4838-8e5c-8fc4c42e5d05")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ac10b530-144b-4dfc-ab37-ad7a8ced8612")
+		(property "Reference" "RC4-5"
+			(at 119.38 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d6c95156-54b9-4f54-a278-f808b4871687")
+		)
+		(pin "2"
+			(uuid "c3dc8d92-1759-4195-a3c9-81260bc6d8b1")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 85.09 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "accba515-4e8d-4804-afea-f36f436141c3")
+		(property "Reference" "DS2"
+			(at 76.2 85.725 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 76.2 83.185 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "034e4344-7cda-43bc-a12a-f56b6e8f68f5")
+		)
+		(pin "2"
+			(uuid "6f0bef00-c613-46da-9667-752b92174ad1")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "afcc8d67-6ed8-4a82-aef7-417b4229ad61")
+		(property "Reference" "RC7-4"
+			(at 180.34 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "982715f0-55ee-4146-b98e-756e5b630dca")
+		)
+		(pin "2"
+			(uuid "7f384a84-9632-4ac9-a8b6-05778cf49f62")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 160.02 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b2cc8c06-500a-41ac-a412-7baf61e0f24c")
+		(property "Reference" "RC6-3"
+			(at 160.02 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 160.02 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 160.02 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 160.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a77d5cb-df53-4102-99ed-4829fa686656")
+		)
+		(pin "2"
+			(uuid "22df81c2-2a06-44e2-bed1-a6d6c14df76a")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC6-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 146.05 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3573dc3-ef18-4f4c-817b-c984ae7cfae9")
+		(property "Reference" "DS5"
+			(at 137.16 146.685 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 137.16 144.145 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "813e7cf6-f821-4e03-95cc-308010bed54e")
+		)
+		(pin "2"
+			(uuid "9669a028-42d7-436f-8ec5-bc3423db62d6")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 119.38 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b39d56f9-3079-43e4-bb1b-80277fdae425")
+		(property "Reference" "RC4-2"
+			(at 119.38 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 119.38 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 119.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 119.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b205d044-9ffa-4dce-82fd-f51ba622a818")
+		)
+		(pin "2"
+			(uuid "29ce7588-4a17-4be4-9207-ea3ed2669aa1")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC4-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 121.92 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c497a9-b81f-4161-88cf-2e58ddb4cdd8")
+		(property "Reference" "RC3-4"
+			(at 99.06 115.57 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 118.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 121.92 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae78f0d3-f75a-49c8-ab9b-8a9831e434d7")
+		)
+		(pin "2"
+			(uuid "a59e897c-0784-437d-9243-baf91d40a453")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba927934-b2e1-4953-b21b-54ef02be8935")
+		(property "Reference" "RC0-5"
+			(at 38.1 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cadba0a-3bb3-40cd-acea-644da4b3e05f")
+		)
+		(pin "2"
+			(uuid "1368ebac-096c-415f-acaf-9afb071e729f")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 125.73 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bb2c72f0-a908-44e7-b7d5-67df52eed516")
+		(property "Reference" "DS4"
+			(at 116.84 126.365 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 116.84 123.825 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5ab0b348-3e2a-4517-90b3-fad111de6205")
+		)
+		(pin "2"
+			(uuid "6e7351bb-5d09-464f-9e8d-535ba0f5c6f3")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be02506a-2bb1-4713-b046-f0327dae72de")
+		(property "Reference" "RC0-1"
+			(at 38.1 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "97a92abd-708c-465e-baf7-79fa35370a7c")
+		)
+		(pin "2"
+			(uuid "c9056b1e-419e-478d-9fc4-be1e95902d28")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "be81432c-e1cf-4ae3-a3e1-c85e3e32bf6d")
+		(property "Reference" "RC5-2"
+			(at 139.7 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f22c39d-012a-4297-b61c-1ff841801333")
+		)
+		(pin "2"
+			(uuid "adbe8c88-ad34-405b-866a-efb64899002f")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c11b6807-83e7-46af-9d7e-9d56aab4109c")
+		(property "Reference" "D46"
+			(at 111.76 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6b653e88-2a4b-46ad-a4e1-fb3b7ccb1c46")
+		)
+		(pin "2"
+			(uuid "6764bae9-067c-4178-897e-2c25048ade8b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D46")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 101.6 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c164cb58-7d29-400c-b219-f07036f5e8c9")
+		(property "Reference" "RC0-3"
+			(at 38.1 95.25 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92164ea1-76d0-4223-80cc-32c093c14fcd")
+		)
+		(pin "2"
+			(uuid "e615b2e5-6986-47ac-8f35-da60c20b811c")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c43b92c2-4283-44f7-8cb3-665623564383")
+		(property "Reference" "D42"
+			(at 111.76 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0929e13-ab77-4737-9d55-142bd9901b1c")
+		)
+		(pin "2"
+			(uuid "0f45988c-1752-479c-97d5-fbada14f9a42")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D42")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c72dd108-be98-47d5-b809-561778aa3212")
+		(property "Reference" "RC2-5"
+			(at 78.74 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "99d2f0fd-ce69-4d4e-a4ab-163c1691ef24")
+		)
+		(pin "2"
+			(uuid "03d1f1e0-40f1-4e90-8bd6-786e9c8d9ffa")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 44.45 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8d5d5a2-9f79-40c5-a9b2-13d9608b5ffe")
+		(property "Reference" "D50"
+			(at 132.08 43.815 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 46.355 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 44.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a606860e-126b-4f3e-bcfe-a2dfa8adc9c8")
+		)
+		(pin "2"
+			(uuid "59120505-a333-4c63-8904-aa379cfb043b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D50")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c996541a-3b07-4fed-9687-afa9b7ffb878")
+		(property "Reference" "RC7-5"
+			(at 180.34 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "560b334e-ed5f-40a2-b100-5974e92ce94c")
+		)
+		(pin "2"
+			(uuid "55bbe733-1ff6-4a73-b892-49d49c6c0fc9")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 180.34 81.28 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce521a1c-e123-4f49-866e-f4f51848f864")
+		(property "Reference" "RC7-2"
+			(at 180.34 74.93 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 180.34 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 180.34 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2a9b15ea-df9e-4ef0-a128-13d2e129d7f7")
+		)
+		(pin "2"
+			(uuid "e9530707-f705-4741-a308-e08f558f67a1")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC7-2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 134.62 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ce6a0c86-f5ce-425e-bd03-ee2eacf01e1e")
+		(property "Reference" "D51"
+			(at 132.08 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 132.08 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 134.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48596e1c-4629-46bb-98c1-de11cd41e539")
+		)
+		(pin "2"
+			(uuid "f7decfb7-c4ef-4861-ba8a-043f44f3b09e")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D51")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf81ef85-b58f-422a-b88a-7b7914aa3581")
+		(property "Reference" "D12"
+			(at 50.8 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e34c154b-a3cb-467d-891b-2f2891056190")
+		)
+		(pin "2"
+			(uuid "dc926c49-c915-470d-b2b5-00749f3505bb")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 33.02 64.77 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d40b4fbb-e58c-433e-b2c5-236bb8aa92c5")
+		(property "Reference" "D1"
+			(at 30.48 64.135 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 30.48 66.675 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 33.02 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "90049b07-ff34-407c-ad1c-bcb8b89b241c")
+		)
+		(pin "2"
+			(uuid "7bd5d68f-4902-47f7-bc35-be0973d0d904")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 139.7 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4b6aeca-4eea-4612-8c4b-ad4cb2f6e578")
+		(property "Reference" "RC5-0"
+			(at 139.7 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 139.7 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 139.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 139.7 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e5729530-792d-44f2-80ff-f6315aae335e")
+		)
+		(pin "2"
+			(uuid "01f42ec4-9037-47c0-8fc0-8f7345fd0a2b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC5-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 60.96 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d8bd7a20-7e9e-41a2-b3c1-1f0ccc876b69")
+		(property "Reference" "RC2-1"
+			(at 78.74 54.61 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 57.15 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 55.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba2015a3-c3ad-44cf-b530-b2a60bac2c12")
+		)
+		(pin "2"
+			(uuid "12bdf482-8bd0-4b7d-a511-fcaadc8ab54d")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "daefbaa6-3e17-4eca-837b-024ccac5fc10")
+		(property "Reference" "D14"
+			(at 50.8 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "12e5236e-b23d-4e38-9768-e28d1693b6eb")
+		)
+		(pin "2"
+			(uuid "1be4fe23-ac83-4b50-b43f-2e4b33c335d7")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 114.3 186.69 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "df14ac0c-5b64-41d1-ac61-954e84a88f4b")
+		(property "Reference" "D47"
+			(at 111.76 186.055 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 111.76 188.595 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 186.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7284aa2f-4456-4e07-9251-a86b7acd95b1")
+		)
+		(pin "2"
+			(uuid "c06243a0-5a23-4af5-88df-f2a88bfb1da0")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D47")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 85.09 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e255666b-19cd-45a4-b5c1-8997235eb1ad")
+		(property "Reference" "D72"
+			(at 172.72 84.455 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 86.995 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "92803ca1-7814-4c2f-986c-c7a2afaea4b2")
+		)
+		(pin "2"
+			(uuid "f1e544c9-5e94-460f-960c-d30fdb857f44")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D72")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 99.06 142.24 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e490f25a-1360-4f95-aa79-5f1d93892bb3")
+		(property "Reference" "RC3-5"
+			(at 99.06 135.89 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 99.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 99.06 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 99.06 142.24 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "056973a8-92e3-49be-9b21-fe961241d12f")
+		)
+		(pin "2"
+			(uuid "01c4c06b-d45d-4ffb-ad72-57ca7686fd55")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC3-5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 166.37 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e6262d19-9b35-41b6-845a-39c20b831416")
+		(property "Reference" "D76"
+			(at 172.72 165.735 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 168.275 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8324bd70-bd5e-4513-bc52-cc4e838003e8")
+		)
+		(pin "2"
+			(uuid "64285f25-2c5b-4231-8d94-7ba284d5a2d2")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D76")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 93.98 105.41 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ea1f34e8-a710-4c79-ad08-39d8b0f7ea6b")
+		(property "Reference" "DS3"
+			(at 96.52 106.045 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 96.52 103.505 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 93.98 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "738869bf-f410-43b7-b7e7-4e927d69911a")
+		)
+		(pin "2"
+			(uuid "71649a24-87f4-49fb-9896-e50c64c03a31")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "DS3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb153eb2-74b0-4cb9-b105-af356654d60d")
+		(property "Reference" "D24"
+			(at 71.12 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "77c4fd5e-5c79-4799-aab6-2f07a57c7df3")
+		)
+		(pin "2"
+			(uuid "a062346b-452b-46dc-a106-fab01848555d")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D24")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 175.26 125.73 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ef64a689-efe5-479a-a53a-19c9f4177765")
+		(property "Reference" "D74"
+			(at 172.72 125.095 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 172.72 127.635 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 175.26 125.73 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fc4be4a8-3bcc-4a9b-8dca-654b73020c91")
+		)
+		(pin "2"
+			(uuid "982449b6-25db-4afc-abf2-592e07b23449")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D74")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 78.74 40.64 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1920e34-64a4-41c9-8680-7fa42f5dfb9d")
+		(property "Reference" "RC2-0"
+			(at 78.74 34.29 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 78.74 36.83 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 78.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 78.74 40.64 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9242378-4df5-4b90-afbf-1098ccb8067f")
+		)
+		(pin "2"
+			(uuid "a135b9b9-316d-4cb2-a5a5-8d618a00a752")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC2-0")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 58.42 182.88 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f1a5bcca-72b0-4fb1-9570-8abc0f731fb7")
+		(property "Reference" "RC1-7"
+			(at 58.42 176.53 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 58.42 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 58.42 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 58.42 182.88 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "058cb33f-3013-4884-ba52-2b175c6e6f25")
+		)
+		(pin "2"
+			(uuid "cb54004f-a1b9-489e-9cdf-00b812c2d5fa")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC1-7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 53.34 105.41 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc941f43-b642-4fef-8515-f8f851adced2")
+		(property "Reference" "D13"
+			(at 50.8 104.775 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 50.8 107.315 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 53.34 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7fc7d473-6e2e-4dd0-b2cc-86749d1a0c5c")
+		)
+		(pin "2"
+			(uuid "ddfe2d89-a50d-4fcc-a9c7-f0d8f1541d03")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Diode:1N4148")
+		(at 73.66 146.05 270)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fcc35b13-8da5-4271-981a-5470b3add3e5")
+		(property "Reference" "D25"
+			(at 71.12 145.415 90)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 71.12 147.955 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_DO-35_SOD27_P7.62mm_Horizontal"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://assets.nexperia.com/documents/data-sheet/1N4148_1N4448.pdf"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Device" "D"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 73.66 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0f0d662a-16b3-4c76-b4ee-49de18b57b47")
+		)
+		(pin "2"
+			(uuid "ba9a1f4c-173e-4b32-907f-fe9b31df718b")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "D25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 38.1 162.56 0)
+		(mirror y)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fd13d6af-afdf-4367-a43b-1889348eabd8")
+		(property "Reference" "RC0-6"
+			(at 38.1 156.21 0)
+			(do_not_autoplace yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_Push"
+			(at 38.1 158.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 38.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 38.1 162.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "854af50a-a007-4ba3-a405-76f0f99e9817")
+		)
+		(pin "2"
+			(uuid "bc5fa1b1-0be1-4e5e-8d2a-64eb74cc8142")
+		)
+		(instances
+			(project "round-robin-9-56"
+				(path "/cbac505e-77a6-4a00-a758-435de33cca16"
+					(reference "RC0-6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
 )

--- a/round-robin-9-56.kicad_sch
+++ b/round-robin-9-56.kicad_sch
@@ -2599,7 +2599,7 @@
 			)
 		)
 	)
-	(global_label "IO 5"
+	(global_label "IO 6"
 		(shape bidirectional)
 		(at 165.1 25.4 90)
 		(fields_autoplaced yes)
@@ -2611,12 +2611,12 @@
 		)
 		(uuid "89461221-a936-49a3-bf5d-18ec120f3e0c")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 165.1 17.2705 90)
+			(at 165.1 17.1911 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(justify right)
+				(justify left)
 				(hide yes)
 			)
 		)


### PR DESCRIPTION
Contains two commits for increased clarity. In the first I just saved the files in a newer version of kicad without making any changes to the schematics. The second commit contains the actual label rename.

Thanks for the schematics!